### PR TITLE
feat: per-stock scanner evaluation for FA consistency

### DIFF
--- a/supabase/functions/_shared/prompts.ts
+++ b/supabase/functions/_shared/prompts.ts
@@ -64,6 +64,9 @@ Risk:
 // but request a simpler output (signal/confidence/reason instead of full entry/exit/scenarios).
 // This guarantees the AI sees identical data and applies identical rules.
 
+// ── Scanner Pass 2 prompts (one stock at a time — mirrors FA format) ──
+// Same rules, same data layout as full analysis. Only difference: simpler output schema.
+
 export const DAY_REFINE_USER = `Inputs: (1) Pre-computed indicators (primary), (2) 1m/15m/1h candles (validation), (3) News headlines (confirmation only).
 
 ${DAY_TRADE_RULES}
@@ -71,12 +74,19 @@ ${DAY_TRADE_RULES}
 - Factor in news sentiment: negative headlines = lower confidence or flip direction. Positive news already priced in if stock is extended.
 - Factor in market context (in indicators section): if SPY bearish and VIX elevated, be more cautious on long setups.
 - Factor in earnings proximity: if earnings within 3 days, SKIP unless explicitly an earnings play.
-- Use SKIP instead of HOLD. Better to SKIP 80% and return 2-3 great picks.
+- SKIP when indicators genuinely conflict. Better to SKIP than give a wrong direction.
 
-Output: JSON array ONLY (no markdown, no backticks).
-[{"ticker":"AAPL","signal":"BUY"|"SELL"|"SKIP","confidence":0-10,"reason":"1-2 sentences"}]
+Output: JSON ONLY (no markdown, no backticks).
+{"signal":"BUY"|"SELL"|"SKIP","confidence":0-10,"reason":"1-2 sentences"}
 
-{{STOCKS}}`;
+---
+{{INDICATOR_SUMMARY}}
+
+Candles:
+{{TECHNICAL_DATA}}
+
+News:
+{{SENTIMENT_DATA}}`;
 
 export const SWING_REFINE_USER = `Inputs: (1) Pre-computed indicators (primary), (2) 4h/1d/1w candles (validation), (3) News headlines (must not contradict technicals).
 
@@ -86,9 +96,16 @@ ${SWING_TRADE_RULES}
 - Factor in news sentiment: negative headlines = lower confidence or flip direction. Positive news already priced in if stock is extended.
 - Factor in market context (in indicators section): if SPY bearish and VIX elevated, be more cautious on long setups.
 - Factor in earnings proximity: if earnings within 7 days, reduce confidence. Within 3 days, SKIP unless explicitly an earnings play.
-- Use SKIP instead of HOLD. Better to SKIP 80% and return 3-5 solid picks.
+- SKIP when indicators genuinely conflict. Better to SKIP than give a wrong direction.
 
-Output: JSON array ONLY (no markdown, no backticks).
-[{"ticker":"AAPL","signal":"BUY"|"SELL"|"SKIP","confidence":0-10,"reason":"1-2 sentences"}]
+Output: JSON ONLY (no markdown, no backticks).
+{"signal":"BUY"|"SELL"|"SKIP","confidence":0-10,"reason":"1-2 sentences"}
 
-{{STOCKS}}`;
+---
+{{INDICATOR_SUMMARY}}
+
+Candles:
+{{TECHNICAL_DATA}}
+
+News:
+{{SENTIMENT_DATA}}`;


### PR DESCRIPTION
## Summary
- Switch scanner Pass 2 from batch evaluation to **individual per-stock Gemini calls**, matching full analysis depth
- Scanner now uses the **exact same prompt template variables** (`{{INDICATOR_SUMMARY}}`, `{{TECHNICAL_DATA}}`, `{{SENTIMENT_DATA}}`) as full analysis
- Confidence threshold unified to **7+** for both day and swing trades
- Pass 1 shortlist reduced from 5 to 3 candidates
- `buildIdea` filter lowered to 6 to let 7+ ideas through

## Why
Batch AI evaluation was producing directional mismatches (BUY vs SELL) between scanner suggestions and full analysis. Per-stock evaluation with identical prompt format eliminates this class of inconsistency.

## Test plan
- [x] Supabase functions deployed (`trading-signals` + `trade-scanner`)
- [x] Local build passes
- [ ] Verify scanner suggestions match FA direction during market hours

Made with [Cursor](https://cursor.com)