### PR TITLE
chore: skip CodeQL for non-code changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,20 @@ name: CodeQL
 on:
   push:
     branches: [master]
+    paths:
+      - "app/**"
+      - "supabase/**"
+      - "*.json"
+      - "*.ts"
+      - "*.js"
   pull_request:
     branches: [master]
+    paths:
+      - "app/**"
+      - "supabase/**"
+      - "*.json"
+      - "*.ts"
+      - "*.js"
   schedule:
     - cron: "0 6 * * 1" # Weekly Monday 6am UTC
 


### PR DESCRIPTION
## Summary
- Add path filters to CodeQL workflow so it only runs on `app/`, `supabase/`, and root config file changes
- Docs, cursor rules, and other non-code PRs will skip CodeQL, saving CI minutes

Made with [Cursor](https://cursor.com)