### PR TITLE
fix: Track 1 ideas preserved on Track 2 failure; refresh bypasses server cache

### DIFF
--- a/app/src/components/TradeIdeas.tsx
+++ b/app/src/components/TradeIdeas.tsx
@@ -82,7 +82,8 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
     setLoading(true);
     setError(null);
     try {
-      const result = await fetchTradeIdeas();
+      // When user explicitly clicks refresh (force=true), bypass server-side DB cache too
+      const result = await fetchTradeIdeas(undefined, force);
       _cache = result;
       _cacheTime = Date.now();
       setData(result);

--- a/app/src/lib/tradeScannerApi.ts
+++ b/app/src/lib/tradeScannerApi.ts
@@ -55,7 +55,8 @@ export interface ScanResult {
 }
 
 export async function fetchTradeIdeas(
-  portfolioTickers?: string[]
+  portfolioTickers?: string[],
+  forceRefresh = false,
 ): Promise<ScanResult> {
   const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
   const res = await fetch(TRADE_SCANNER_URL, {
@@ -64,7 +65,7 @@ export async function fetchTradeIdeas(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${supabaseKey}`,
     },
-    body: JSON.stringify({ portfolioTickers: portfolioTickers ?? [] }),
+    body: JSON.stringify({ portfolioTickers: portfolioTickers ?? [], forceRefresh }),
   });
 
   const data = await res.json().catch(() => ({}));

--- a/supabase/functions/trade-scanner/index.ts
+++ b/supabase/functions/trade-scanner/index.ts
@@ -2170,19 +2170,18 @@ Deno.serve(async (req) => {
       // Sort final dayIdeas by confidence descending
       dayIdeas.sort((a, b) => b.confidence - a.confidence);
 
-      // Only persist to DB when AI ran successfully — if Gemini was rate-limited/quota-exhausted,
-      // keep the previous scan in the DB so we don't serve empty results for the rest of the day.
-      // Never overwrite a non-empty result with an empty array — preserve previous good scan.
-      if (dayAISucceeded) {
-        if (dayIdeas.length > 0) {
-          await writeToDB(sb, 'day_trades', dayIdeas, 390);
-        } else {
-          console.log('[Trade Scanner] Day scan produced 0 ideas — preserving previous scan results');
-          dayIdeas = dayRow?.data ?? [];
-        }
+      // Caching rules:
+      // - If we have any ideas (from Track 1, Track 2, or both) → always write to DB
+      // - If Track 2 AI failed but Track 1 produced ideas → still write those to DB
+      // - Only fall back to previous DB scan if we truly have nothing at all
+      if (dayIdeas.length > 0) {
+        await writeToDB(sb, 'day_trades', dayIdeas, 390);
+      } else if (!dayAISucceeded) {
+        console.warn('[Trade Scanner] Day AI failed and Track 1 empty — skipping DB write to preserve previous results');
+        dayIdeas = dayRow?.data ?? [];
       } else {
-        console.warn('[Trade Scanner] Day AI failed — skipping DB write to preserve previous results');
-        dayIdeas = dayRow?.data ?? []; // Fall back to whatever was in DB
+        console.log('[Trade Scanner] Day scan produced 0 ideas — preserving previous scan results');
+        dayIdeas = dayRow?.data ?? [];
       }
     }
 


### PR DESCRIPTION
Two fixes shipped together:

**Bug 1:** Track 1 key-level ideas were thrown away when Track 2 Gemini failed. The old `else { dayIdeas = stale }` block overwrote Track 1 results. Fixed to: if dayIdeas.length > 0 (from any track), always write to DB.

**Bug 2:** The refresh button on Trade Ideas bypassed the 5-min client cache but NOT the server-side DB cache. Fixed `fetchTradeIdeas(undefined, force)` so an explicit user refresh triggers a full rescan on the server too.

Made with [Cursor](https://cursor.com)