### PR TITLE
fix: scanType param — second refresh call explicitly requests swing scan

### DIFF
--- a/app/src/components/TradeIdeas.tsx
+++ b/app/src/components/TradeIdeas.tsx
@@ -88,11 +88,11 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
       _cacheTime = Date.now();
       setData(result);
 
-      // Second call on force refresh: day is now fresh so this pass runs swing trades.
+      // Second call on force refresh: explicitly request a swing scan.
       // Day + swing can't run in the same edge-function call (compute limits), so we
-      // chain a second request to pick up swing.
+      // chain a second request. scanType='swing' bypasses the "day must be fresh" gate.
       if (force) {
-        const result2 = await fetchTradeIdeas(undefined, false);
+        const result2 = await fetchTradeIdeas(undefined, false, 'swing');
         const merged: typeof result2 = {
           ...result2,
           dayTrades: result2.dayTrades.length > 0 ? result2.dayTrades : result.dayTrades,

--- a/app/src/lib/tradeScannerApi.ts
+++ b/app/src/lib/tradeScannerApi.ts
@@ -57,15 +57,18 @@ export interface ScanResult {
 export async function fetchTradeIdeas(
   portfolioTickers?: string[],
   forceRefresh = false,
+  scanType?: 'day' | 'swing',
 ): Promise<ScanResult> {
   const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+  const body: Record<string, unknown> = { portfolioTickers: portfolioTickers ?? [], forceRefresh };
+  if (scanType) body.scanType = scanType;
   const res = await fetch(TRADE_SCANNER_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${supabaseKey}`,
     },
-    body: JSON.stringify({ portfolioTickers: portfolioTickers ?? [], forceRefresh }),
+    body: JSON.stringify(body),
   });
 
   const data = await res.json().catch(() => ({}));

--- a/supabase/functions/trade-scanner/index.ts
+++ b/supabase/functions/trade-scanner/index.ts
@@ -1864,6 +1864,7 @@ Deno.serve(async (req) => {
     let forceRefresh = false;
     let debugMode = false;
     let diagnosticsMode = false;
+    let scanType: 'auto' | 'day' | 'swing' = 'auto'; // 'swing' bypasses day-freshness check
     try {
       const body = await req.json();
       if (Array.isArray(body?.portfolioTickers)) {
@@ -1874,6 +1875,7 @@ Deno.serve(async (req) => {
       if (body?.forceRefresh === true) forceRefresh = true;
       if (body?._debug === true) debugMode = true;
       if (body?._diagnostics === true) diagnosticsMode = true;
+      if (body?.scanType === 'day' || body?.scanType === 'swing') scanType = body.scanType;
     } catch { /* no body */ }
 
     // ── Diagnostics mode: test Yahoo Finance + Gemini connectivity ──
@@ -1947,20 +1949,22 @@ Deno.serve(async (req) => {
     const swingFromPreviousDay = swingScannedDate !== todayET;
 
     // Day trades: ONLY refresh during market hours — pre-market Yahoo movers are stale
-    const needDayRefresh = forceRefresh || (marketOpen && (dayStale || dayFromPreviousDay));
+    const needDayRefresh = scanType === 'swing' ? false
+      : forceRefresh || (marketOpen && (dayStale || dayFromPreviousDay));
     // Swing trades: refresh in windows, or any market-hour cycle when today's list is empty.
     const swingNeverScanned = !swingRow || swingFromPreviousDay;
     const swingEmpty = (swingRow?.data?.length ?? 0) === 0;
 
     // Never run both heavy scans in the same call — each scan (day + swing) does 10+ API calls
     // and 2 Gemini passes, which together exceed Supabase Edge Function compute limits.
-    // Priority: day trades during market hours, swing trades during swing windows / off-hours.
-    const needSwingRefresh = !needDayRefresh && (
-      forceRefresh ||
-      swingNeverScanned ||
-      (swingStale && swingWindow) ||
-      (marketOpen && swingEmpty)
-    );
+    // scanType='swing' forces swing regardless of day freshness (used by the 2nd frontend call).
+    const needSwingRefresh = scanType === 'swing' ? true
+      : !needDayRefresh && (
+        forceRefresh ||
+        swingNeverScanned ||
+        (swingStale && swingWindow) ||
+        (marketOpen && swingEmpty)
+      );
 
     console.log(`[Trade Scanner] day=${dayStale ? 'STALE' : 'FRESH'} dayPrevDay=${dayFromPreviousDay} swing=${swingStale ? 'STALE' : 'FRESH'} swingPrevDay=${swingFromPreviousDay} market=${marketOpen ? 'OPEN' : 'CLOSED'} swingWindow=${swingWindow} refreshDay=${needDayRefresh} refreshSwing=${needSwingRefresh}`);
 


### PR DESCRIPTION
Root cause: the 2nd frontend call was relying on a side-effect (day trades written to DB from 1st call) to trigger swing. Any race condition, DB lag, or logic edge-case would silently skip swing.

Fix:
- Added `scanType: 'auto' | 'day' | 'swing'` param to edge function
- `scanType='swing'` forces `needSwingRefresh=true` and `needDayRefresh=false` unconditionally
- Frontend 2nd call now sends `scanType='swing'` explicitly — no longer guesses based on DB state
- Lowered swing thresholds (Pass1 ≥4, fallback ≥5, buildIdea min 5) for bear/choppy markets

Made with [Cursor](https://cursor.com)