### PR TITLE
feat: split realized vs unrealized P&L on Performance scorecards

### DIFF
--- a/app/src/components/PaperTrading/shared/SignalScorecard.tsx
+++ b/app/src/components/PaperTrading/shared/SignalScorecard.tsx
@@ -34,20 +34,42 @@ export function SignalScorecard({ title, subtitle, data, color }: SignalScorecar
     );
   }
 
+  const hasUnrealized = data.unrealizedPnl !== 0 && data.activeTrades > 0;
+  const hasRealized = data.realizedPnl !== 0;
+
   return (
     <div className={cn('rounded-xl border p-4', colorClasses[color])}>
-      <div className="flex items-center justify-between mb-1">
+      <div className="flex items-start justify-between mb-1">
         <div>
           <p className={cn('text-sm font-semibold', textColors[color])}>{title}</p>
           <p className="text-[10px] text-[hsl(var(--muted-foreground))]">{subtitle}</p>
         </div>
         <div className="text-right">
-          <p className={cn(
-            'text-lg font-bold tabular-nums',
-            data.totalPnl > 0 ? 'text-emerald-600' : data.totalPnl < 0 ? 'text-red-600' : textColors[color]
-          )}>
-            {fmtUsd(data.totalPnl, 0, true)}
-          </p>
+          {hasUnrealized && hasRealized ? (
+            <>
+              <p className={cn(
+                'text-base font-bold tabular-nums leading-tight',
+                data.realizedPnl >= 0 ? 'text-emerald-600' : 'text-red-600'
+              )}>
+                {fmtUsd(data.realizedPnl, 0, true)}
+                <span className="text-[9px] font-normal text-[hsl(var(--muted-foreground))] ml-1">realized</span>
+              </p>
+              <p className={cn(
+                'text-xs font-semibold tabular-nums',
+                data.unrealizedPnl >= 0 ? 'text-emerald-500' : 'text-red-400'
+              )}>
+                {fmtUsd(data.unrealizedPnl, 0, true)}
+                <span className="text-[9px] font-normal text-[hsl(var(--muted-foreground))] ml-1">open</span>
+              </p>
+            </>
+          ) : (
+            <p className={cn(
+              'text-lg font-bold tabular-nums',
+              data.totalPnl > 0 ? 'text-emerald-600' : data.totalPnl < 0 ? 'text-red-600' : textColors[color]
+            )}>
+              {fmtUsd(data.totalPnl, 0, true)}
+            </p>
+          )}
         </div>
       </div>
 
@@ -88,6 +110,9 @@ export function SignalScorecard({ title, subtitle, data, color }: SignalScorecar
               <p className="text-[10px] text-[hsl(var(--muted-foreground))]">Best</p>
               <p className="text-xs font-bold text-emerald-600 tabular-nums truncate">
                 {data.bestTrade.ticker} {fmtUsd(data.bestTrade.pnl, 0, true)}
+                {data.bestTrade.isOpen && (
+                  <span className="text-[9px] font-normal text-[hsl(var(--muted-foreground))] ml-0.5">(open)</span>
+                )}
               </p>
             </div>
           )}
@@ -96,6 +121,9 @@ export function SignalScorecard({ title, subtitle, data, color }: SignalScorecar
               <p className="text-[10px] text-[hsl(var(--muted-foreground))]">Worst</p>
               <p className="text-xs font-bold text-red-600 tabular-nums truncate">
                 {data.worstTrade.ticker} {fmtUsd(data.worstTrade.pnl, 0)}
+                {data.worstTrade.isOpen && (
+                  <span className="text-[9px] font-normal text-[hsl(var(--muted-foreground))] ml-0.5">(open)</span>
+                )}
               </p>
             </div>
           )}

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -720,11 +720,16 @@ export interface CategoryPerformance {
   wins: number;
   losses: number;
   winRate: number;
+  /** Realized P&L from closed trades only */
+  realizedPnl: number;
+  /** Unrealized P&L from active/open positions */
+  unrealizedPnl: number;
+  /** realizedPnl + unrealizedPnl — kept for backward compat */
   totalPnl: number;
   avgPnl: number;
   avgReturnPct: number;
-  bestTrade: { ticker: string; pnl: number } | null;
-  worstTrade: { ticker: string; pnl: number } | null;
+  bestTrade: { ticker: string; pnl: number; isOpen?: boolean } | null;
+  worstTrade: { ticker: string; pnl: number; isOpen?: boolean } | null;
   totalDeployed: number;
 }
 
@@ -874,8 +879,8 @@ export async function recalculatePerformanceByCategory(): Promise<CategoryPerfor
     const wins = completed.filter(t => (t.pnl ?? 0) > 0);
     const losses = completed.filter(t => (t.pnl ?? 0) < 0);
 
-    const totalPnl = completed.reduce((s, t) => s + (t.pnl ?? 0), 0);
-    const avgPnl = completed.length > 0 ? totalPnl / completed.length : 0;
+    const realizedPnl = completed.reduce((s, t) => s + (t.pnl ?? 0), 0);
+    const avgPnl = completed.length > 0 ? realizedPnl / completed.length : 0;
 
     // Avg return %
     const returns = completed
@@ -883,15 +888,17 @@ export async function recalculatePerformanceByCategory(): Promise<CategoryPerfor
       .map(t => ((t.pnl ?? 0) / ((t.fill_price ?? 1) * (t.quantity ?? 1))) * 100);
     const avgReturnPct = returns.length > 0 ? returns.reduce((a, b) => a + b, 0) / returns.length : 0;
 
-    // For active long-term positions with unrealized P&L, include in active stats
-    const unrealizedPnl = active
-      .filter(t => t.status === 'FILLED' && t.pnl != null)
-      .reduce((s, t) => s + (t.pnl ?? 0), 0);
+    // Unrealized P&L from active FILLED positions (live floating gains/losses)
+    const filledActive = active.filter(t => t.status === 'FILLED' && t.pnl != null);
+    const unrealizedPnl = filledActive.reduce((s, t) => s + (t.pnl ?? 0), 0);
 
-    // Best/worst
-    const sortedByPnl = [...completed].sort((a, b) => (b.pnl ?? 0) - (a.pnl ?? 0));
-    const best = sortedByPnl[0] ?? null;
-    const worst = sortedByPnl[sortedByPnl.length - 1] ?? null;
+    // Best/worst: include active FILLED positions so open losers like POOL show up
+    const allForBestWorst = [
+      ...completed.map(t => ({ ticker: t.ticker, pnl: t.pnl ?? 0, isOpen: false })),
+      ...filledActive.map(t => ({ ticker: t.ticker, pnl: t.pnl ?? 0, isOpen: true })),
+    ].sort((a, b) => b.pnl - a.pnl);
+    const best = allForBestWorst[0] ?? null;
+    const worst = allForBestWorst[allForBestWorst.length - 1] ?? null;
 
     const totalDeployed = active.reduce((s, t) => s + (t.position_size ?? 0), 0);
 
@@ -902,11 +909,13 @@ export async function recalculatePerformanceByCategory(): Promise<CategoryPerfor
       wins: wins.length,
       losses: losses.length,
       winRate: completed.length > 0 ? (wins.length / completed.length) * 100 : 0,
-      totalPnl: totalPnl + unrealizedPnl,
+      realizedPnl,
+      unrealizedPnl,
+      totalPnl: realizedPnl + unrealizedPnl,
       avgPnl,
       avgReturnPct,
-      bestTrade: best ? { ticker: best.ticker, pnl: best.pnl ?? 0 } : null,
-      worstTrade: worst && completed.length > 0 ? { ticker: worst.ticker, pnl: worst.pnl ?? 0 } : null,
+      bestTrade: best,
+      worstTrade: allForBestWorst.length > 0 ? worst : null,
       totalDeployed,
     });
   }


### PR DESCRIPTION
## Summary
- Category scorecards (Suggested Finds, Scanner Day Trades, etc.) now show **Realized P&L** (closed trades) and **Open P&L** (floating unrealized) as two separate lines — no more misleading mixed totals
- **Best / Worst** now scans both closed and active FILLED positions, so big open losers like POOL show up with an `(open)` label
- Win rate is unchanged (still closed-trades only) and now correctly reads alongside the realized number

## Test plan
- [ ] Open Performance tab → each scorecard should show two P&L lines when there are both closed and open trades
- [ ] "Worst" for Suggested Finds should now surface any deeply underwater open position with "(open)" label
- [ ] Scorecards with only one type (e.g. pure closed or pure open) still show a single P&L number as before

Made with [Cursor](https://cursor.com)