### PR TITLE
feat: promote Options Wheel to top-level /options route

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { BrowserRouter, Routes, Route, NavLink, useLocation } from 'react-router-dom';
 import { SpeedInsights } from '@vercel/speed-insights/react';
 import { Analytics } from '@vercel/analytics/react';
-import { Activity, Briefcase, Brain, Lightbulb, RefreshCw, TrendingUp, User, LogOut, ChevronDown, Bot } from 'lucide-react';
+import { Activity, Briefcase, Brain, Lightbulb, RefreshCw, TrendingUp, User, LogOut, ChevronDown, Bot, CircleDollarSign } from 'lucide-react';
 import type { StockWithConviction, RiskProfile } from './types';
 import { getUserData, saveUserData, addTickers, updateStock, removeStock, clearAllData, importStocksWithPositions } from './lib/storage';
 import { getCloudUserData, cloudAddTickers, cloudRemoveTicker, cloudClearAll, migrateGuestToCloud, cloudImportStocksWithPositions } from './lib/cloudStorage';
@@ -21,6 +21,7 @@ import { SuggestedFinds } from './components/SuggestedFinds';
 import { MarketMovers } from './components/MarketMovers';
 import { TradingSignals } from './components/TradingSignals';
 import { PaperTrading } from './components/PaperTrading';
+import { OptionsWheelPage } from './components/OptionsWheelPage';
 import { StockDetail } from './components/StockDetail';
 import { AddTickersModal } from './components/AddTickersModal';
 import { AuthModal } from './components/AuthModal';
@@ -883,6 +884,20 @@ function AppContent() {
                 Paper Trading
               </NavLink>
             )}
+            {isAuthed && (
+              <NavLink
+                to="/options"
+                className={({ isActive }) => cn(
+                  'flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all',
+                  isActive
+                    ? 'bg-gradient-to-r from-violet-600 to-purple-600 text-white shadow-md shadow-violet-500/25'
+                    : 'text-slate-500 hover:text-slate-700 hover:bg-white/80'
+                )}
+              >
+                <CircleDollarSign className="w-4 h-4" />
+                Options Wheel
+              </NavLink>
+            )}
           </div>
         </div>
       </header>
@@ -914,6 +929,7 @@ function AppContent() {
           <Route path="/movers" element={<MarketMovers />} />
           <Route path="/signals" element={<TradingSignals />} />
           {isAuthed && <Route path="/paper-trading" element={<PaperTrading />} />}
+          {isAuthed && <Route path="/options" element={<OptionsWheelPage />} />}
         </Routes>
       </main>
 

--- a/app/src/components/OptionsWheelPage.tsx
+++ b/app/src/components/OptionsWheelPage.tsx
@@ -1,0 +1,37 @@
+import { CircleDollarSign } from 'lucide-react';
+import { OptionsTab } from './PaperTrading/tabs/OptionsTab';
+
+/**
+ * Top-level Options Wheel page — accessible via /options route.
+ *
+ * A standalone premium income engine for selling puts and covered calls
+ * on quality stocks. Separate from Paper Trading — this is its own product.
+ */
+export function OptionsWheelPage() {
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="flex items-center gap-3 mb-1">
+            <div className="p-2 rounded-xl bg-violet-100">
+              <CircleDollarSign className="w-5 h-5 text-violet-600" />
+            </div>
+            <h1 className="text-xl font-bold text-[hsl(var(--foreground))]">Options Wheel Engine</h1>
+          </div>
+          <p className="text-sm text-[hsl(var(--muted-foreground))] ml-12">
+            Sell puts on quality stocks you'd own. Collect premium. Compound returns.
+          </p>
+        </div>
+        <div className="text-right hidden sm:block">
+          <p className="text-[11px] text-[hsl(var(--muted-foreground))]">Target</p>
+          <p className="text-sm font-bold text-violet-600">70–80% annual</p>
+          <p className="text-[10px] text-[hsl(var(--muted-foreground))]">beat husband's 60% ✌️</p>
+        </div>
+      </div>
+
+      {/* Main content */}
+      <OptionsTab />
+    </div>
+  );
+}

--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -78,10 +78,9 @@ import {
   ValidationTab,
   StrategyPerformanceTab,
   PerformanceTab,
-  OptionsTab,
 } from './tabs';
 
-export type Tab = 'portfolio' | 'today' | 'smart' | 'strategies' | 'validation' | 'history' | 'performance' | 'settings' | 'options';
+export type Tab = 'portfolio' | 'today' | 'smart' | 'strategies' | 'validation' | 'history' | 'performance' | 'settings';
 
 export function PaperTrading() {
   const [config, setConfig] = useState<AutoTraderConfig>(getAutoTraderConfig);
@@ -402,7 +401,6 @@ export function PaperTrading() {
             { id: 'strategies' as Tab,  label: 'Influencers',      short: 'Influencers', icon: BarChart3,     count: sourcePerf.length },
             { id: 'validation' as Tab,  label: 'System Learning', short: 'Learning',    icon: ClipboardCheck },
             { id: 'smart' as Tab,       label: 'Smart Trading',    short: 'Smart',       icon: Brain },
-            { id: 'options' as Tab,     label: 'Options Wheel',    short: 'Options',     icon: TrendingUp },
             { id: 'settings' as Tab,    label: 'Settings',         short: 'Settings',    icon: Settings },
           ].map(t => (
             <button
@@ -484,9 +482,6 @@ export function PaperTrading() {
               totalDeployed={totalDeployed}
               maxAllocation={config.maxTotalAllocation}
             />
-          )}
-          {tab === 'options' && (
-            <OptionsTab />
           )}
           {tab === 'settings' && (
             <SettingsTab config={config} onUpdate={updateConfig} />


### PR DESCRIPTION
## Summary
- Options Wheel Engine is now a top-level page at `/options`, not a sub-tab inside Paper Trading
- New nav link with `CircleDollarSign` icon (distinct violet gradient active state)
- New `OptionsWheelPage` wrapper component with full-page header showing the 70-80% target
- Removed Options tab from PaperTrading inner tab bar — clean separation of concerns

## Why
Options is a standalone premium income engine. Burying it inside Paper Trading's tab system made it hard to find and implied it was a reporting feature rather than an active trading tool.

Made with [Cursor](https://cursor.com)