### PR TITLE
fix: block after-hours order execution in both schedulers

### DIFF
--- a/app/src/hooks/useAutoTradeScheduler.ts
+++ b/app/src/hooks/useAutoTradeScheduler.ts
@@ -130,8 +130,8 @@ async function preGenerateSuggestedFinds() {
   const todayEt = getSuggestionDateEt();
   if (_lastSuggestedFindsDate === todayEt) return;
 
-  // Only run at/after 9:30 AM ET (market open) and we haven't run today yet.
-  // Server-side preGenerateSuggestedFinds also gates at 9:30 AM — keep in sync.
+  // Discovery (page population) runs any time after 9:30 AM so the /finds page is
+  // always populated after login. Trading execution inside is further gated by isMarketHoursET().
   const now = new Date();
   const et = new Date(now.toLocaleString('en-US', { timeZone: 'America/New_York' }));
   const mins = et.getHours() * 60 + et.getMinutes();
@@ -146,9 +146,9 @@ async function preGenerateSuggestedFinds() {
       `[AutoTradeScheduler] Suggested Finds ready: ${result.compounders.length} compounders, ${result.goldMines.length} gold mines`
     );
 
-    // Auto-trade qualifying Suggested Finds
+    // Auto-trade qualifying Suggested Finds — only during market hours
     const config = await loadAutoTraderConfig();
-    if (config.enabled && config.accountId) {
+    if (config.enabled && config.accountId && isMarketHoursET()) {
       const allStocks = [...result.compounders, ...result.goldMines];
 
       // Identify top picks (first in each list that meets minSuggestedFindsConviction).

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -424,6 +424,7 @@ export function getSchedulerStatus() {
 /** Trigger a manual run outside the cron schedule */
 export async function triggerManualRun(): Promise<string> {
   if (_running) return 'already executing';
+  if (!isMarketHoursET()) return 'skipped: outside market hours (9:30 AM – 4:30 PM ET)';
   try {
     await runSchedulerCycle();
     return 'completed';
@@ -3846,7 +3847,7 @@ async function preGenerateSuggestedFinds(
 ): Promise<void> {
   const today = getETDateString();
   if (_lastSuggestedFindsDate === today) return;
-  if (getETMinutes() < 9 * 60 + 30) return; // wait for market open (9:30 AM ET)
+  if (!isMarketHoursET()) return; // outside market hours — never place LT orders outside 9:30 AM–4:00 PM ET
 
   try {
     log('Fetching today\'s Suggested Finds...');


### PR DESCRIPTION
## Summary
- `preGenerateSuggestedFinds` on **server** (`scheduler.ts`) only checked `>= 9:30 AM` — never blocked `> 4:00 PM`. Now gates with `isMarketHoursET()`.
- `triggerManualRun` on server had **no market hours check at all** — any manual UI trigger after close would run a full trade cycle. Now returns early outside market hours.
- `preGenerateSuggestedFinds` on **browser** (`useAutoTradeScheduler.ts`) had the same missing upper bound. Trading execution block now wrapped in `isMarketHoursET()` — discovery/page population still runs any time after 9:30 AM.

## Root cause
Both schedulers called `preGenerateSuggestedFinds` *before* their respective market hours gate, so after-hours triggers (IB stays connected, browser tab left open) could place LONG_TERM orders.

## Test plan
- [ ] Verify no SF trades fire when triggering a manual run after 4 PM ET
- [ ] Verify SF trades still fire normally between 9:30 AM – 4:00 PM ET
- [ ] Verify `/finds` page still populates after login even outside market hours

Made with [Cursor](https://cursor.com)