### PR TITLE
fix: options realized P&L was silently excluding losing trades

### DIFF
--- a/app/src/lib/optionsApi.ts
+++ b/app/src/lib/optionsApi.ts
@@ -312,7 +312,9 @@ export async function getOptionsMonthlyStats(): Promise<OptionsMonthlyStats> {
   const trades = (closed ?? []).filter(t => Math.abs(t.pnl ?? 0) > 1);
   const wins = trades.filter(t => (t.pnl ?? 0) > 0);
   const losses = trades.filter(t => (t.pnl ?? 0) < 0);
-  const premiumCollected = wins.reduce((s: number, t: { pnl: number | null }) => s + (t.pnl ?? 0), 0);
+  // Net realized P&L across ALL closed trades (wins + losses) — the true closed income figure.
+  // Previously only summed wins, causing losses like JPM -$105 to be silently excluded.
+  const premiumCollected = trades.reduce((s: number, t: { pnl: number | null }) => s + (t.pnl ?? 0), 0);
   const totalCapital = trades.reduce((s: number, t: { option_capital_req: number | null }) => s + (t.option_capital_req ?? 0), 0);
   const daysInMonth = new Date().getDate();
   const annualizedReturn = totalCapital > 0 ? (premiumCollected / totalCapital) * (365 / daysInMonth) * 100 : 0;


### PR DESCRIPTION
## Bug
`premiumCollected` in `optionsApi.ts` was computed via `wins.reduce()` — only positive P&L trades counted. Losing trades (JPM -$105, NOW -$21) were completely excluded, making the Monthly Income header show **+$98** instead of the true **-$28** net.

## Fix
Changed `wins.reduce()` → `trades.reduce()` so all closed positions (wins + losses) are included in the realized figure.

## Impact
- "Realized (closed)" header now shows the honest net P&L for the month
- Win rate, loss count display was already correct (those used `wins`/`losses` arrays)
- Annualized return now also reflects true net return, not just winners

Made with [Cursor](https://cursor.com)