### PR TITLE
Fix double-trading in options wheel scanner

### DIFF
--- a/auto-trader/src/lib/options-scanner.ts
+++ b/auto-trader/src/lib/options-scanner.ts
@@ -916,20 +916,6 @@ export async function runOptionsScan(freeCapital = 100_000): Promise<OptionsScan
   // Sort by annual yield descending
   opportunities.sort((a, b) => b.annualYield - a.annualYield);
 
-  // Auto-trade top opportunities if enabled
-  const { enabled: autoEnabled, maxContracts } = autoConfig;
-  if (autoEnabled && opportunities.length > 0) {
-    const toTrade = opportunities.slice(0, maxContracts);
-    for (const opp of toTrade) {
-      const result = await autoTradeOption(opp);
-      if (result.isLive) {
-        console.log(`[Options Scan] Auto-traded ${opp.ticker}: IB order ${result.ibOrderId}`);
-      } else {
-        console.log(`[Options Scan] Paper-traded ${opp.ticker} (auto-trade off or IB unavailable)`);
-      }
-    }
-  }
-
   // Persist opportunities
   for (const opp of opportunities) {
     await sb.from('options_scan_results').upsert({


### PR DESCRIPTION
## Summary
- `runOptionsScan()` was calling `autoTradeOption()` internally for every opportunity when `autoEnabled=true`
- The scheduler then called `autoTradeOption()` again on the same returned list → 2× IB orders per ticker
- Fix: removed the auto-trade block from inside `runOptionsScan()` — the scanner now only finds and returns opportunities, execution is the scheduler's responsibility

## Test plan
- [ ] Confirm next morning scan produces exactly 1 IB order per qualifying ticker (not 2)
- [ ] Verify `options_scan_results` records still persist correctly (that path was not changed)

Made with [Cursor](https://cursor.com)