### PR TITLE
Fix: cost basis floor guard prevents guaranteed covered call loss

### DIFF
--- a/auto-trader/src/lib/options-manager.ts
+++ b/auto-trader/src/lib/options-manager.ts
@@ -584,9 +584,21 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
         }
       } catch { /* non-blocking — insert with 0 if chain unavailable */ }
 
-      // Use the higher of: 10% OTM floor OR the 20-delta strike from chain
-      const rawCcStrike = Math.max(minCcStrikeFloor, ccStrikeFromChain ?? minCcStrikeFloor);
+      // Three-guard rule (from SMB Capital covered-calls video — "the deadly mistake"):
+      // NEVER locate the short call below the share acquisition price (the put strike).
+      // If stock drops after assignment and we sell a call below cost basis, any bounce
+      // that triggers assignment locks in a guaranteed realized loss on the shares —
+      // wiping out all premium collected across the entire wheel cycle.
+      //
+      // Guard 1: acquisition price (put strike = cost basis of the assigned shares)
+      // Guard 2: 10% OTM floor above current stock price  (recovery room)
+      // Guard 3: 20-delta strike from chain               (video's probability target)
+      // Final strike = highest of all three — even if premium collected is tiny.
+      const acquisitionPrice = pos.option_strike; // the put strike that was assigned
+      const rawCcStrike = Math.max(acquisitionPrice, minCcStrikeFloor, ccStrikeFromChain ?? minCcStrikeFloor);
       const ccStrike = Math.round(rawCcStrike * 4) / 4; // round to nearest $0.25
+
+      const inCostBasisProtectionMode = rawCcStrike <= acquisitionPrice * 1.005; // within 0.5% of cost basis
 
       await sb.from('paper_trades').insert({
         ticker: pos.ticker,
@@ -609,10 +621,13 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
         notes: `Covered call after assignment on ${pos.ticker} put at $${pos.option_strike} — collected $${(ccPremium * 100).toFixed(0)} premium`,
       });
 
-      console.log(`[Options Manager] Assignment detected — covered call queued: ${pos.ticker} $${ccStrike}C exp ${ccExpiryISO}`);
+      const modeTag = inCostBasisProtectionMode
+        ? ' [COST BASIS PROTECTION — premium may be minimal]'
+        : '';
+      console.log(`[Options Manager] Assignment detected — covered call queued: ${pos.ticker} $${ccStrike}C exp ${ccExpiryISO}${modeTag}`);
       persistEvent(pos.ticker, 'warning',
-        `📌 ${pos.ticker} assignment → covered call queued: $${ccStrike}C exp ${ccExpiryISO}, premium $${(ccPremium * 100).toFixed(0)}`,
-        { action: 'flagged', source: 'options', metadata: { reason: 'assignment_detected_covered_call_queued', stockPrice, strike: pos.option_strike, ccStrike, ccExpiry: ccExpiryISO, ccPremium } }
+        `📌 ${pos.ticker} assignment → covered call queued: $${ccStrike}C exp ${ccExpiryISO}, premium $${(ccPremium * 100).toFixed(0)}${modeTag}`,
+        { action: 'flagged', source: 'options', metadata: { reason: 'assignment_detected_covered_call_queued', stockPrice, acquisitionPrice, strike: pos.option_strike, ccStrike, ccExpiry: ccExpiryISO, ccPremium, inCostBasisProtectionMode } }
       );
     }
   }


### PR DESCRIPTION
## Summary
Closes a critical gap identified from the SMB Capital covered-calls video ("Avoid This Deadly Covered Call Mistake").

### The Bug
When a put is assigned and the stock drops further post-assignment, our CC strike selection of `max(10% OTM, 20-delta)` could land **below** the share acquisition price (put strike). Any stock bounce that triggered assignment would then force a **realized loss on the shares**, wiping out all premium collected across the entire wheel cycle.

**Example:**
| | Value |
|---|---|
| Put assigned at (cost basis) | $100 |
| Stock drops to | $75 |
| Old CC strike | $82.50 (10% above $75) |
| Stock bounces to | $85 → called away at $82.50 |
| Share loss | -$17.50/share → guaranteed loss |

### The Fix — Three-Guard Rule
```typescript
// Guard 1: acquisition price (put strike = cost basis)   ← NEW
// Guard 2: 10% OTM floor above current price
// Guard 3: 20-delta chain strike
const ccStrike = max(acquisitionPrice, 10%OTM, chainDeltaStrike)
```
Premium collected may be minimal in cost-basis-protection mode (like the video's $0.47/$0.14 examples) — that is the correct behavior. Never trade guaranteed capital loss for a few extra dollars of premium.

### Why Roll-Up Protection Propagates
`evaluateAndRollCall()` already requires `newStrike > pos.option_strike`, and `pos.option_strike` is now guaranteed ≥ acquisition price, so all subsequent rolls are automatically protected.

## Test Plan
- [ ] Assignment at $100, stock drops to $75 → CC strike ≥ $100 (not $82.50)
- [ ] Assignment at $100, stock stays near $100 → 10% OTM / 20-delta determines strike as before
- [ ] Log shows `[COST BASIS PROTECTION]` tag when strike is at/near acquisition price
- [ ] Roll from a cost-basis-protected CC → new strike > original CC strike (still protected)

Made with [Cursor](https://cursor.com)