### PR TITLE
Morning Brief: AI-powered daily pre-market research dashboard

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { BrowserRouter, Routes, Route, NavLink, useLocation } from 'react-router-dom';
 import { SpeedInsights } from '@vercel/speed-insights/react';
 import { Analytics } from '@vercel/analytics/react';
-import { Activity, Briefcase, Brain, Lightbulb, RefreshCw, User, LogOut, ChevronDown, Bot, CircleDollarSign } from 'lucide-react';
+import { Activity, Briefcase, Brain, Lightbulb, RefreshCw, User, LogOut, ChevronDown, Bot, CircleDollarSign, Newspaper } from 'lucide-react';
 import type { StockWithConviction, RiskProfile } from './types';
 import { getUserData, saveUserData, addTickers, updateStock, removeStock, clearAllData, importStocksWithPositions } from './lib/storage';
 import { getCloudUserData, cloudAddTickers, cloudRemoveTicker, cloudClearAll, migrateGuestToCloud, cloudImportStocksWithPositions } from './lib/cloudStorage';
@@ -21,6 +21,7 @@ import { SuggestedFinds } from './components/SuggestedFinds';
 import { TradingSignals } from './components/TradingSignals';
 import { PaperTrading } from './components/PaperTrading';
 import { OptionsWheelPage } from './components/OptionsWheelPage';
+import { MorningBrief } from './components/MorningBrief';
 import { StockDetail } from './components/StockDetail';
 import { AddTickersModal } from './components/AddTickersModal';
 import { AuthModal } from './components/AuthModal';
@@ -873,6 +874,18 @@ function AppContent() {
               <CircleDollarSign className="w-4 h-4" />
               Options Wheel
             </NavLink>
+            <NavLink
+              to="/morning-brief"
+              className={({ isActive }) => cn(
+                'flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all',
+                isActive
+                  ? 'bg-gradient-to-r from-amber-500 to-orange-500 text-white shadow-md shadow-amber-500/25'
+                  : 'text-slate-500 hover:text-slate-700 hover:bg-white/80'
+              )}
+            >
+              <Newspaper className="w-4 h-4" />
+              Morning Brief
+            </NavLink>
             {isAuthed && (
               <NavLink
                 to="/paper-trading"
@@ -918,6 +931,7 @@ function AppContent() {
           <Route path="/signals" element={<TradingSignals />} />
           {isAuthed && <Route path="/paper-trading" element={<PaperTrading />} />}
           {isAuthed && <Route path="/options" element={<OptionsWheelPage />} />}
+          <Route path="/morning-brief" element={<MorningBrief />} />
         </Routes>
       </main>
 

--- a/app/src/components/MorningBrief.tsx
+++ b/app/src/components/MorningBrief.tsx
@@ -1,0 +1,375 @@
+import { useEffect, useState } from 'react';
+import { TrendingUp, TrendingDown, Minus, Calendar, BarChart2, Newspaper, Star, ChevronRight, RefreshCw, Clock, AlertCircle } from 'lucide-react';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL as string,
+  import.meta.env.VITE_SUPABASE_ANON_KEY as string,
+);
+import { cn } from '../lib/utils';
+
+// ── Types ────────────────────────────────────────────────
+
+interface EconEvent {
+  time_et: string;
+  event: string;
+  prior: string | null;
+  estimate: string | null;
+  importance: 'high' | 'medium' | 'low';
+}
+
+interface EarningsItem {
+  ticker: string;
+  when: string;
+  note: string;
+  direction: 'bullish' | 'bearish' | 'neutral' | 'volatile';
+}
+
+interface TopMover {
+  ticker: string;
+  direction: 'bullish' | 'bearish' | 'neutral' | 'volatile';
+  catalyst: string;
+  why: string;
+}
+
+interface ResearchTheme {
+  theme: string;
+  tickers: string[];
+  note: string;
+}
+
+interface SecondaryName {
+  ticker: string;
+  direction: 'bullish' | 'bearish' | 'neutral' | 'volatile';
+  note: string;
+}
+
+interface MorningBrief {
+  id: string;
+  brief_date: string;
+  macro_snapshot: string;
+  macro_tone: string;
+  economic_events: EconEvent[];
+  earnings: EarningsItem[];
+  top_movers: TopMover[];
+  research_themes: ResearchTheme[];
+  secondary_names: SecondaryName[];
+  week_ahead: string;
+  raw_news_count: number;
+  generated_at: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────
+
+function directionIcon(d: string) {
+  if (d === 'bullish') return <TrendingUp className="w-4 h-4 text-emerald-400" />;
+  if (d === 'bearish') return <TrendingDown className="w-4 h-4 text-red-400" />;
+  if (d === 'volatile') return <BarChart2 className="w-4 h-4 text-amber-400" />;
+  return <Minus className="w-4 h-4 text-slate-400" />;
+}
+
+function directionBadge(d: string) {
+  const base = 'px-2 py-0.5 rounded-full text-xs font-semibold';
+  if (d === 'bullish') return <span className={cn(base, 'bg-emerald-500/20 text-emerald-300')}>Bullish</span>;
+  if (d === 'bearish') return <span className={cn(base, 'bg-red-500/20 text-red-300')}>Bearish</span>;
+  if (d === 'volatile') return <span className={cn(base, 'bg-amber-500/20 text-amber-300')}>Volatile</span>;
+  return <span className={cn(base, 'bg-slate-500/20 text-slate-300')}>Neutral</span>;
+}
+
+function importanceDot(imp: string) {
+  if (imp === 'high') return <span className="w-2 h-2 rounded-full bg-red-400 shrink-0 mt-1.5" />;
+  if (imp === 'medium') return <span className="w-2 h-2 rounded-full bg-amber-400 shrink-0 mt-1.5" />;
+  return <span className="w-2 h-2 rounded-full bg-slate-500 shrink-0 mt-1.5" />;
+}
+
+function formatDate(d: string) {
+  return new Date(d + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+}
+
+function timeAgo(iso: string) {
+  const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 60000);
+  if (diff < 1) return 'just now';
+  if (diff < 60) return `${diff}m ago`;
+  return `${Math.floor(diff / 60)}h ago`;
+}
+
+// ── Section wrapper ───────────────────────────────────────
+
+function Section({ icon, title, children, className }: { icon: React.ReactNode; title: string; children: React.ReactNode; className?: string }) {
+  return (
+    <div className={cn('bg-slate-800/60 rounded-xl border border-slate-700/50 p-4', className)}>
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-slate-400">{icon}</span>
+        <h3 className="text-sm font-semibold text-slate-200 uppercase tracking-wide">{title}</h3>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── Empty State ───────────────────────────────────────────
+
+function EmptyState({ isToday }: { isToday: boolean }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <div className="w-16 h-16 rounded-full bg-slate-800 flex items-center justify-center mb-4">
+        <Newspaper className="w-8 h-8 text-slate-500" />
+      </div>
+      <h3 className="text-slate-300 font-semibold mb-2">
+        {isToday ? "Today's brief hasn't been generated yet" : 'No brief for this date'}
+      </h3>
+      <p className="text-slate-500 text-sm max-w-sm">
+        {isToday
+          ? 'The morning brief runs automatically at 8:00 AM ET on weekdays. Check back after 8 AM, or trigger a manual run from the auto-trader.'
+          : 'No morning brief was generated for this date.'}
+      </p>
+    </div>
+  );
+}
+
+// ── Main Component ────────────────────────────────────────
+
+export function MorningBrief() {
+  const [brief, setBrief] = useState<MorningBrief | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [selectedDate, setSelectedDate] = useState<string>('');
+  const [availableDates, setAvailableDates] = useState<string[]>([]);
+
+  const todayStr = new Date().toLocaleDateString('en-CA');
+
+  async function fetchBriefs() {
+    setLoading(true);
+    const { data } = await supabase
+      .from('morning_briefs')
+      .select('*')
+      .order('brief_date', { ascending: false })
+      .limit(10);
+
+    if (data && data.length > 0) {
+      const dates = data.map((d: MorningBrief) => d.brief_date);
+      setAvailableDates(dates);
+      const target = selectedDate && dates.includes(selectedDate) ? selectedDate : dates[0];
+      setSelectedDate(target);
+      setBrief(data.find((d: MorningBrief) => d.brief_date === target) ?? null);
+    } else {
+      setAvailableDates([]);
+      setBrief(null);
+    }
+    setLoading(false);
+  }
+
+  useEffect(() => { fetchBriefs(); }, []);
+
+  useEffect(() => {
+    if (selectedDate && availableDates.length > 0) {
+      supabase
+        .from('morning_briefs')
+        .select('*')
+        .eq('brief_date', selectedDate)
+        .single()
+        .then(({ data }: { data: MorningBrief | null }) => setBrief(data ?? null));
+    }
+  }, [selectedDate]);
+
+  const isToday = selectedDate === todayStr;
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-slate-900 flex items-center justify-center">
+        <div className="flex items-center gap-3 text-slate-400">
+          <RefreshCw className="w-5 h-5 animate-spin" />
+          <span>Loading morning brief...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-900 text-slate-100 p-4 md:p-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-white flex items-center gap-2">
+            <Newspaper className="w-6 h-6 text-blue-400" />
+            Morning Brief
+          </h1>
+          {brief && (
+            <p className="text-slate-400 text-sm mt-0.5 flex items-center gap-1.5">
+              <Clock className="w-3.5 h-3.5" />
+              Generated {timeAgo(brief.generated_at)} · {brief.raw_news_count} news items processed
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {availableDates.length > 1 && (
+            <select
+              value={selectedDate}
+              onChange={e => setSelectedDate(e.target.value)}
+              className="bg-slate-800 border border-slate-700 text-slate-200 text-sm rounded-lg px-3 py-1.5"
+            >
+              {availableDates.map(d => (
+                <option key={d} value={d}>
+                  {d === todayStr ? `Today — ${d}` : d}
+                </option>
+              ))}
+            </select>
+          )}
+          <button
+            onClick={fetchBriefs}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-lg text-sm text-slate-300 transition-colors"
+          >
+            <RefreshCw className="w-3.5 h-3.5" />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {!brief ? (
+        <EmptyState isToday={isToday} />
+      ) : (
+        <>
+          {/* Date heading */}
+          <div className="mb-4">
+            <h2 className="text-lg font-semibold text-slate-100">{formatDate(brief.brief_date)}</h2>
+          </div>
+
+          {/* Macro snapshot — hero card */}
+          {brief.macro_snapshot && (
+            <div className="bg-gradient-to-br from-blue-900/40 to-indigo-900/30 border border-blue-700/40 rounded-xl p-5 mb-4">
+              <p className="text-sm font-medium text-blue-300 mb-1 uppercase tracking-wide">Market Snapshot</p>
+              <p className="text-slate-100 leading-relaxed">{brief.macro_snapshot}</p>
+              {brief.macro_tone && (
+                <p className="text-slate-400 text-sm mt-3 leading-relaxed border-t border-blue-700/30 pt-3">
+                  {brief.macro_tone}
+                </p>
+              )}
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+            {/* Top Movers */}
+            {brief.top_movers?.length > 0 && (
+              <Section icon={<Star className="w-4 h-4" />} title="Top Movers" className="lg:col-span-2">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  {brief.top_movers.map((m, i) => (
+                    <div key={i} className="bg-slate-900/60 rounded-lg p-3 border border-slate-700/40">
+                      <div className="flex items-center justify-between mb-1.5">
+                        <div className="flex items-center gap-2">
+                          {directionIcon(m.direction)}
+                          <span className="font-bold text-white">{m.ticker}</span>
+                          {directionBadge(m.direction)}
+                        </div>
+                      </div>
+                      <p className="text-xs text-blue-300 font-medium mb-1">{m.catalyst}</p>
+                      <p className="text-xs text-slate-400 leading-relaxed">{m.why}</p>
+                    </div>
+                  ))}
+                </div>
+              </Section>
+            )}
+
+            {/* Economic Calendar */}
+            {brief.economic_events?.length > 0 && (
+              <Section icon={<Calendar className="w-4 h-4" />} title="Economic Calendar">
+                <div className="space-y-2">
+                  {brief.economic_events.map((e, i) => (
+                    <div key={i} className="flex items-start gap-2.5">
+                      {importanceDot(e.importance)}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="text-xs font-mono text-slate-400 shrink-0">{e.time_et}</span>
+                          <span className="text-sm text-slate-200 font-medium">{e.event}</span>
+                        </div>
+                        {(e.estimate || e.prior) && (
+                          <p className="text-xs text-slate-500 mt-0.5">
+                            {e.estimate && `Est: ${e.estimate}`}
+                            {e.estimate && e.prior && ' · '}
+                            {e.prior && `Prior: ${e.prior}`}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </Section>
+            )}
+
+            {/* Earnings */}
+            {brief.earnings?.length > 0 && (
+              <Section icon={<BarChart2 className="w-4 h-4" />} title="Earnings Today">
+                <div className="space-y-2">
+                  {brief.earnings.map((e, i) => (
+                    <div key={i} className="flex items-start gap-2.5">
+                      {directionIcon(e.direction)}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="font-bold text-white text-sm">{e.ticker}</span>
+                          <span className="text-xs text-slate-500">
+                            {e.when === 'before_open' ? 'Pre-market' : e.when === 'after_close' ? 'After close' : e.when}
+                          </span>
+                          {directionBadge(e.direction)}
+                        </div>
+                        <p className="text-xs text-slate-400 mt-0.5 leading-relaxed">{e.note}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </Section>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+            {/* Research Themes */}
+            {brief.research_themes?.length > 0 && (
+              <Section icon={<ChevronRight className="w-4 h-4" />} title="Research Themes">
+                <div className="space-y-3">
+                  {brief.research_themes.map((t, i) => (
+                    <div key={i}>
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="text-sm font-semibold text-slate-200">{t.theme}</span>
+                        <div className="flex gap-1 flex-wrap">
+                          {t.tickers?.map(tk => (
+                            <span key={tk} className="px-1.5 py-0.5 bg-slate-700 rounded text-xs text-slate-300 font-mono">{tk}</span>
+                          ))}
+                        </div>
+                      </div>
+                      <p className="text-xs text-slate-400 leading-relaxed">{t.note}</p>
+                    </div>
+                  ))}
+                </div>
+              </Section>
+            )}
+
+            {/* Secondary Names */}
+            {brief.secondary_names?.length > 0 && (
+              <Section icon={<Newspaper className="w-4 h-4" />} title="Also on Radar">
+                <div className="space-y-2">
+                  {brief.secondary_names.map((s, i) => (
+                    <div key={i} className="flex items-start gap-2">
+                      {directionIcon(s.direction)}
+                      <div>
+                        <span className="font-bold text-white text-sm mr-2">{s.ticker}</span>
+                        <span className="text-xs text-slate-400">{s.note}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </Section>
+            )}
+          </div>
+
+          {/* Week Ahead */}
+          {brief.week_ahead && (
+            <div className="bg-slate-800/40 border border-slate-700/40 rounded-xl p-4">
+              <div className="flex items-center gap-2 mb-2">
+                <AlertCircle className="w-4 h-4 text-amber-400" />
+                <h3 className="text-sm font-semibold text-slate-200 uppercase tracking-wide">Week Ahead</h3>
+              </div>
+              <p className="text-slate-400 text-sm leading-relaxed">{brief.week_ahead}</p>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/auto-trader/src/lib/morning-brief.ts
+++ b/auto-trader/src/lib/morning-brief.ts
@@ -1,0 +1,153 @@
+/**
+ * Morning brief generator — runs at 8:00 AM ET on weekdays.
+ *
+ * Data sources (all free-tier):
+ *   1. Finnhub /news?category=general      — last 12 hours of market news
+ *   2. Finnhub /calendar/earnings           — today's earnings reporters
+ *   3. Finnhub /calendar/economic           — today's economic releases
+ *
+ * Sends raw data to the generate-morning-brief edge function which uses
+ * Llama 70B (via Groq) to synthesize a structured JSON briefing, then
+ * upserts it to morning_briefs table.
+ */
+
+import { getSupabase } from './supabase.js';
+
+const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+const SUPABASE_URL = process.env.SUPABASE_URL ?? '';
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY ?? '';
+
+function log(msg: string) {
+  console.log(`[Morning Brief] ${msg}`);
+}
+
+function todayET(): string {
+  return new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' }); // YYYY-MM-DD
+}
+
+function hoursAgoUnix(hours: number): number {
+  return Math.floor((Date.now() - hours * 3_600_000) / 1000);
+}
+
+// ── Finnhub Fetchers ──────────────────────────────────────
+
+async function fetchMarketNews() {
+  try {
+    const from = hoursAgoUnix(14); // slightly wider window to catch overnight
+    const url = `https://finnhub.io/api/v1/news?category=general&minId=${from}&token=${FINNHUB_KEY}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Finnhub news ${res.status}`);
+    const data = await res.json() as Array<{
+      headline: string; summary: string; related: string; datetime: number; source: string;
+    }>;
+    // Keep last 12h, deduplicate by headline
+    const cutoff = hoursAgoUnix(12);
+    const seen = new Set<string>();
+    return data
+      .filter(n => n.datetime >= cutoff)
+      .filter(n => { if (seen.has(n.headline)) return false; seen.add(n.headline); return true; })
+      .slice(0, 60);
+  } catch (err) {
+    log(`News fetch failed: ${err}`);
+    return [];
+  }
+}
+
+async function fetchEarningsToday(dateStr: string) {
+  try {
+    const url = `https://finnhub.io/api/v1/calendar/earnings?from=${dateStr}&to=${dateStr}&token=${FINNHUB_KEY}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Finnhub earnings ${res.status}`);
+    const data = await res.json() as { earningsCalendar?: Array<{
+      symbol: string; date: string; epsEstimate?: number; hour?: string;
+    }> };
+    return (data.earningsCalendar ?? []).slice(0, 30);
+  } catch (err) {
+    log(`Earnings fetch failed: ${err}`);
+    return [];
+  }
+}
+
+async function fetchEconomicEventsToday(dateStr: string) {
+  try {
+    const url = `https://finnhub.io/api/v1/calendar/economic?from=${dateStr}&to=${dateStr}&token=${FINNHUB_KEY}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Finnhub econ ${res.status}`);
+    const data = await res.json() as { economicCalendar?: Array<{
+      event: string; time: string; prior?: string; estimate?: string; impact?: string;
+    }> };
+    return (data.economicCalendar ?? []).map(e => ({
+      event: e.event,
+      time: e.time,
+      prior: e.prior ?? null,
+      estimate: e.estimate ?? null,
+      importance: e.impact === 'high' ? 'high' : e.impact === 'medium' ? 'medium' : 'low',
+    })).slice(0, 20);
+  } catch (err) {
+    log(`Economic calendar fetch failed: ${err}`);
+    return [];
+  }
+}
+
+// ── Check if already generated today ─────────────────────
+
+async function alreadyGeneratedToday(dateStr: string): Promise<boolean> {
+  const sb = getSupabase();
+  const { data } = await sb
+    .from('morning_briefs')
+    .select('id')
+    .eq('brief_date', dateStr)
+    .maybeSingle();
+  return !!data;
+}
+
+// ── Main Entry Point ──────────────────────────────────────
+
+export async function generateMorningBrief(): Promise<void> {
+  const dateStr = todayET();
+  log(`Generating brief for ${dateStr}...`);
+
+  // Skip if already done today (re-run safe)
+  if (await alreadyGeneratedToday(dateStr)) {
+    log(`Brief for ${dateStr} already exists — skipping`);
+    return;
+  }
+
+  // Fetch all data sources in parallel
+  const [news, earnings, economicEvents] = await Promise.all([
+    fetchMarketNews(),
+    fetchEarningsToday(dateStr),
+    fetchEconomicEventsToday(dateStr),
+  ]);
+
+  log(`Data collected — ${news.length} news items, ${earnings.length} earnings, ${economicEvents.length} econ events`);
+
+  if (news.length === 0 && earnings.length === 0) {
+    log('No data to synthesize — skipping (market may be closed)');
+    return;
+  }
+
+  // Call edge function for AI synthesis
+  const edgeFnUrl = `${SUPABASE_URL}/functions/v1/generate-morning-brief`;
+  const res = await fetch(edgeFnUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
+    },
+    body: JSON.stringify({ brief_date: dateStr, news, earnings, economic_events: economicEvents }),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text();
+    log(`Edge function error ${res.status}: ${errText}`);
+    return;
+  }
+
+  const result = await res.json() as { ok: boolean; brief_date: string };
+  if (result.ok) {
+    log(`✅ Morning brief for ${result.brief_date} generated and saved`);
+  } else {
+    log(`❌ Edge function returned error: ${JSON.stringify(result)}`);
+  }
+}

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -71,6 +71,7 @@ import { runWatchlistScreener } from './lib/watchlist-screener.js';
 import { runOptionsManageCycle } from './lib/options-manager.js';
 import { runDipWatcher } from './lib/dip-watcher.js';
 import { warmPositionPriceCache } from './routes/positions.js';
+import { generateMorningBrief } from './lib/morning-brief.js';
 
 // ── Types ────────────────────────────────────────────────
 
@@ -289,6 +290,18 @@ export function startScheduler(): void {
   }, { timezone: 'America/New_York' });
 
   console.log('[Scheduler] Started — every 15 min + 9:36 ET first-candle pass + 9:45 earnings exit + 14:30 earnings entry + 15:55 EOD close (weekdays)');
+
+  // Morning brief — runs 8:00 AM ET weekdays, before market open
+  // Fetches Finnhub news + earnings + economic calendar, synthesizes via Llama 70B
+  cron.schedule('0 8 * * 1-5', async () => {
+    try {
+      log('[Scheduler] Running morning brief generation...');
+      await generateMorningBrief();
+    } catch (err) {
+      console.error('[Scheduler] Morning brief failed:', err instanceof Error ? err.message : err);
+    }
+  }, { timezone: 'America/New_York' });
+  log('Morning brief: weekdays 8:00 AM ET');
 
   // Weekly watchlist screener — runs Monday 10:30 AM ET to surface new ticker candidates
   cron.schedule('30 10 * * 1', async () => {

--- a/supabase/functions/generate-morning-brief/index.ts
+++ b/supabase/functions/generate-morning-brief/index.ts
@@ -1,0 +1,168 @@
+/**
+ * Generate a structured pre-market trading briefing from raw market data.
+ *
+ * Input (POST body):
+ *   {
+ *     brief_date: string;          // YYYY-MM-DD
+ *     news: NewsItem[];            // Finnhub general market news (last 12h)
+ *     earnings: EarningsItem[];    // today's earnings reporters
+ *     economic_events: EconItem[]; // scheduled economic releases
+ *   }
+ *
+ * Output: upserts to morning_briefs table and returns the structured brief.
+ */
+
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions';
+const GROQ_MODEL = 'llama-3.3-70b-versatile';
+
+const BRIEF_SYSTEM = `You are a professional pre-market trading analyst. You synthesize raw market data into a concise, actionable daily briefing for a retail options and equity trader.
+
+Return ONLY a single JSON object (no markdown, no code blocks) with these exact fields:
+
+{
+  "macro_snapshot": "2-3 sentence market setup for today. Cover: Fed stance, dominant market theme, overall risk tone (risk-on/off). Be specific and direct.",
+  "macro_tone": "1-2 paragraph expanded macro context. What's driving markets? Any geopolitical developments, commodity moves, or sentiment shifts?",
+  "economic_events": [
+    { "time_et": "8:30 AM", "event": "CPI MoM", "prior": "0.4%", "estimate": "0.3%", "importance": "high" }
+  ],
+  "earnings": [
+    { "ticker": "TSLA", "when": "before_open", "note": "Expected EPS $0.52. Watch guidance on energy business.", "direction": "neutral" }
+  ],
+  "top_movers": [
+    { "ticker": "NVDA", "direction": "bullish", "catalyst": "Earnings beat + raised guidance", "why": "Revenue up 78% YoY driven by data center demand. Options market pricing 8% move." }
+  ],
+  "research_themes": [
+    { "theme": "AI Infrastructure", "tickers": ["NVDA", "AMD", "SMCI"], "note": "Hyperscaler capex guidance being raised across the board." }
+  ],
+  "secondary_names": [
+    { "ticker": "WMT", "direction": "bullish", "note": "Tariff exemption granted on consumer electronics imports." }
+  ],
+  "week_ahead": "Key events this week: Tuesday Fed speakers (Williams 2pm), Wednesday FOMC minutes, Thursday jobless claims + PPI, Friday options expiration (quad witching)."
+}
+
+Rules:
+- top_movers: max 5 names, ranked by likely intraday volatility
+- secondary_names: additional tickers from news, brief note only
+- economic_events: today's releases only, sorted by time
+- earnings: pre-market AND after-close reporters for today
+- direction: "bullish" | "bearish" | "neutral" | "volatile"
+- importance: "high" | "medium" | "low"
+- If no data for a section, use empty array [] or empty string ""
+- Be specific, concise, and trader-focused — avoid generic statements`;
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+
+  try {
+    const body = await req.json() as {
+      brief_date: string;
+      news: Array<{ headline: string; summary: string; related: string; datetime: number; source: string }>;
+      earnings: Array<{ symbol: string; date: string; epsEstimate?: number; hour?: string }>;
+      economic_events: Array<{ event: string; time: string; prior?: string; estimate?: string; importance?: string }>;
+    };
+
+    const { brief_date, news, earnings, economic_events } = body;
+    if (!brief_date) throw new Error('brief_date required');
+
+    // Build compact raw data summary for the LLM
+    const newsSummary = (news ?? []).slice(0, 40).map(n =>
+      `[${n.related || 'MACRO'}] ${n.headline}${n.summary ? ': ' + n.summary.slice(0, 200) : ''}`
+    ).join('\n');
+
+    const earningsSummary = (earnings ?? []).map(e =>
+      `${e.symbol} — ${e.hour === 'bmo' ? 'Before Open' : e.hour === 'amc' ? 'After Close' : 'TBD'}${e.epsEstimate ? `, EPS est: $${e.epsEstimate}` : ''}`
+    ).join('\n');
+
+    const econSummary = (economic_events ?? []).map(e =>
+      `${e.time} ET — ${e.event}${e.estimate ? ` (est: ${e.estimate}` : ''}${e.prior ? `, prior: ${e.prior})` : ')'}`
+    ).join('\n');
+
+    const userPrompt = `Date: ${brief_date}
+
+=== MARKET NEWS (last 12 hours) ===
+${newsSummary || 'No news items available.'}
+
+=== EARNINGS TODAY ===
+${earningsSummary || 'No earnings reporters today.'}
+
+=== ECONOMIC CALENDAR TODAY ===
+${econSummary || 'No major economic releases scheduled.'}
+
+Generate the structured daily market briefing JSON for this trading day.`;
+
+    const groqRes = await fetch(GROQ_URL, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${Deno.env.get('GROQ_API_KEY')}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: GROQ_MODEL,
+        messages: [
+          { role: 'system', content: BRIEF_SYSTEM },
+          { role: 'user', content: userPrompt },
+        ],
+        temperature: 0.3,
+        max_tokens: 2048,
+      }),
+    });
+
+    if (!groqRes.ok) throw new Error(`Groq error: ${groqRes.status} ${await groqRes.text()}`);
+    const groqData = await groqRes.json() as { choices: [{ message: { content: string } }] };
+    const raw = groqData.choices[0].message.content.trim();
+
+    // Strip any accidental markdown fences
+    const jsonStr = raw.replace(/^```json\s*/i, '').replace(/^```\s*/i, '').replace(/```\s*$/i, '').trim();
+    const brief = JSON.parse(jsonStr) as {
+      macro_snapshot: string;
+      macro_tone: string;
+      economic_events: unknown[];
+      earnings: unknown[];
+      top_movers: unknown[];
+      research_themes: unknown[];
+      secondary_names: unknown[];
+      week_ahead: string;
+    };
+
+    // Upsert into morning_briefs
+    const sb = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    );
+
+    const { error: upsertErr } = await sb.from('morning_briefs').upsert({
+      brief_date,
+      macro_snapshot: brief.macro_snapshot ?? '',
+      macro_tone: brief.macro_tone ?? '',
+      economic_events: brief.economic_events ?? [],
+      earnings: brief.earnings ?? [],
+      top_movers: brief.top_movers ?? [],
+      research_themes: brief.research_themes ?? [],
+      secondary_names: brief.secondary_names ?? [],
+      week_ahead: brief.week_ahead ?? '',
+      raw_news_count: (news ?? []).length,
+      generated_at: new Date().toISOString(),
+    }, { onConflict: 'brief_date' });
+
+    if (upsertErr) throw new Error(`DB upsert failed: ${upsertErr.message}`);
+
+    return new Response(JSON.stringify({ ok: true, brief_date, brief }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+
+  } catch (err) {
+    console.error('[generate-morning-brief]', err);
+    return new Response(JSON.stringify({ error: String(err) }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/migrations/20260424000004_morning_briefs.sql
+++ b/supabase/migrations/20260424000004_morning_briefs.sql
@@ -1,0 +1,24 @@
+-- Morning brief table — stores AI-synthesized daily market briefings
+-- Generated at 8 AM ET each weekday from Finnhub news, earnings calendar,
+-- and economic data releases.
+
+CREATE TABLE IF NOT EXISTS morning_briefs (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  brief_date      DATE NOT NULL UNIQUE,
+  macro_snapshot  TEXT,              -- 2-3 sentence market setup for the day
+  macro_tone      TEXT,              -- extended macro context
+  economic_events JSONB DEFAULT '[]', -- [{time, event, prior, estimate, importance}]
+  earnings        JSONB DEFAULT '[]', -- [{ticker, when, eps_est, direction, note}]
+  top_movers      JSONB DEFAULT '[]', -- [{ticker, direction, catalyst, why}]
+  research_themes JSONB DEFAULT '[]', -- [{theme, tickers, note}]
+  secondary_names JSONB DEFAULT '[]', -- [{ticker, direction, note}]
+  week_ahead      TEXT,              -- key events coming in next 5 trading days
+  raw_news_count  INT DEFAULT 0,     -- how many news items were processed
+  generated_at    TIMESTAMPTZ DEFAULT NOW(),
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_morning_briefs_date ON morning_briefs (brief_date DESC);
+
+COMMENT ON TABLE morning_briefs IS
+  'AI-synthesized daily pre-market briefings. One row per trading day, upserted each morning at 8 AM ET.';


### PR DESCRIPTION
## Summary
Fully automated morning brief that replaces 45-60 minutes of manual newsletter reading with a 2-minute scannable dashboard.

### How it works
```
8:00 AM ET (weekday cron)
  → Fetch: Finnhub news (last 12h) + earnings calendar + economic calendar
  → POST to generate-morning-brief edge function
  → Llama 70B synthesizes structured JSON brief
  → Upsert to morning_briefs table
  → /morning-brief tab displays dark-theme dashboard
```

### Sections generated
| Section | Source |
|---|---|
| Macro Snapshot | News synthesis |
| Macro Tone | News synthesis |
| Economic Calendar | Finnhub economic calendar |
| Earnings Today | Finnhub earnings calendar |
| Top Movers (ranked) | News catalyst extraction |
| Research Themes | Cross-ticker theme detection |
| Secondary Names | News mentions |
| Week Ahead | Forward-looking events |

### No new API keys needed
Uses Finnhub (already connected) + Groq/Llama (already used in other edge functions). No Gmail, no newsletter subscriptions required.

## Test plan
- [ ] Run `generateMorningBrief()` manually → brief appears in DB
- [ ] /morning-brief tab shows dark dashboard with all sections
- [ ] Date picker loads historical briefs
- [ ] Re-running today doesn't create duplicate (idempotent)
- [ ] Scheduler log shows "Morning brief: weekdays 8:00 AM ET"

Made with [Cursor](https://cursor.com)