### PR TITLE
fix: prevent JSON truncation in Suggested Finds analysis

### DIFF
--- a/app/src/components/PaperTrading/tabs/OptionsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/OptionsTab.tsx
@@ -500,13 +500,16 @@ export function OptionsTab() {
   // The backend responds immediately (fire-and-forget); scan takes ~90s for full watchlist.
   const handleRefresh = useCallback(async () => {
     setScanning(true);
+    console.log('[Options Scan] Requesting scan from auto-trader...');
     try {
-      await fetch('http://localhost:3001/api/scheduler/options-scan', {
+      const res = await fetch('http://localhost:3001/api/scheduler/options-scan', {
         method: 'POST',
         signal: AbortSignal.timeout(5_000),
       });
-    } catch {
-      // auto-trader offline or timed out — still reload data
+      const body = await res.json().catch(() => ({}));
+      console.log('[Options Scan] Scan started:', body);
+    } catch (err) {
+      console.warn('[Options Scan] Auto-trader offline — refreshing data only.', err);
       setScanning(false);
       await load();
       return;
@@ -515,16 +518,19 @@ export function OptionsTab() {
     // Poll every 15s for up to 3 minutes, reloading data as results come in
     let elapsed = 0;
     const poll = setInterval(async () => {
-      await load();
       elapsed += 15;
+      console.log(`[Options Scan] Polling for results... (${elapsed}s elapsed)`);
+      await load();
       if (elapsed >= 180) {
         clearInterval(poll);
         setScanning(false);
+        console.log('[Options Scan] Scan polling complete.');
       }
     }, 15_000);
 
     // Also do an immediate reload after 20s (first results arrive)
     setTimeout(async () => {
+      console.log('[Options Scan] First-results reload (20s)');
       await load();
     }, 20_000);
 

--- a/app/src/lib/aiSuggestedFinds.ts
+++ b/app/src/lib/aiSuggestedFinds.ts
@@ -1053,7 +1053,7 @@ export async function discoverStocks(
     buildGoldMineAnalysisPrompt(validGoldMineMetrics, marketNews, goldMineCandidates, currentTheme),
     'discover_goldmines',
     0.3,
-    4000
+    8000
   );
   const goldMines = parseGoldMineAnalysis(goldMineAnalysisRaw);
 
@@ -1136,7 +1136,7 @@ export async function discoverCategoryStocks(
     buildCompounderAnalysisPrompt(validMetrics),
     'discover_compounders',
     0.3,
-    4000
+    8000
   );
   const compounders = parseCompounderResponse(compounderRaw);
 
@@ -1209,7 +1209,7 @@ export async function discoverGoldMineCategoryStocks(
     buildGoldMineCategoryAnalysisPrompt(validMetrics, category),
     'discover_goldmines',
     0.3,
-    4000
+    8000
   );
   const goldMines = parseGoldMineAnalysis(analysisRaw);
 

--- a/auto-trader/src/lib/discovery.ts
+++ b/auto-trader/src/lib/discovery.ts
@@ -552,7 +552,7 @@ export async function generateSuggestedFinds(): Promise<DiscoveryResult> {
   await sleep(2000);
 
   console.log('[Discovery] Step 3: HuggingFace analyzing compounders...');
-  const compounderRaw = await callHuggingFace(buildCompounderAnalysisPrompt(validMetrics), 'discover_compounders', 0.3, 4000);
+  const compounderRaw = await callHuggingFace(buildCompounderAnalysisPrompt(validMetrics), 'discover_compounders', 0.3, 8000);
   const compounders = parseStocksResponse(compounderRaw, 'Steady Compounder');
 
   // ── GOLD MINES PIPELINE ──
@@ -577,7 +577,7 @@ export async function generateSuggestedFinds(): Promise<DiscoveryResult> {
   console.log('[Discovery] Step 5c: HuggingFace analyzing Gold Mines...');
   const goldMineRaw = await callHuggingFace(
     buildGoldMineAnalysisPrompt(validGoldMineMetrics, marketNews, goldMineCandidates, currentTheme),
-    'discover_goldmines', 0.3, 4000,
+    'discover_goldmines', 0.3, 8000,
   );
   const goldMines = parseStocksResponse(goldMineRaw, 'Gold Mine');
 

--- a/supabase/functions/huggingface-proxy/index.ts
+++ b/supabase/functions/huggingface-proxy/index.ts
@@ -14,7 +14,7 @@ const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions';
 // Model fallback: try best quality first, fall back on rate limits
 const GROQ_MODELS = [
   'llama-3.3-70b-versatile',   // Best reasoning for stock discovery
-  'qwen/qwen3-32b',            // Smart fallback with higher limits
+  'llama-3.1-8b-instant',      // Fast non-thinking fallback (avoids Qwen3 reasoning token drain)
   'llama3-8b-8192',            // Last resort
 ];
 


### PR DESCRIPTION
## Summary
- When `llama-3.3-70b-versatile` was rate-limited, `qwen/qwen3-32b` ran as fallback but its built-in thinking mode consumed most of the 4000-token budget — leaving the actual JSON output truncated mid-string (`SyntaxError: Unterminated string in JSON at position 1248`)
- Replaced `qwen/qwen3-32b` with `llama-3.1-8b-instant` in the fallback chain (no thinking mode, 128K context)
- Raised `maxOutputTokens` for all analysis calls from 4000 → 8000 for additional headroom

## Test plan
- [ ] Reload Suggested Finds — full pipeline should complete without JSON parse errors
- [ ] Console should show `[Discovery] Done: X compounders, Y gold mines` 

Made with [Cursor](https://cursor.com)