### PR TITLE
fix: morning brief 500 errors

### DIFF
--- a/app/src/components/PaperTrading/tabs/OptionsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/OptionsTab.tsx
@@ -500,13 +500,16 @@ export function OptionsTab() {
   // The backend responds immediately (fire-and-forget); scan takes ~90s for full watchlist.
   const handleRefresh = useCallback(async () => {
     setScanning(true);
+    console.log('[Options Scan] Requesting scan from auto-trader...');
     try {
-      await fetch('http://localhost:3001/api/scheduler/options-scan', {
+      const res = await fetch('http://localhost:3001/api/scheduler/options-scan', {
         method: 'POST',
         signal: AbortSignal.timeout(5_000),
       });
-    } catch {
-      // auto-trader offline or timed out — still reload data
+      const body = await res.json().catch(() => ({}));
+      console.log('[Options Scan] Scan started:', body);
+    } catch (err) {
+      console.warn('[Options Scan] Auto-trader offline — refreshing data only.', err);
       setScanning(false);
       await load();
       return;
@@ -515,16 +518,19 @@ export function OptionsTab() {
     // Poll every 15s for up to 3 minutes, reloading data as results come in
     let elapsed = 0;
     const poll = setInterval(async () => {
-      await load();
       elapsed += 15;
+      console.log(`[Options Scan] Polling for results... (${elapsed}s elapsed)`);
+      await load();
       if (elapsed >= 180) {
         clearInterval(poll);
         setScanning(false);
+        console.log('[Options Scan] Scan polling complete.');
       }
     }, 15_000);
 
     // Also do an immediate reload after 20s (first results arrive)
     setTimeout(async () => {
+      console.log('[Options Scan] First-results reload (20s)');
       await load();
     }, 20_000);
 

--- a/supabase/functions/generate-morning-brief/index.ts
+++ b/supabase/functions/generate-morning-brief/index.ts
@@ -99,11 +99,14 @@ Deno.serve(async (req: Request) => {
     let economic_events = body.economic_events;
 
     if (!news) {
-      const twelveHoursAgo = Math.floor(Date.now() / 1000) - 12 * 3600;
       const raw = await fetchFinnhub<{ id: number; headline: string; summary: string; related: string; datetime: number; source: string }[]>(
-        `/news?category=general&minId=${twelveHoursAgo}`, finnhubKey
+        `/news?category=general`, finnhubKey
       );
-      news = raw ?? [];
+      // Filter to last 12 hours by datetime (Unix timestamp)
+      const twelveHoursAgo = Math.floor(Date.now() / 1000) - 12 * 3600;
+      news = (raw ?? []).filter(n => n.datetime >= twelveHoursAgo);
+      // Fall back to all available news if nothing recent
+      if (news.length === 0) news = raw ?? [];
     }
 
     if (!earnings) {
@@ -166,7 +169,7 @@ Generate the structured daily market briefing JSON for this trading day.`;
             { role: 'user', content: userPrompt },
           ],
           temperature: 0.3,
-          max_tokens: 1500,
+          max_tokens: 3000,
         }),
       });
 
@@ -222,7 +225,18 @@ Generate the structured daily market briefing JSON for this trading day.`;
       }
     }
 
-    const jsonStr = raw.replace(/^```json\s*/i, '').replace(/^```\s*/i, '').replace(/```\s*$/i, '').trim();
+    // Strip markdown fences and any leading/trailing non-JSON text
+    let jsonStr = raw
+      .replace(/^```json\s*/im, '')
+      .replace(/^```\s*/im, '')
+      .replace(/```\s*$/im, '')
+      .trim();
+    // Extract first {...} block in case model adds preamble text
+    const braceStart = jsonStr.indexOf('{');
+    const braceEnd = jsonStr.lastIndexOf('}');
+    if (braceStart !== -1 && braceEnd !== -1 && braceEnd > braceStart) {
+      jsonStr = jsonStr.slice(braceStart, braceEnd + 1);
+    }
     const brief = JSON.parse(jsonStr) as {
       macro_snapshot: string; macro_tone: string;
       economic_events: unknown[]; earnings: unknown[];


### PR DESCRIPTION
## Summary
- **Broken Finnhub news filter**: the URL used `minId=<unix_timestamp>` but Finnhub's `minId` is an article ID (a small integer) — passing a timestamp like `1745762400` filtered out every single article silently. Fixed to fetch all news and filter by `datetime` in-process.
- **JSON truncation**: `max_tokens: 1500` was too small for the full brief JSON (macro + top movers + earnings + economic events + themes). Raised to `3000`.
- **Robust JSON extraction**: extract first `{...}` block before `JSON.parse` to handle model preamble text.

## Test plan
- [ ] Click "Generate Now" on Morning Brief tab — should succeed without 500
- [ ] Brief should now include actual market news headlines

Made with [Cursor](https://cursor.com)