### PR TITLE
fix: tighten options scanner for tariff-volatile environment

### DIFF
--- a/app/src/components/PaperTrading/tabs/OptionsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/OptionsTab.tsx
@@ -500,13 +500,16 @@ export function OptionsTab() {
   // The backend responds immediately (fire-and-forget); scan takes ~90s for full watchlist.
   const handleRefresh = useCallback(async () => {
     setScanning(true);
+    console.log('[Options Scan] Requesting scan from auto-trader...');
     try {
-      await fetch('http://localhost:3001/api/scheduler/options-scan', {
+      const res = await fetch('http://localhost:3001/api/scheduler/options-scan', {
         method: 'POST',
         signal: AbortSignal.timeout(5_000),
       });
-    } catch {
-      // auto-trader offline or timed out — still reload data
+      const body = await res.json().catch(() => ({}));
+      console.log('[Options Scan] Scan started:', body);
+    } catch (err) {
+      console.warn('[Options Scan] Auto-trader offline — refreshing data only.', err);
       setScanning(false);
       await load();
       return;
@@ -515,16 +518,19 @@ export function OptionsTab() {
     // Poll every 15s for up to 3 minutes, reloading data as results come in
     let elapsed = 0;
     const poll = setInterval(async () => {
-      await load();
       elapsed += 15;
+      console.log(`[Options Scan] Polling for results... (${elapsed}s elapsed)`);
+      await load();
       if (elapsed >= 180) {
         clearInterval(poll);
         setScanning(false);
+        console.log('[Options Scan] Scan polling complete.');
       }
     }, 15_000);
 
     // Also do an immediate reload after 20s (first results arrive)
     setTimeout(async () => {
+      console.log('[Options Scan] First-results reload (20s)');
       await load();
     }, 20_000);
 

--- a/auto-trader/src/lib/options-scanner.ts
+++ b/auto-trader/src/lib/options-scanner.ts
@@ -64,7 +64,7 @@ const NEWS_LOOKBACK_DAYS = 7;              // check news from last N days
 const MAX_SECTOR_POSITIONS = 2;            // max concurrent positions in same sector
 const MAX_BETA = 1.5;                      // skip high-beta stocks for put selling
 const STOCK_TREND_SMA_DAYS = 50;           // stock must be above its own 50-day SMA
-const MAX_STOCK_DECLINE_3M_PCT = 20;       // skip if stock down >20% in 3 months
+const MAX_STOCK_DECLINE_3M_PCT = 12;       // skip if stock down >12% in 3 months
 const MARKET_OPEN_BUFFER_MS = 30 * 60_000; // don't trade in first 30 min after open
 
 // Market discount gate — skip if stock is within this % of its 52-week high.
@@ -98,6 +98,7 @@ const RED_FLAG_HARD = [
 // Soft stops — require 2+ headlines to avoid incidental mentions on large caps
 const RED_FLAG_SOFT = [
   'bankruptcy', 'class action', 'recall', 'ceo resign', 'cfo resign',
+  'tariff', 'trade war', 'import duty', 'trade dispute',
 ];
 
 // ── Types ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- AAPL, JPM, and NOW puts all took losses in April 2026 because the scanner had no awareness of tariff/trade-war macro exposure — Finnhub sentiment scores individual company news, not structural supply-chain risk
- Added tariff-related terms to `RED_FLAG_SOFT`: `"tariff"`, `"trade war"`, `"import duty"`, `"trade dispute"` — requires 2+ headlines in the last 7 days to block entry (same logic as existing soft stops, avoiding false positives from incidental mentions on large caps)
- Tightened `MAX_STOCK_DECLINE_3M_PCT` from 20% → 12% — AAPL-style rollover (10-15% decline) was passing under the old 20% threshold

## Effect
- AAPL currently has persistent tariff coverage in news → would be blocked at Check 4.5
- Stocks in a clear 3-month downtrend (>12% down) are blocked at Check 3.5 before even reaching options chain evaluation
- No change to any other gate — clean, targeted fix

## Test plan
- [ ] Run a scan and confirm AAPL shows `skip_reason: negative_sentiment` or `down_X%_3m`
- [ ] Confirm non-tariff STABLE names (VPU, WM, etc.) are unaffected

Made with [Cursor](https://cursor.com)