### PR TITLE
fix: BLTR→PLTR OCR correction for Palantir

### DIFF
--- a/supabase/functions/extract-strategy-metadata-from-transcript/index.ts
+++ b/supabase/functions/extract-strategy-metadata-from-transcript/index.ts
@@ -275,6 +275,7 @@ Deno.serve(async (req) => {
   const TICKER_CORRECTIONS: Record<string, string> = {
     KKI: 'QQQ', KQQ: 'QQQ', QQ: 'QQQ', KQQQ: 'QQQ',
     MERA: 'META', NVDIA: 'NVDA', NFDA: 'NVDA',
+    BLTR: 'PLTR', PLRT: 'PLTR',  // P/B OCR misread on Palantir
     TSLA: 'TSLA', // identity — keep common ones to prevent further drift
   };
   const rawSignals = Array.isArray(extracted.extracted_signals) ? extracted.extracted_signals : [];


### PR DESCRIPTION
## Summary
- The transcript LLM was OCR-misreading `PLTR` as `BLTR` (P/B visual confusion)
- Added `BLTR: 'PLTR'` and `PLRT: 'PLTR'` to `TICKER_CORRECTIONS` in `extract-strategy-metadata-from-transcript`
- Patched 4 existing DB records in `external_strategy_signals` directly (2 EXPIRED from Apr 14, 2 PENDING for Apr 27 now corrected to PLTR)
- Edge function redeployed

## Test plan
- [ ] PLTR signals now show correctly in Execute Past Window / trade log
- [ ] Future Somesh videos with PLTR parse correctly

Made with [Cursor](https://cursor.com)