### PR TITLE
fix: add belt-and-suspenders market hours guard in executeScannerTrade

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -2195,6 +2195,10 @@ async function executeScannerTrade(
 ): Promise<string> {
   const { ticker, signal, confidence: scannerConf, mode } = idea;
 
+  // Belt-and-suspenders: never place scanner orders outside market hours,
+  // regardless of which code path invoked this function.
+  if (!isMarketHoursET()) return 'skipped:outside-market-hours';
+
   if (await hasActiveTrade(ticker)) return 'skipped:duplicate';
 
   // ── Daily max-loss gate ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Scanner trades were placed at 9:15 AM ET (before market open at 9:30 AM) in a prior auto-trader session. The top-level cycle guard (`isMarketHoursET()` at the top of `runSchedulerCycle`) should prevent this, but something allowed it through — possibly a timing edge case where the pre-market scanner refreshed `swing_trades` at 9:14 AM, triggering the realtime execution path.

Added a second `isMarketHoursET()` check directly inside `executeScannerTrade()` as a belt-and-suspenders guarantee that no scanner order can reach IB before 9:30 AM ET, regardless of which code path invoked it.

## Root cause (best hypothesis)

The Supabase realtime subscription on `trade_scans` fired at 9:14:29 AM ET (when `swing_trades` was updated by the pre-market scan). The 3-second debounce fired at 9:14:32, called `runTradeExecutionOnly()`. The outer `isMarketHoursET()` check should have returned false at 9:14 AM, but for unknown reasons the trades executed anyway.

Made with [Cursor](https://cursor.com)