### PR TITLE
fix: gate scanner trades to 9:35 AM ET

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -2197,7 +2197,10 @@ async function executeScannerTrade(
 
   // Belt-and-suspenders: never place scanner orders outside market hours,
   // regardless of which code path invoked this function.
-  if (!isMarketHoursET()) return 'skipped:outside-market-hours';
+  // Also block the 9:30–9:34 window — the first candle hasn't formed yet and
+  // spreads are widest right at open. The dedicated 9:36 first-candle cron
+  // handles first-candle setups; scanner trades shouldn't race it.
+  if (!isMarketHoursET() || getETMinutes() < 9 * 60 + 35) return 'skipped:outside-market-hours';
 
   if (await hasActiveTrade(ticker)) return 'skipped:duplicate';
 


### PR DESCRIPTION
## Summary
- Scanner trades now blocked from 9:30–9:34 AM ET (first candle window)
- `executeScannerTrade` guard updated: `!isMarketHoursET() || getETMinutes() < 9*60+35`
- Position management paths (loss cuts, dip buys, profit takes) are unaffected — they run from 9:30 via the main cycle gate
- The 9:36 first-candle cron is the intended entry point for opening-range setups

Made with [Cursor](https://cursor.com)