### PR TITLE
fix: influencer signals never blocked by scanner trades on same ticker

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -2721,8 +2721,12 @@ async function executeExternalStrategySignal(
   // execution window opens), losing their allocationSplit group context. Always use the lenient
   // conflict check for them so they aren't blocked by a same-direction strategy trade.
   const isGenericAutoSignal = (signal.notes ?? '').toLowerCase().includes('generic strategy auto');
+  // Influencer signals (strategy_video_id != null) must never be blocked by a scanner trade
+  // on the same ticker — they are fundamentally different signal sources. A scanner trade and
+  // an influencer signal for AMD are not duplicates: one is AI-generated, the other is a human
+  // expert's specific level. Only block if the SAME video already has an active trade open.
   if (!skipConfirmationGates) {
-    if (allowDuplicateTicker || isGenericAutoSignal) {
+    if (allowDuplicateTicker || isGenericAutoSignal || signal.strategy_video_id != null) {
       const activeTrades = await getActiveTrades();
       const sameTickerTrades = activeTrades.filter(
         trade => trade.ticker.toUpperCase() === ticker


### PR DESCRIPTION
## Problem
If the scanner placed a trade on AMD and Somesh's video also mentioned AMD, his signal would hit the blunt `hasActiveTrade` check and be skipped as a duplicate. These are not duplicates — different sources, different entry levels, different theses.

## Fix
Extended the smart conflict check to activate for all influencer signals (`strategy_video_id != null`). The smart check only blocks if the **same strategy video** already has an active trade for that ticker+mode+direction. Scanner trades (`strategy_video_id = null`) can never match, so they never block influencer signals.

## What still works
- Allocation splits within the same video (T1/T2 targets) still use the smart check
- Scanner-vs-scanner duplicates still use the blunt check  
- A second signal from the same Somesh video for the same ticker is still blocked

Made with [Cursor](https://cursor.com)