### PR TITLE
Add swing trade quality gates (chop + low-volume)

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -98,6 +98,7 @@ interface TradeIdea {
   in_play_score?: number;
   pass1_confidence?: number;
   market_condition?: 'trend' | 'chop';
+  volumeVs10dAvg?: number | null;
 }
 
 interface TradingSignalsResponse {
@@ -2243,6 +2244,35 @@ async function executeScannerTrade(
         action: 'skipped', source: 'scanner', mode, skip_reason: 'inside_orb',
       });
       return 'skipped:inside_orb';
+    }
+  }
+
+  // ── Swing trade quality gates ─────────────────────────────────────────
+  // Swing trades bypass the ORB/VWAP gates above (intraday metrics don't apply
+  // to multi-day holds), so we enforce quality via the scanner's own ML features.
+  //
+  // Chop gate: scanner records market_condition='chop' when the stock has no
+  // clear trend structure. Entering a swing trade in chop is low-probability —
+  // the AI narrative can say "bullish" but the regime label doesn't lie.
+  //
+  // Volume gate: volume_vs_10d_avg < 0.3 means the stock is trading at less than
+  // 30% of its normal volume. Low-conviction entries in thin conditions gap through
+  // stop-loss levels rather than filling cleanly (as seen with AAON on 2026-04-28,
+  // which had 0.06x volume and blew through its stop by $1.04, costing -1.32R).
+  if (mode === 'SWING_TRADE') {
+    if (idea.market_condition === 'chop') {
+      log(`${ticker}: swing trade skipped — market_condition=chop`);
+      persistEvent(ticker, 'skipped', `Swing trade skipped: choppy market conditions`, {
+        action: 'skipped', source: 'scanner', mode, skip_reason: 'swing_chop',
+      });
+      return 'skipped:swing_chop';
+    }
+    if (idea.volumeVs10dAvg != null && idea.volumeVs10dAvg < 0.3) {
+      log(`${ticker}: swing trade skipped — volume ${idea.volumeVs10dAvg.toFixed(2)}x avg (< 0.3x threshold)`);
+      persistEvent(ticker, 'skipped', `Swing trade skipped: low volume (${idea.volumeVs10dAvg.toFixed(2)}x 10d avg)`, {
+        action: 'skipped', source: 'scanner', mode, skip_reason: 'swing_low_volume',
+      });
+      return 'skipped:swing_low_volume';
     }
   }
 

--- a/supabase/functions/trade-scanner/index.ts
+++ b/supabase/functions/trade-scanner/index.ts
@@ -68,6 +68,7 @@ interface TradeIdea {
   in_play_score?: number;
   pass1_confidence?: number;
   market_condition?: 'trend' | 'chop';
+  volumeVs10dAvg?: number | null;
 }
 
 interface ScanResult {
@@ -976,6 +977,7 @@ function buildIdea(
     in_play_score: quote._inPlayScore,
     pass1_confidence: opts?.pass1Confidence,
     market_condition: opts?.marketCondition,
+    volumeVs10dAvg: avgVol > 0 ? round(volRatio, 2) : null,
   };
 }
 


### PR DESCRIPTION
## Summary
- **Chop gate**: blocks swing trades when `market_condition='chop'` (scanner's own regime label)
- **Low-volume gate**: blocks swing trades when `volumeVs10dAvg < 0.3` (< 30% of normal volume)
- **Trade-scanner**: now exposes `volumeVs10dAvg` in `TradeIdea` (computed directly from `regularMarketVolume / averageDailyVolume10Day`)

## Root cause (AAON, 2026-04-28)
AAON entered as a swing trade with `market_condition=chop` and `volume_vs_10d_avg=0.06`. Scanner AI narrative said "bullish" (Groq fallback due to Gemini exhaustion) but ML features contradicted it. Stop was blown through by $1.04 due to thin tape — no buyers to absorb the gap.

Both gates would have blocked this trade at entry.

## Test plan
- [ ] Verify trade-scanner returns `volumeVs10dAvg` in next scan response
- [ ] Verify `skipped:swing_chop` / `skipped:swing_low_volume` events appear in logs for qualifying trades
- [ ] Confirm day trades are unaffected by the new gate block

Made with [Cursor](https://cursor.com)