### PR TITLE
docs: add 90-minute rule research

### DIFF
--- a/docs/cursor/2026-04-28-90-minute-rule.md
+++ b/docs/cursor/2026-04-28-90-minute-rule.md
@@ -1,0 +1,60 @@
+# 90-Minute Rule — Research & Backlog
+
+**Date:** 2026-04-28  
+**Source:** Somesh (Kay Capitals) Instagram video
+
+---
+
+## The Concept
+
+If the first 90 minutes of trading (9:30–11:00 AM ET) are choppy or unprofitable, stop trading for the rest of the day. The reasoning: if you can't make money when the market is most volatile and active, you won't make it when it gets drier later. Protects both money and mental capital.
+
+---
+
+## Data Analysis (as of 2026-04-28)
+
+Queried all closed scanner DAY_TRADEs (`strategy_video_id IS NULL`, `status = CLOSED`).
+
+| Date | F90 trades | F90 P&L | F90 WR | Rest trades | Rest P&L | Rest WR | Day P&L |
+|---|---|---|---|---|---|---|---|
+| 2026-02-13 | 0 | — | — | 1 | -$2.47 | 0% | -$2.47 |
+| 2026-02-17 | 0 | — | — | 2 | +$1,070 | 50% | +$1,070 |
+| 2026-02-18 | 0 | — | — | 1 | +$105 | 100% | +$105 |
+| 2026-04-20 | 0 | — | — | 4 | +$3,010 | 100% | +$3,010 |
+| 2026-04-22 | 0 | — | — | 1 | -$1,346 | 0% | -$1,346 |
+| 2026-04-23 | 1 | -$660 | 0% | 0 | — | — | -$660 |
+| 2026-04-24 | 13 | +$1,401 | 85% | 2 | -$63 | 50% | +$1,338 |
+| 2026-04-27 | 7 | +$772 | 71% | 8 | +$551 | 62% | +$1,323 |
+| 2026-04-28 | 1 | $0 | 0% | 0 | — | — | $0 |
+
+**Days with data in both windows:** 2 (Apr 24, Apr 27 — both had good first-90 sessions)  
+**Days with bad first-90 AND rest-of-day trades:** 0
+
+### Verdict: Insufficient data
+Only 9 trading days total, only 2 with trades in both windows, and we've never seen a *bad* first-90 day with rest-of-day follow-on trades. Can't confirm or reject the premise yet.
+
+---
+
+## Key Design Decisions (already agreed)
+
+1. **Apply to scanner trades only** — influencer signals (Somesh's levels) should be exempt. He posted them knowing the market conditions; it would be contradictory to use his rule to block his own signals.
+2. **Implementation approach (when ready):** Add a soft gate — if scanner P&L at 11:00 AM ET < $0 (or < configurable threshold), pause new scanner DAY_TRADE entries for the rest of the day. Reuses existing `isDayTradeLossGateActive` architecture.
+3. **NOT just another loss gate** — the value is in detecting choppiness *before* the main loss gate fires. A day where you break even on 10 bad trades in F90 is a signal to stop even without a net loss.
+
+---
+
+## When to Revisit
+
+Re-run this analysis when we have **20+ trading days** with pre-11 AM scanner activity. With the new 9:35 gate in place (added 2026-04-28), the system now consistently enters trades in the F90 window — data will accumulate faster.
+
+To re-run the query:
+```bash
+# In auto-trader dir with env loaded, or via Supabase REST:
+# paper_trades WHERE mode=DAY_TRADE AND status=CLOSED AND strategy_video_id IS NULL AND pnl IS NOT NULL
+# Group by date, split at 11:00 AM ET, compare F90 P&L vs rest-of-day P&L
+```
+
+---
+
+## Related PRs
+- `fix/scanner-935-gate` (#143) — scanner trades now start at 9:35, ensuring F90 window has data


### PR DESCRIPTION
Captures the 90-minute rule analysis from today's session — insufficient data to validate yet, design decisions documented for when we revisit.

Made with [Cursor](https://cursor.com)