### PR TITLE
Add Wyckoff volume divergence gate (Four More Phase)

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -99,6 +99,7 @@ interface TradeIdea {
   pass1_confidence?: number;
   market_condition?: 'trend' | 'chop';
   volumeVs10dAvg?: number | null;
+  volumeVsPriorPeak?: number | null;
 }
 
 interface TradingSignalsResponse {
@@ -2273,6 +2274,18 @@ async function executeScannerTrade(
         action: 'skipped', source: 'scanner', mode, skip_reason: 'swing_low_volume',
       });
       return 'skipped:swing_low_volume';
+    }
+
+    // Wyckoff "Four More Phase" gate: new move on volume weaker than the prior 20-day peak.
+    // If today's volume is < 65% of the highest-volume session in the last 20 days,
+    // the move lacks institutional conviction — smart money likely already distributed.
+    // This is the same pattern Somesh calls the "Four More Phase" (Wyckoff Distribution).
+    if (signal === 'BUY' && idea.volumeVsPriorPeak != null && idea.volumeVsPriorPeak < 0.65) {
+      log(`${ticker}: swing trade skipped — volume divergence ${idea.volumeVsPriorPeak.toFixed(2)}x prior peak (< 0.65x threshold) — Wyckoff Four More Phase risk`);
+      persistEvent(ticker, 'skipped', `Swing trade skipped: Wyckoff volume divergence (${idea.volumeVsPriorPeak.toFixed(2)}x prior 20d peak)`, {
+        action: 'skipped', source: 'scanner', mode, skip_reason: 'swing_volume_divergence',
+      });
+      return 'skipped:swing_volume_divergence';
     }
   }
 

--- a/supabase/functions/trade-scanner/index.ts
+++ b/supabase/functions/trade-scanner/index.ts
@@ -69,6 +69,9 @@ interface TradeIdea {
   pass1_confidence?: number;
   market_condition?: 'trend' | 'chop';
   volumeVs10dAvg?: number | null;
+  // Wyckoff volume divergence: current volume vs highest-volume bar in last 20 days.
+  // < 0.7 on a new-high candle = "Four More Phase" risk (retail FOMO, smart money out).
+  volumeVsPriorPeak?: number | null;
 }
 
 interface ScanResult {
@@ -958,6 +961,24 @@ function buildIdea(
     if (sma50 > 0 && Math.abs((price - sma50) / sma50) <= 0.02) tags.push('at-sma50');
   }
 
+  // ── Wyckoff volume divergence: current vs prior 20-day peak ──────────────
+  // Somesh's "Four More Phase": if price is making a new move but volume is
+  // meaningfully weaker than the highest-volume day in the last 20 sessions,
+  // smart money has likely already distributed. Flag so the scheduler can gate.
+  // Only computed when we have OHLCV bars (swing trades always have these;
+  // day trades may not — non-blocking when absent).
+  let volumeVsPriorPeak: number | null = null;
+  const bars = quote._ohlcvBars ?? [];
+  if (bars.length >= 5 && volume > 0) {
+    // bars[0] = today (newest-first). Look at bars[1..20] = prior 20 sessions.
+    const priorBars = bars.slice(1, 21);
+    const priorPeakVol = priorBars.reduce((max, b) => Math.max(max, b.v ?? 0), 0);
+    if (priorPeakVol > 0) {
+      volumeVsPriorPeak = round(volume / priorPeakVol, 2);
+      if (volumeVsPriorPeak < 0.6) tags.push('volume-divergence');
+    }
+  }
+
   return {
     ticker: eval_.ticker,
     name: quote.shortName ?? quote.longName ?? eval_.ticker,
@@ -978,6 +999,7 @@ function buildIdea(
     pass1_confidence: opts?.pass1Confidence,
     market_condition: opts?.marketCondition,
     volumeVs10dAvg: avgVol > 0 ? round(volRatio, 2) : null,
+    volumeVsPriorPeak,
   };
 }
 


### PR DESCRIPTION
## Summary
- **New gate**: swing BUY skipped if `volumeVsPriorPeak < 0.65` (today's volume < 65% of the highest-volume day in the last 20 sessions)
- **New scanner field**: `volumeVsPriorPeak` computed in `buildIdea()` using existing `_ohlcvBars` daily data — zero extra API calls
- **New tag**: `volume-divergence` added to `TradeIdea.tags` when prior-peak ratio < 0.6

## Why
Somesh's "Four More Phase" (Wyckoff Distribution): when price makes a new move on weaker volume than the prior peak, retail is chasing while smart money has already distributed. This is a precursor to distribution/reversal.

AAON (2026-04-28): 0.06x avg volume. Would have been caught by both the `volumeVs10dAvg < 0.3` gate (already shipped in #146) AND this new `volumeVsPriorPeak < 0.65` check.

## Test plan
- [ ] Verify scanner returns `volumeVsPriorPeak` and `volume-divergence` tag on next scan
- [ ] Confirm `skipped:swing_volume_divergence` appears in logs for qualifying trades
- [ ] Confirm high-volume legitimate breakouts (e.g. earnings day) are NOT blocked

Made with [Cursor](https://cursor.com)