### PR TITLE
feat(options): add 3% red-day entry trigger + moderate IV spike booster

### DIFF
--- a/auto-trader/src/lib/dip-watcher.ts
+++ b/auto-trader/src/lib/dip-watcher.ts
@@ -18,7 +18,8 @@
 import { getSupabase, createAutoTradeEvent } from './supabase.js';
 
 const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
-const DIP_THRESHOLD_PCT = 5;      // stock down ≥5% from 20-day high = dip entry
+const DIP_THRESHOLD_PCT = 5;      // stock down ≥5% from 20-day high = dip entry (cumulative)
+const RED_DAY_THRESHOLD_PCT = 3;  // single-session drop ≥3% = red day entry (same-day IV spike)
 const DIP_LOOKBACK_DAYS = 20;     // measure high over last 20 trading days
 
 // Track which tickers we've already alerted on today (reset at midnight)
@@ -52,23 +53,31 @@ interface DipCheckResult {
   price: number;
   recentHigh: number;
   dipPct: number;
+  todayChangePct: number;  // single-session % change (from Finnhub quote dp field)
   aboveSma50: boolean;
-  isDip: boolean;
+  isDip: boolean;          // true if cumulative dip ≥5% OR single-session drop ≥3%
+  trigger: 'cumulative_dip' | 'red_day' | 'both' | null;
 }
 
 async function checkDip(ticker: string): Promise<DipCheckResult | null> {
   const to = Math.floor(Date.now() / 1000);
   const from = to - 86400 * (DIP_LOOKBACK_DAYS + 10); // extra buffer
 
-  const data = await fetchJson<{ c?: number[]; h?: number[] }>(
-    `https://finnhub.io/api/v1/stock/candle?symbol=${ticker}&resolution=D&from=${from}&to=${to}&token=${FINNHUB_KEY}`
-  );
+  const [candles, quote] = await Promise.all([
+    fetchJson<{ c?: number[]; h?: number[] }>(
+      `https://finnhub.io/api/v1/stock/candle?symbol=${ticker}&resolution=D&from=${from}&to=${to}&token=${FINNHUB_KEY}`
+    ),
+    fetchJson<{ c: number; dp: number }>(
+      `https://finnhub.io/api/v1/quote?symbol=${ticker}&token=${FINNHUB_KEY}`
+    ),
+  ]);
 
-  if (!data?.c || !data.h || data.c.length < 10) return null;
+  if (!candles?.c || !candles.h || candles.c.length < 10) return null;
 
-  const closes = data.c;
-  const highs = data.h;
+  const closes = candles.c;
+  const highs = candles.h;
   const price = closes[closes.length - 1];
+  const todayChangePct = quote?.dp ?? 0;
 
   // 20-day high from recent highs
   const recentHighs = highs.slice(-DIP_LOOKBACK_DAYS);
@@ -82,9 +91,16 @@ async function checkDip(ticker: string): Promise<DipCheckResult | null> {
   const aboveSma50 = sma50 !== null ? price > sma50 : true;
 
   const dipPct = recentHigh > 0 ? ((recentHigh - price) / recentHigh) * 100 : 0;
-  const isDip = dipPct >= DIP_THRESHOLD_PCT && aboveSma50;
+  const isCumulativeDip = dipPct >= DIP_THRESHOLD_PCT && aboveSma50;
+  const isRedDay = todayChangePct <= -RED_DAY_THRESHOLD_PCT && aboveSma50;
+  const isDip = isCumulativeDip || isRedDay;
 
-  return { ticker, price, recentHigh, dipPct, aboveSma50, isDip };
+  const trigger = (isCumulativeDip && isRedDay) ? 'both'
+    : isCumulativeDip ? 'cumulative_dip'
+    : isRedDay ? 'red_day'
+    : null;
+
+  return { ticker, price, recentHigh, dipPct, todayChangePct, aboveSma50, isDip, trigger };
 }
 
 export async function runDipWatcher(): Promise<void> {
@@ -113,7 +129,12 @@ export async function runDipWatcher(): Promise<void> {
     dipCandidates.push(result.ticker);
     alertedToday.add(result.ticker);
 
-    const msg = `📉 Dip entry: ${result.ticker} down ${result.dipPct.toFixed(1)}% from 20d high ($${result.recentHigh.toFixed(2)} → $${result.price.toFixed(2)}) — uptrend intact`;
+    const triggerDesc = result.trigger === 'red_day'
+      ? `red day ${result.todayChangePct.toFixed(1)}% today`
+      : result.trigger === 'both'
+        ? `red day ${result.todayChangePct.toFixed(1)}% today + down ${result.dipPct.toFixed(1)}% from 20d high`
+        : `down ${result.dipPct.toFixed(1)}% from 20d high ($${result.recentHigh.toFixed(2)})`;
+    const msg = `📉 Dip entry: ${result.ticker} — ${triggerDesc} @ $${result.price.toFixed(2)} — uptrend intact`;
     console.log(`[Dip Watcher] ${msg}`);
 
     createAutoTradeEvent({
@@ -125,10 +146,11 @@ export async function runDipWatcher(): Promise<void> {
       message: msg,
       metadata: {
         dipPct: result.dipPct,
+        todayChangePct: result.todayChangePct,
         recentHigh: result.recentHigh,
         currentPrice: result.price,
         aboveSma50: result.aboveSma50,
-        trigger: 'dip_watcher',
+        trigger: result.trigger ?? 'dip_watcher',
       },
     });
   }

--- a/auto-trader/src/lib/options-scanner.ts
+++ b/auto-trader/src/lib/options-scanner.ts
@@ -56,6 +56,7 @@ const MAX_POSITIONS_NORMAL = 12;           // max concurrent open options puts (
 const MAX_POSITIONS_HIGH_VIX = 6;          // VIX > 25 — half positions in stress
 const EARNINGS_BLACKOUT_DAYS = 7;
 const IV_SPIKE_THRESHOLD = 20;             // points — sudden IV jump = news event
+const RED_DAY_THRESHOLD_PCT = 3;           // single-session drop ≥3% = red day entry (influencer: elevated IV, lower price)
 const MIN_PROB_PROFIT = 75;                // minimum 75% OTM probability (video: 80-90%, we set 75 as floor)
 const VIX_SPIKE_MIN_PROB_PROFIT = 60;      // VIX-spike + 200 DMA mode: accept higher assignment risk (0.35δ → ~65% OTM)
 const MAX_SPREAD_PCT = 0.30;               // bid-ask spread must be < 30% of mid
@@ -219,12 +220,12 @@ async function fetchJson<T>(url: string): Promise<T | null> {
   }
 }
 
-async function getStockQuote(ticker: string): Promise<{ price: number; change: number } | null> {
-  const data = await fetchJson<{ c: number; d: number }>(
+async function getStockQuote(ticker: string): Promise<{ price: number; change: number; pctChange: number } | null> {
+  const data = await fetchJson<{ c: number; d: number; dp: number }>(
     `https://finnhub.io/api/v1/quote?symbol=${ticker}&token=${FINNHUB_KEY}`
   );
   if (!data?.c) return null;
-  return { price: data.c, change: data.d ?? 0 };
+  return { price: data.c, change: data.d ?? 0, pctChange: data.dp ?? 0 };
 }
 
 async function getRSI(ticker: string): Promise<{ rsi: number; prevRsi: number } | null> {
@@ -574,7 +575,10 @@ async function checkStock(
   // Get current price
   const quote = await getStockQuote(ticker);
   if (!quote) return { ticker, skipped: true, reason: 'no_price_data' };
-  const { price } = quote;
+  const { price, pctChange: todayPctChange } = quote;
+  // Single-session red day: stock dropped ≥3% today = same IV spike rationale as cumulative dip.
+  // Influencer insight: entering on a hard red day captures elevated same-day IV at a lower strike.
+  const redDayEntry = todayPctChange <= -RED_DAY_THRESHOLD_PCT;
 
   // Check 3: Min price
   const effectiveMinPrice = minPrice ?? MIN_STOCK_PRICE;
@@ -582,7 +586,10 @@ async function checkStock(
   if (price < effectiveMinPrice) return { ticker, skipped: true, reason: `price_too_low_${price.toFixed(0)}` };
 
   // Check 3.2: Dip detection + SMA20 + Bollinger Bands (shared candle fetch — zero extra API calls)
-  // Dip entry: stock dropped ≥5% from 20-day high = elevated IV, larger OTM cushion
+  // Dip entry (cumulative): stock dropped ≥5% from 20-day high = elevated IV, larger OTM cushion
+  // Red day entry: stock dropped ≥3% in a single session = same-day IV spike (new gate, influencer insight)
+  // Either qualifies as "any dip entry" and unlocks the same benefits: yield floor reduction,
+  // 52w-high exemption, SMA20 floor exemption, and +1 contract conviction.
   // SMA20 = BB middle band; ±2σ gives lower/upper bands.
   // BB lower band touch = prime entry: stock oversold, IV elevated, bigger OTM cushion.
   let dipEntry = false;
@@ -596,7 +603,13 @@ async function checkStock(
       const recentHigh = Math.max(...dipBars.slice(-20).map(b => b.high));
       const dipPct = ((recentHigh - price) / recentHigh) * 100;
       dipEntry = dipPct >= DIP_ENTRY_BONUS_THRESHOLD;
-      checks.dipEntry = `${dipPct.toFixed(1)}%_from_20d_high${dipEntry ? '_DIP' : ''}`;
+      // Either a cumulative 5%+ dip OR a same-session 3%+ red day qualifies as a dip entry
+      const anyDipEntry = dipEntry || redDayEntry;
+      checks.dipEntry = `${dipPct.toFixed(1)}%_from_20d_high${dipEntry ? '_CUM_DIP' : ''}${redDayEntry ? `_RED_DAY(${todayPctChange.toFixed(1)}%)` : ''}${anyDipEntry && !dipEntry ? '_DIP' : ''}`;
+      dipEntry = anyDipEntry;
+    } else if (redDayEntry) {
+      dipEntry = true;
+      checks.dipEntry = `red_day(${todayPctChange.toFixed(1)}%)_DIP`;
     }
     // SMA20 + Bollinger Bands (needs ≥ 20 closes)
     if (dipBars && dipBars.length >= 20) {
@@ -859,9 +872,17 @@ async function checkStock(
     : 'building_history';
   const ivOk = ivRank === null || ivRank >= effectiveMinIvRank;
 
-  // Check 9.5: IV spike — sudden >20pt jump = news event, skip
+  // Check 9.5: IV spike detection.
+  // Large spike (≥20pt delta) = news event risk → block.
+  // Moderate spike (5–19pt delta) = fear premium, not news explosion → conviction booster (+1 contract).
+  // Especially meaningful when paired with a red day entry: the IV rise confirms panic selling.
   const ivSpike = await checkIvSpike(ticker, currentIvPct);
-  checks.noIvSpike = ivSpike.spiked ? `SPIKE+${ivSpike.delta.toFixed(0)}pts` : `ok(${ivSpike.delta > 0 ? '+' : ''}${ivSpike.delta.toFixed(0)}pts)`;
+  const ivModerateBoost = !ivSpike.spiked && ivSpike.delta >= 5;
+  checks.noIvSpike = ivSpike.spiked
+    ? `SPIKE+${ivSpike.delta.toFixed(0)}pts`
+    : ivModerateBoost
+      ? `moderate_boost+${ivSpike.delta.toFixed(0)}pts`
+      : `ok(${ivSpike.delta > 0 ? '+' : ''}${ivSpike.delta.toFixed(0)}pts)`;
   if (ivSpike.spiked) {
     return { ticker, skipped: true, reason: `iv_spike:+${ivSpike.delta.toFixed(0)}pts` };
   }
@@ -884,12 +905,13 @@ async function checkStock(
   ].filter(Boolean).length;
 
   // Scale contracts 1–N by conviction, capped by tier config.
-  // Stacking: base score → +1 for dip entry → +1 for BB lower band touch (high conviction entry)
+  // Stacking: base score → +1 for dip entry (cumulative or red day) → +1 for BB lower band touch
+  //           → +1 for moderate IV spike (confirms fear premium is real, not just noise)
   const baseContracts = (put.probProfit >= 80 && (ivRank ?? 0) >= 65 && rsiBonus) ? 3
     : (put.probProfit >= 75 && (ivRank ?? 0) >= 55) ? 2 : 1;
   const contracts = Math.min(
     tierCfg.maxContracts,
-    baseContracts + (dipEntry ? 1 : 0) + (bbSignal === 'at_lower' ? 1 : 0),
+    baseContracts + (dipEntry ? 1 : 0) + (bbSignal === 'at_lower' ? 1 : 0) + (ivModerateBoost ? 1 : 0),
   );
 
   return {


### PR DESCRIPTION
## Summary

Implements two improvements to the Options Wheel Engine, both stemming from the influencer strategy analysis:

- **3% same-session red day trigger** — A stock that drops ≥3% in a single session provides the same entry advantages as a cumulative 5% dip: elevated IV (fear premium), lower strike, and potential short-term reversion. Both `dip-watcher` and `options-scanner` now recognize either condition.
  - Dip watcher fetches the Finnhub quote (`dp` field) alongside daily candles to detect today's percent change
  - `isDip` is now `cumulativeDip (≥5% from 20d high) OR redDay (≥3% today) AND aboveSma50`
  - Log `trigger` field shows `cumulative_dip` | `red_day` | `both`
  - Scanner's `getStockQuote` now returns `pctChange`; `checkStock` sets `redDayEntry` and folds it into `dipEntry`, unlocking yield floor reduction, 52w-high exemption, SMA20 floor exemption, and +1 contract

- **Moderate IV spike booster** — When IV rises 5–19 pts vs yesterday (not an extreme news event, which blocks at ≥20pts), this is a conviction signal — fear premium is real. Adds +1 contract to the conviction stack. Especially meaningful when paired with a red day entry.

## Test plan
- [ ] Deploy auto-trader — confirm `[Dip Watcher]` logs show `red_day` trigger when a watchlist stock drops ≥3% intraday
- [ ] Verify `checks.dipEntry` in `options_trade_events` metadata shows `RED_DAY(...)` label for same-session dips
- [ ] Verify `checks.noIvSpike` shows `moderate_boost+Npts` for 5–19pt IV delta stocks
- [ ] Confirm large IV spike (≥20pt) still blocks entry
- [ ] TypeScript: `npx tsc --noEmit` — 0 errors ✅
- [ ] Frontend build: `npm run build` — clean ✅

Made with [Cursor](https://cursor.com)