### PR TITLE
fix: recent-loss cooldown gate + real AI post-mortems for LOSS trades

### DIFF
--- a/auto-trader/src/lib/feedback.ts
+++ b/auto-trader/src/lib/feedback.ts
@@ -2,9 +2,15 @@
  * Trade feedback loop — analyze completed trades, update performance patterns.
  * Ported from app/src/lib/aiFeedback.ts for server-side rehydration.
  * Feeds buildFeedbackContext in edge functions so AI learns from history.
+ *
+ * LOSS analysis uses Groq (llama-4-scout) for real post-mortem text.
+ * Template fallback activates if the API key is missing or the call fails.
  */
 
 import { getSupabase } from './supabase.js';
+
+const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions';
+const GROQ_MODEL = 'meta-llama/llama-4-scout-17b-16e-instruct';
 
 interface PaperTradeLike {
   id: string;
@@ -107,6 +113,99 @@ function generateLesson(
   };
 }
 
+/**
+ * Calls Groq to generate a specific post-mortem for a LOSS trade.
+ * Returns null on any failure so the caller can fall back to the template.
+ *
+ * Failure categories (one of):
+ *   stop_too_tight | stop_too_wide | bad_entry_timing | macro_headwind |
+ *   sector_rotation | scanner_overconfidence | eod_timeout | unknown
+ */
+async function generateLossLessonWithAI(ctx: {
+  ticker: string;
+  mode: string;
+  signal: string;
+  scannerConfidence: number | null;
+  faConfidence: number | null;
+  entryPrice: number | null;
+  fillPrice: number | null;
+  stopLoss: number | null;
+  targetPrice: number | null;
+  closePrice: number | null;
+  pnlPercent: number | null;
+  closeReason: string | null;
+  scannerReason: string | null;
+  faRationale: { technical?: string; sentiment?: string; risk?: string } | null;
+  duration: number | null;
+}): Promise<LessonResult | null> {
+  const groqKey = process.env['GROQ_API_KEY'] ?? '';
+  if (!groqKey) return null;
+
+  const stopDist = ctx.entryPrice && ctx.stopLoss
+    ? (Math.abs(ctx.entryPrice - ctx.stopLoss) / ctx.entryPrice * 100).toFixed(1)
+    : 'unknown';
+  const riskReward = ctx.entryPrice && ctx.stopLoss && ctx.targetPrice
+    ? (Math.abs(ctx.targetPrice - ctx.entryPrice) / Math.abs(ctx.entryPrice - ctx.stopLoss)).toFixed(2)
+    : 'unknown';
+
+  const prompt = `You are a trading post-mortem analyst. A ${ctx.mode} ${ctx.signal} trade on ${ctx.ticker} just closed as a LOSS.
+
+Trade details:
+- Close reason: ${ctx.closeReason ?? 'unknown'}
+- P&L: ${ctx.pnlPercent != null ? `${ctx.pnlPercent.toFixed(1)}%` : 'unknown'}
+- Entry price: ${ctx.fillPrice ?? ctx.entryPrice ?? 'unknown'}
+- Stop loss: ${ctx.stopLoss ?? 'unknown'} (${stopDist}% from entry)
+- Target price: ${ctx.targetPrice ?? 'unknown'} (R:R = ${riskReward})
+- Close price: ${ctx.closePrice ?? 'unknown'}
+- Duration: ${ctx.duration != null ? `${ctx.duration} minutes` : 'unknown'}
+- Scanner confidence: ${ctx.scannerConfidence ?? 'unknown'}/9
+- FA confidence: ${ctx.faConfidence ?? 'unknown'}/9
+- Scanner rationale: ${ctx.scannerReason ?? 'not recorded'}
+- FA technical: ${ctx.faRationale?.technical ?? 'not recorded'}
+- FA risk: ${ctx.faRationale?.risk ?? 'not recorded'}
+
+Respond ONLY with valid JSON in this exact format (no markdown, no explanation):
+{
+  "failure_category": "<one of: stop_too_tight|stop_too_wide|bad_entry_timing|macro_headwind|sector_rotation|scanner_overconfidence|eod_timeout|unknown>",
+  "what_failed": "<1-2 specific sentences about what went wrong for THIS trade>",
+  "what_to_do_differently": "<1 sentence — concrete change to entry criteria, stop placement, or timing>",
+  "market_context": "<1 sentence about market conditions that contributed>"
+}`;
+
+  try {
+    const res = await fetch(GROQ_URL, {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${groqKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: GROQ_MODEL,
+        messages: [{ role: 'user', content: prompt }],
+        max_tokens: 300,
+        temperature: 0.3,
+      }),
+    });
+
+    if (!res.ok) return null;
+
+    const data = await res.json() as { choices: [{ message: { content: string } }] };
+    const raw = data.choices[0]?.message?.content?.trim() ?? '';
+    const parsed = JSON.parse(raw) as {
+      failure_category: string;
+      what_failed: string;
+      what_to_do_differently: string;
+      market_context: string;
+    };
+
+    return {
+      lesson: `${ctx.ticker} ${ctx.signal} LOSS [${parsed.failure_category}]: ${parsed.what_failed} ${parsed.what_to_do_differently}`,
+      whatWorked: 'N/A',
+      whatFailed: `[${parsed.failure_category}] ${parsed.what_failed}`,
+      marketContext: parsed.market_context,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function extractPatterns(texts: string[]): string[] {
   const keywords: Record<string, number> = {};
   const patterns = [
@@ -182,28 +281,35 @@ export async function analyzeCompletedTrade(trade: PaperTradeLike): Promise<bool
     ? Math.round((new Date(trade.closed_at).getTime() - new Date(trade.opened_at).getTime()) / 60000)
     : null;
 
-  const lesson = generateLesson(
-    {
-      ticker: trade.ticker,
-      mode: trade.mode,
-      signal: trade.signal,
-      scannerConfidence: trade.scanner_confidence,
-      faConfidence: trade.fa_confidence,
-      faRecommendation: trade.fa_recommendation,
-      entryPrice: trade.entry_price,
-      stopLoss: trade.stop_loss,
-      targetPrice: trade.target_price,
-      fillPrice: trade.fill_price,
-      closePrice: trade.close_price,
-      pnl: trade.pnl,
-      pnlPercent: trade.pnl_percent,
-      closeReason: trade.close_reason,
-      faRationale: trade.fa_rationale,
-      scannerReason: trade.scanner_reason,
-      duration,
-    },
-    outcome
-  );
+  const templateCtx = {
+    ticker: trade.ticker,
+    mode: trade.mode,
+    signal: trade.signal,
+    scannerConfidence: trade.scanner_confidence,
+    faConfidence: trade.fa_confidence,
+    faRecommendation: trade.fa_recommendation,
+    entryPrice: trade.entry_price,
+    stopLoss: trade.stop_loss,
+    targetPrice: trade.target_price,
+    fillPrice: trade.fill_price,
+    closePrice: trade.close_price,
+    pnl: trade.pnl,
+    pnlPercent: trade.pnl_percent,
+    closeReason: trade.close_reason,
+    faRationale: trade.fa_rationale,
+    scannerReason: trade.scanner_reason,
+    duration,
+  };
+
+  // For LOSS trades, try to generate a real AI post-mortem first.
+  // Template fallback activates if Groq is unavailable or returns invalid JSON.
+  let lesson: LessonResult;
+  if (outcome === 'LOSS') {
+    const aiLesson = await generateLossLessonWithAI(templateCtx);
+    lesson = aiLesson ?? generateLesson(templateCtx, outcome);
+  } else {
+    lesson = generateLesson(templateCtx, outcome);
+  }
 
   const sb = getSupabase();
   const { error } = await sb.from('trade_learnings').insert({

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -373,6 +373,26 @@ export async function hasActiveTrade(
   return (count ?? 0) > 0;
 }
 
+/**
+ * Returns true if the ticker had a closed loss within the last `lookbackDays` days.
+ * Used to prevent re-entering a ticker that recently stopped out — particularly
+ * important for LONG_TERM positions where consecutive losses (e.g. POOL ×2) destroy capital.
+ */
+export async function hasRecentLoss(
+  ticker: string,
+  lookbackDays = 21,
+): Promise<boolean> {
+  const since = new Date(Date.now() - lookbackDays * 86_400_000).toISOString();
+  const sb = getSupabase();
+  const { count } = await sb
+    .from('paper_trades')
+    .select('id', { count: 'exact', head: true })
+    .eq('ticker', ticker)
+    .lt('pnl', 0)
+    .gte('closed_at', since);
+  return (count ?? 0) > 0;
+}
+
 export async function countActivePositions(): Promise<number> {
   const sb = getSupabase();
   const { count } = await sb

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -35,6 +35,7 @@ import {
   getActiveTrades,
   getLongTermExposureByTag,
   hasActiveTrade,
+  hasRecentLoss,
   countActivePositions,
   createPaperTrade,
   updatePaperTrade,
@@ -2251,6 +2252,20 @@ async function executeScannerTrade(
 
   if (await hasActiveTrade(ticker)) return 'skipped:duplicate';
 
+  // ── Recent-loss cooldown gate ─────────────────────────────────────────
+  // Block re-entry on any ticker that lost money in the last N days.
+  // SWING_TRADE uses 14 days; DAY_TRADE uses 5 days (intraday patterns reset faster).
+  {
+    const lookbackDays = mode === 'SWING_TRADE' ? 14 : 5;
+    if (await hasRecentLoss(ticker, lookbackDays)) {
+      log(`${ticker}: skipped — recent loss within ${lookbackDays}d cooldown`);
+      persistEvent(ticker, 'skipped', `Re-entry blocked — ticker had a loss within ${lookbackDays} days`, {
+        action: 'skipped', source: 'scanner', mode, skip_reason: 'recent_loss_cooldown',
+      });
+      return 'skipped:recent_loss_cooldown';
+    }
+  }
+
   // ── Daily max-loss gate ───────────────────────────────────────────────
   if (mode === 'DAY_TRADE' && await isDayTradeLossGateActive(config)) {
     log(`${ticker}: day-trade skipped — daily loss gate active`);
@@ -2573,6 +2588,18 @@ async function _executeSuggestedFindTradeInner(
   if (!isMarketHoursET()) return 'skipped:outside-market-hours';
 
   if (await hasActiveTrade(ticker)) return 'skipped:duplicate';
+
+  // ── Recent-loss cooldown gate ─────────────────────────────────────────
+  // LONG_TERM trades use a 21-day lookback. This caught the POOL ×2 scenario
+  // where two consecutive confidence-9 entries both stopped out at -24% and -25%.
+  if (await hasRecentLoss(ticker, 21)) {
+    log(`${ticker}: LONG_TERM skipped — recent loss within 21d cooldown`);
+    persistEvent(ticker, 'skipped', `LONG_TERM re-entry blocked — ticker had a loss within 21 days`, {
+      action: 'skipped', source: 'suggested_finds', mode: 'LONG_TERM',
+      skip_reason: 'recent_loss_cooldown',
+    });
+    return 'skipped:recent_loss_cooldown';
+  }
 
   // Same-day guard: block a second entry for the same ticker on the same ET calendar day.
   // Protects against TEN-style duplicate orders that slip through hasActiveTrade due to


### PR DESCRIPTION
## Problem

Analysis of 39 confidence-9 closed trades revealed two structural issues:

**1. POOL doubled down at confidence 9 and lost both times (-$8,133 combined)**
`hasActiveTrade()` only blocks re-entry while a position is *open*. Once the first POOL trade stopped out at -25%, the gate cleared immediately. Nothing prevented the system from re-entering POOL days later — also at confidence 9, also at -24%.

**2. The feedback loop was generating identical boilerplate for every loss**
`generateLesson()` produced `"High confidence but still lost — may indicate market regime change"` for all 18 confidence-9 losses. No trade-specific analysis. This made `trade_learnings.what_failed` useless for pattern detection, Brier Score analysis, or any future failure classification.

## Changes

### `supabase.ts` — `hasRecentLoss(ticker, lookbackDays)`
New exported function that queries `paper_trades` for any closed loss within a rolling window. Non-blocking on error (fails open).

### `scheduler.ts` — re-entry cooldown gate
Added after `hasActiveTrade()` check in both `executeScannerTrade` and `_executeSuggestedFindTradeInner`:
- **LONG_TERM** (suggested finds): 21-day cooldown
- **SWING_TRADE** (scanner): 14-day cooldown  
- **DAY_TRADE** (scanner): 5-day cooldown (intraday patterns reset faster)

### `feedback.ts` — real AI post-mortems for LOSS trades
`analyzeCompletedTrade()` now calls Groq (llama-4-scout) for LOSS outcomes with trade-specific context: entry price, stop distance, R:R ratio, close reason, duration, scanner rationale. Response includes a `failure_category` tag:
```
stop_too_tight | stop_too_wide | bad_entry_timing | macro_headwind |
sector_rotation | scanner_overconfidence | eod_timeout | unknown
```
Template fallback activates if GROQ_API_KEY is missing or the call fails.

## Test plan
- [ ] Verify build passes (`npm run build` ✅)
- [ ] Confirm `hasRecentLoss` is called in both scanner and suggested-find paths
- [ ] After next LOSS trade, check `trade_learnings.what_failed` has specific text instead of boilerplate
- [ ] Verify POOL (or any recently-stopped ticker) gets `skipped:recent_loss_cooldown` in logs

Made with [Cursor](https://cursor.com)