### PR TITLE
feat: automated heartbeat health monitoring + KeepAlive auto-restart

### DIFF
--- a/app/src/components/EngineHealthIndicator.tsx
+++ b/app/src/components/EngineHealthIndicator.tsx
@@ -1,5 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
+import { createClient } from '@supabase/supabase-js';
 import { cn } from '../lib/utils';
+
+const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL ?? '',
+  import.meta.env.VITE_SUPABASE_ANON_KEY ?? '',
+);
 
 interface SchedulerStatus {
   running: boolean;       // cron job is active
@@ -29,21 +35,40 @@ function isMarketHours(): boolean {
   return true;
 }
 
-function getHealthLevel(status: SchedulerStatus | null, reachable: boolean): HealthLevel {
-  if (!reachable || !status) return 'idle';
-  if (!isMarketHours()) return 'idle';
-
-  if (status.lastResult.startsWith('error')) return 'error';
-  if (status.lastResult === 'never') return 'warning';
-
-  if (status.lastRun) {
-    const minutesAgo = (Date.now() - new Date(status.lastRun).getTime()) / 60000;
-    if (minutesAgo > 120) return 'error';
-    if (minutesAgo > 30) return 'warning';
+function getHealthLevel(
+  status: SchedulerStatus | null,
+  reachable: boolean,
+  heartbeat: HeartbeatRow | null,
+): HealthLevel {
+  // If live endpoint is reachable, use it as source of truth
+  if (reachable && status) {
+    if (!isMarketHours()) return 'idle';
+    if (status.lastResult.startsWith('error')) return 'error';
+    if (status.lastResult === 'never') return 'warning';
+    if (status.lastRun) {
+      const minutesAgo = (Date.now() - new Date(status.lastRun).getTime()) / 60000;
+      if (minutesAgo > 120) return 'error';
+      if (minutesAgo > 30) return 'warning';
+    }
+    if (status.lastResult.startsWith('ok') || status.lastResult.startsWith('skipped')) return 'healthy';
+    return 'warning';
   }
 
-  if (status.lastResult.startsWith('ok') || status.lastResult.startsWith('skipped')) return 'healthy';
-  return 'warning';
+  // Service unreachable — fall back to Supabase heartbeat
+  if (heartbeat) {
+    const minsAgo = (Date.now() - new Date(heartbeat.last_seen_at).getTime()) / 60000;
+    if (isMarketHours()) {
+      if (minsAgo > 30) return 'error';   // stale during market hours = problem
+      if (minsAgo > 10) return 'warning';
+      return heartbeat.status === 'error' ? 'error'
+           : heartbeat.status === 'degraded' ? 'warning' : 'healthy';
+    }
+    // Outside market hours: show degraded if stale > 4h (service may have crashed overnight)
+    if (minsAgo > 240) return 'warning';
+    return 'idle';
+  }
+
+  return 'idle';
 }
 
 function timeAgo(isoStr: string | null): string {
@@ -57,14 +82,25 @@ function timeAgo(isoStr: string | null): string {
   return `${Math.floor(hours / 24)}d ago`;
 }
 
+interface HeartbeatRow {
+  last_seen_at: string;
+  status: 'ok' | 'degraded' | 'error';
+  ib_connected: boolean;
+  active_trades: number;
+  last_cycle_result: string | null;
+  run_count: number;
+}
+
 export function EngineHealthIndicator() {
   const [status, setStatus] = useState<SchedulerStatus | null>(null);
+  const [heartbeat, setHeartbeat] = useState<HeartbeatRow | null>(null);
   const [reachable, setReachable] = useState(false);
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const popoverRef = useRef<HTMLDivElement>(null);
 
   async function fetchStatus() {
+    // Try the live HTTP endpoint first
     try {
       const res = await fetch(`${AUTO_TRADER_URL}/api/scheduler/status`, {
         signal: AbortSignal.timeout(4000),
@@ -76,6 +112,18 @@ export function EngineHealthIndicator() {
     } catch {
       setReachable(false);
       setStatus(null);
+    }
+
+    // Always fetch Supabase heartbeat as fallback / corroboration
+    try {
+      const { data } = await supabase
+        .from('system_heartbeats')
+        .select('last_seen_at, status, ib_connected, active_trades, last_cycle_result, run_count')
+        .eq('id', 'auto-trader')
+        .single();
+      setHeartbeat(data as HeartbeatRow | null);
+    } catch {
+      // Non-blocking
     } finally {
       setLoading(false);
     }
@@ -83,7 +131,7 @@ export function EngineHealthIndicator() {
 
   useEffect(() => {
     fetchStatus();
-    const interval = setInterval(fetchStatus, 5 * 60 * 1000);
+    const interval = setInterval(fetchStatus, 60 * 1000); // refresh every minute
     return () => clearInterval(interval);
   }, []);
 
@@ -97,7 +145,7 @@ export function EngineHealthIndicator() {
     return () => document.removeEventListener('mousedown', handleClick);
   }, [open]);
 
-  const health = getHealthLevel(status, reachable);
+  const health = getHealthLevel(status, reachable, heartbeat);
 
   const dotColor: Record<HealthLevel, string> = {
     healthy: 'bg-emerald-500',
@@ -114,9 +162,9 @@ export function EngineHealthIndicator() {
   };
 
   const label: Record<HealthLevel, string> = {
-    healthy: 'Engine running',
-    warning: 'Engine degraded',
-    error: 'Engine error',
+    healthy: reachable ? 'Engine running' : 'Engine running (heartbeat)',
+    warning: reachable ? 'Engine degraded' : 'Engine unreachable',
+    error: reachable ? 'Engine error' : 'Engine down',
     idle: 'Market closed',
   };
 
@@ -151,10 +199,44 @@ export function EngineHealthIndicator() {
           </div>
 
           {!reachable ? (
-            <p className="text-xs text-slate-500">
-              Auto-trader service unreachable at{' '}
-              <span className="font-mono">{AUTO_TRADER_URL}</span>
-            </p>
+            <div className="space-y-2 text-xs text-slate-600">
+              <p className="text-slate-500">
+                Live endpoint unreachable at{' '}
+                <span className="font-mono text-xs">{AUTO_TRADER_URL}</span>
+              </p>
+              {heartbeat && (
+                <>
+                  <div className="flex justify-between">
+                    <span className="text-slate-400">Last heartbeat</span>
+                    <span className={cn(
+                      'font-medium',
+                      (Date.now() - new Date(heartbeat.last_seen_at).getTime()) / 60000 > 30
+                        ? 'text-red-600' : 'text-slate-700'
+                    )}>
+                      {timeAgo(heartbeat.last_seen_at)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-slate-400">IB connection</span>
+                    <span className={cn('font-medium', heartbeat.ib_connected ? 'text-emerald-600' : 'text-slate-400')}>
+                      {heartbeat.ib_connected ? 'Connected' : 'Disconnected'}
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-slate-400">Active trades</span>
+                    <span className="font-medium">{heartbeat.active_trades}</span>
+                  </div>
+                  {heartbeat.last_cycle_result && (
+                    <div className="flex justify-between">
+                      <span className="text-slate-400">Last result</span>
+                      <span className="font-medium text-right max-w-[160px] truncate">
+                        {heartbeat.last_cycle_result}
+                      </span>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
           ) : status ? (
             <div className="space-y-2 text-xs text-slate-600">
               <div className="flex justify-between">

--- a/auto-trader/com.portfolio-assistant.auto-trader.plist
+++ b/auto-trader/com.portfolio-assistant.auto-trader.plist
@@ -29,9 +29,9 @@
     <key>RunAtLoad</key>
     <true/>
 
-    <!-- Don't restart if it exits (start.sh handles its own lifecycle) -->
+    <!-- Restart automatically if the process exits (crash recovery) -->
     <key>KeepAlive</key>
-    <false/>
+    <true/>
 
     <key>StandardOutPath</key>
     <string>/tmp/auto-trader-stdout.log</string>

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -779,3 +779,38 @@ export async function getPerformance(): Promise<{
     .single();
   return data as { total_trades: number; win_rate: number; avg_win: number; avg_loss: number } | null;
 }
+
+// ── System Heartbeat ──────────────────────────────────────
+
+export interface HeartbeatPayload {
+  status: 'ok' | 'degraded' | 'error';
+  ibConnected: boolean;
+  activeTrades: number;
+  lastCycleResult: string | null;
+  lastCycleAt: string | null;
+  runCount: number;
+}
+
+/**
+ * Upserts a single-row heartbeat record so the dashboard can detect
+ * whether the auto-trader is alive even when the HTTP endpoint is unreachable.
+ * Silently swallows errors — a failed heartbeat write must never crash the service.
+ */
+export async function upsertHeartbeat(payload: HeartbeatPayload): Promise<void> {
+  try {
+    const sb = getSupabase();
+    await sb.from('system_heartbeats').upsert({
+      id: 'auto-trader',
+      last_seen_at: new Date().toISOString(),
+      status: payload.status,
+      ib_connected: payload.ibConnected,
+      active_trades: payload.activeTrades,
+      last_cycle_result: payload.lastCycleResult,
+      last_cycle_at: payload.lastCycleAt,
+      run_count: payload.runCount,
+      updated_at: new Date().toISOString(),
+    }, { onConflict: 'id' });
+  } catch {
+    // Intentionally silent — heartbeat failure must not impact trading
+  }
+}

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -52,6 +52,7 @@ import {
   updateExternalStrategySignal,
   savePortfolioSnapshot,
   getPerformance,
+  upsertHeartbeat,
   type AutoTraderConfig,
   type ExternalStrategySignal,
   type PaperTrade,
@@ -416,6 +417,28 @@ Action needed: Check the auto-trader service and restart if necessary.`,
       console.error('[Scheduler] Initial cycle failed:', err);
     });
   }, 10_000);
+
+  // ── Heartbeat — write to Supabase every 60s ─────────────────────────────
+  // This lets the dashboard show "last seen X min ago" even when the HTTP
+  // endpoint is unreachable, and lets a cloud-side pg_cron staleness checker
+  // send an email alert when the service is completely down.
+  async function writeHeartbeat() {
+    const s = getSchedulerStatus();
+    const activeTrades = await getActiveTrades().then(t => t.length).catch(() => 0);
+    await upsertHeartbeat({
+      status: s.lastResult.startsWith('error') ? 'error'
+            : s.ibConnected ? 'ok' : 'degraded',
+      ibConnected: s.ibConnected,
+      activeTrades,
+      lastCycleResult: s.lastResult,
+      lastCycleAt: s.lastRun,
+      runCount: s.runCount,
+    });
+  }
+  // Write immediately on startup (so dashboard shows "just now" after a restart)
+  setTimeout(() => writeHeartbeat().catch(() => {}), 5_000);
+  // Then every 60s
+  setInterval(() => writeHeartbeat().catch(() => {}), 60_000);
 }
 
 export function stopScheduler(): void {

--- a/auto-trader/start.sh
+++ b/auto-trader/start.sh
@@ -17,7 +17,6 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
 PORT="${PORT:-3001}"
-service_already_running="no"
 
 # ── Colors ──
 RED='\033[0;31m'
@@ -66,9 +65,16 @@ if [ -n "$listener_pids" ]; then
   done <<< "$listener_pids"
 
   if [ "$running_our_service" = "yes" ]; then
+    # Service is already running. With KeepAlive=true launchd only calls start.sh
+    # after the process exits — so this only happens if called manually while the
+    # service is already up. Wait for it to exit naturally (or be killed externally),
+    # then fall through to restart. This prevents an infinite KeepAlive restart loop.
     echo -e "${GREEN}✅ Auto-trader already running on port $PORT${NC}"
-    echo "   No restart needed for Node service; continuing with IB Gateway checks."
-    service_already_running="yes"
+    echo "   Waiting for existing process to exit before restarting..."
+    while lsof -tiTCP:"$PORT" -sTCP:LISTEN > /dev/null 2>&1; do
+      sleep 5
+    done
+    echo "   Process exited — proceeding with restart."
   else
     echo "   Attempting to stop stale listener(s): $listener_pids"
     echo "$listener_pids" | xargs kill -TERM 2>/dev/null || true
@@ -138,11 +144,6 @@ else
 fi
 
 # ── Start auto-trader Node.js service ──
-
-if [ "$service_already_running" = "yes" ]; then
-  echo -e "${GREEN}✅ Leaving existing auto-trader process running${NC}"
-  exit 0
-fi
 
 echo -e "${GREEN}🤖 Starting auto-trader service on port $PORT...${NC}"
 echo ""

--- a/supabase/migrations/20260430000001_system_heartbeat.sql
+++ b/supabase/migrations/20260430000001_system_heartbeat.sql
@@ -1,0 +1,30 @@
+-- System Heartbeat Table
+--
+-- The auto-trader upserts a single row here every 60 seconds.
+-- The dashboard reads this as a fallback when the HTTP endpoint is unreachable.
+-- A pg_cron job checks staleness and fires send-alert edge function if dead.
+
+create table if not exists system_heartbeats (
+  id               text        primary key default 'auto-trader',
+  last_seen_at     timestamptz not null default now(),
+  status           text        not null default 'ok',  -- 'ok' | 'degraded' | 'error'
+  ib_connected     boolean     not null default false,
+  active_trades    int         not null default 0,
+  last_cycle_result text,
+  last_cycle_at    timestamptz,
+  run_count        int         not null default 0,
+  last_alert_sent_at timestamptz,                      -- rate-limits failure emails
+  updated_at       timestamptz not null default now()
+);
+
+alter table system_heartbeats enable row level security;
+
+-- Dashboard (anon/authenticated) can read
+create policy "public read heartbeat"
+  on system_heartbeats for select
+  using (true);
+
+-- Only service role can write (auto-trader uses service role key)
+create policy "service write heartbeat"
+  on system_heartbeats for all
+  using (auth.role() = 'service_role');

--- a/supabase/migrations/20260430000002_heartbeat_staleness_cron.sql
+++ b/supabase/migrations/20260430000002_heartbeat_staleness_cron.sql
@@ -1,0 +1,114 @@
+-- Heartbeat Staleness Checker — pg_cron (cloud-side safety net)
+--
+-- Checks every 10 minutes during market hours if the auto-trader heartbeat
+-- is stale (last seen > 30 minutes ago). If stale, calls send-alert-email.
+--
+-- This catches the case where the Node.js service completely crashes —
+-- the service-side dead man's switch can't fire if the process is dead.
+-- Rate-limited to one alert per hour via system_heartbeats.last_alert_sent_at.
+--
+-- Requires: system_heartbeats table (20260430000001_system_heartbeat.sql)
+-- Requires: pg_cron and pg_net extensions (already enabled by morning_brief migration)
+
+create or replace function public.check_heartbeat_staleness()
+returns void
+language plpgsql
+security definer
+as $$
+declare
+  v_url           text;
+  v_key           text;
+  v_alert_email   text;
+  v_last_seen     timestamptz;
+  v_last_alert    timestamptz;
+  v_stale_mins    numeric;
+  v_et_now        timestamptz;
+  v_et_hour       int;
+  v_et_dow        int;  -- 0=Sun, 6=Sat
+begin
+  v_url := current_setting('app.supabase_url', true);
+  v_key := current_setting('app.supabase_anon_key', true);
+  if v_url is null or v_key is null then
+    raise warning '[heartbeat] app.supabase_url or app.supabase_anon_key not set — skipping';
+    return;
+  end if;
+
+  -- Only alert during market hours ET (9:30–17:00 Mon–Fri)
+  -- pg uses server timezone; convert to ET
+  v_et_now  := now() at time zone 'America/New_York';
+  v_et_hour := extract(hour from v_et_now);
+  v_et_dow  := extract(dow  from v_et_now);  -- 0=Sun, 6=Sat
+
+  if v_et_dow in (0, 6) then return; end if;      -- weekends
+  if v_et_hour < 9 or v_et_hour >= 17 then return; end if;  -- outside trading day
+  if v_et_hour = 9 and extract(minute from v_et_now) < 30 then return; end if;
+
+  -- Read heartbeat
+  select last_seen_at, last_alert_sent_at
+  into   v_last_seen, v_last_alert
+  from   system_heartbeats
+  where  id = 'auto-trader'
+  limit  1;
+
+  -- No heartbeat row at all → service never wrote one (treat as stale)
+  if v_last_seen is null then
+    v_stale_mins := 999;
+  else
+    v_stale_mins := extract(epoch from (now() - v_last_seen)) / 60;
+  end if;
+
+  -- Only alert if stale for > 30 minutes
+  if v_stale_mins < 30 then return; end if;
+
+  -- Rate-limit: don't send more than once per hour
+  if v_last_alert is not null and (now() - v_last_alert) < interval '1 hour' then return; end if;
+
+  -- Get alert email from config
+  select alert_email
+  into   v_alert_email
+  from   auto_trader_config
+  where  id = 'default'
+  limit  1;
+
+  if v_alert_email is null then return; end if;
+
+  -- Update rate-limit timestamp before sending (prevents duplicate if function runs twice)
+  update system_heartbeats
+  set    last_alert_sent_at = now()
+  where  id = 'auto-trader';
+
+  -- Fire send-alert-email edge function
+  perform net.http_post(
+    url     := v_url || '/functions/v1/send-alert-email',
+    headers := jsonb_build_object(
+      'Content-Type',  'application/json',
+      'Authorization', 'Bearer ' || v_key
+    ),
+    body := jsonb_build_object(
+      'alert_type', 'heartbeat_stale',
+      'subject',    '🚨 Auto-Trader: Service appears to be down',
+      'body',       format(
+        E'The auto-trader heartbeat has not been updated for %s minutes.\n\nLast seen: %s ET\n\nThe service may have crashed. It should restart automatically via LaunchAgent.\n\nIf trades are open, check Interactive Brokers directly.',
+        round(v_stale_mins)::text,
+        to_char(v_last_seen at time zone 'America/New_York', 'YYYY-MM-DD HH24:MI')
+      ),
+      'email_to',   v_alert_email
+    )
+  );
+end;
+$$;
+
+-- Schedule: every 10 minutes during market hours (UTC: 13:00–21:00 = 9:00 AM–5:00 PM ET)
+-- Using UTC range to cover both EST and EDT without timezone offset issues.
+do $$
+begin
+  perform cron.unschedule('check-heartbeat-staleness');
+exception when others then null;
+end;
+$$;
+
+select cron.schedule(
+  'check-heartbeat-staleness',
+  '*/10 13-21 * * 1-5',
+  'select public.check_heartbeat_staleness()'
+);


### PR DESCRIPTION
## What this does

The auto-trader now heals itself and emails you only when it breaks. No daily digests, no dashboards to check — just silence when everything is fine and an email when it's not.

## Changes

### LaunchAgent (`KeepAlive: true`)
Previously `KeepAlive: false` — if the Node.js process crashed, launchd did nothing. Now launchd automatically restarts the service after any crash.

`start.sh` updated: when it detects the service is already running, it waits for the process to exit before restarting (prevents infinite restart loops with KeepAlive). The stale-process kill path is unchanged.

### `system_heartbeats` Supabase table (migration 1)
Single-row table. Auto-trader upserts every 60 seconds with: `last_seen_at`, `status`, `ib_connected`, `active_trades`, `last_cycle_result`, `run_count`. Persists health data independently of the Node.js process.

### `upsertHeartbeat()` + scheduler.ts
Called on startup (5s delay) and every 60s via `setInterval`. Silently swallows all errors — a failed heartbeat write must never crash the service.

### pg_cron staleness checker (migration 2)
Runs every 10 min during market hours (UTC 13:00–21:00 Mon–Fri). If `last_seen_at > 30 min` ago AND last alert was > 1 hour ago, calls existing `send-alert-email` edge function. Email includes last-seen timestamp so you know how long it's been down.

This is the key safety net: the service-side dead man's switch can't fire if the process is dead. The pg_cron check runs in the cloud regardless.

### `EngineHealthIndicator.tsx`
- Polls Supabase heartbeat every minute (was 5 min, and only the live HTTP endpoint)
- Falls back to Supabase data when HTTP endpoint is unreachable: shows "Engine down — last seen 47 min ago", active trade count, IB status
- Labels updated: "Engine running (heartbeat)" vs "Engine down" vs "Engine unreachable"

## One-time setup needed
Make sure `auto_trader_config.alert_email` is set with your email address — that's what the staleness checker reads. The existing `send-alert-email` edge function + Resend are already configured.

## Test plan
- [ ] Kill the Node process manually → LaunchAgent restarts it automatically
- [ ] Check dashboard shows Supabase heartbeat after service starts
- [ ] Verify `system_heartbeats` row updates every ~60s in Supabase table editor
- [ ] Kill service, wait 30+ min during market hours → confirm alert email arrives

Made with [Cursor](https://cursor.com)