### PR TITLE
fix: block order placement before 9:30 AM ET on all execution paths

### DIFF
--- a/app/src/components/TradeIdeas.tsx
+++ b/app/src/components/TradeIdeas.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import {
   Flame,
   TrendingUp,
@@ -17,11 +17,7 @@ import {
 } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { fetchTradeIdeas, type TradeIdea, type ScanResult, type KeyLevelSetup } from '../lib/tradeScannerApi';
-import {
-  getAutoTraderConfig,
-  processTradeIdeas,
-  type ProcessResult,
-} from '../lib/autoTrader';
+import { getAutoTraderConfig } from '../lib/autoTrader';
 import { getActiveTrades, getAllTrades } from '../lib/paperTradesApi';
 import { Spinner } from './Spinner';
 
@@ -126,22 +122,8 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
   const [data, setData] = useState<ScanResult | null>(_cache);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [autoTrading, setAutoTrading] = useState(false);
-  const [, setAutoTradeResults] = useState<ProcessResult[]>([]);
   const [tradedTickers, setTradedTickers] = useState<Set<string>>(new Set());
   const [marketOpen, setMarketOpen] = useState(() => isMarketHoursWindow());
-  // Track already-processed tickers — persisted to sessionStorage keyed by date so
-  // revisiting the page on the same day doesn't re-trigger processTradeIdeas (which
-  // would otherwise burn AI quota on every navigation to /signals).
-  const _today = new Date().toISOString().slice(0, 10);
-  const _processedKey = `auto-trade-processed-${_today}`;
-  const _storedProcessed = (() => {
-    try {
-      const raw = sessionStorage.getItem(_processedKey);
-      return raw ? new Set<string>(JSON.parse(raw) as string[]) : new Set<string>();
-    } catch { return new Set<string>(); }
-  })();
-  const processedRef = useRef<Set<string>>(_storedProcessed);
 
   // Re-check market hours every minute so the badge updates as windows open/close.
   useEffect(() => {
@@ -222,32 +204,6 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Auto-trade: when new data arrives and auto-trading is enabled,
-  // process any new ideas that haven't been processed yet
-  useEffect(() => {
-    if (!data) return;
-    const config = getAutoTraderConfig();
-    if (!config.enabled) return;
-
-    const allIdeas = [...(data.dayTrades ?? []), ...(data.swingTrades ?? [])];
-    const newIdeas = allIdeas.filter(i => !processedRef.current.has(i.ticker));
-    if (newIdeas.length === 0) return;
-
-    // Mark as processing so we don't re-trigger — persist to sessionStorage so
-    // navigating away and back doesn't reprocess the same tickers today.
-    newIdeas.forEach(i => processedRef.current.add(i.ticker));
-    try {
-      sessionStorage.setItem(_processedKey, JSON.stringify([...processedRef.current]));
-    } catch { /* storage quota exceeded — non-fatal */ }
-
-    setAutoTrading(true);
-    processTradeIdeas(newIdeas, config)
-      .then(results => {
-        setAutoTradeResults(prev => [...results, ...prev].slice(0, 20));
-      })
-      .catch(console.error)
-      .finally(() => setAutoTrading(false));
-  }, [data]);
 
   const dayIdeas = data?.dayTrades ?? [];
   const swingIdeas = data?.swingTrades ?? [];
@@ -285,13 +241,7 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
             </span>
           )}
           {loading && <Spinner size="xs" className="text-amber-500" />}
-          {autoTrading && (
-            <span className="flex items-center gap-1 text-[10px] font-semibold bg-blue-50 text-blue-700 border border-blue-200 px-1.5 py-0.5 rounded-full">
-              <Bot className="w-3 h-3 animate-pulse" />
-              Auto-executing...
-            </span>
-          )}
-          {getAutoTraderConfig().enabled && !autoTrading && (
+          {getAutoTraderConfig().enabled && (
             <span className="flex items-center gap-1 text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200 px-1.5 py-0.5 rounded-full">
               <Bot className="w-3 h-3" />
               AUTO

--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -6,6 +6,15 @@
  * Runs entirely in the browser. No backend polling needed.
  */
 
+/** Returns true only during regular US market hours: 9:30 AM – 4:00 PM ET, Mon–Fri. */
+function isMarketOpen(): boolean {
+  const et = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
+  const day = et.getDay();
+  if (day === 0 || day === 6) return false;
+  const mins = et.getHours() * 60 + et.getMinutes();
+  return mins >= 9 * 60 + 30 && mins <= 16 * 60;
+}
+
 import type { TradeIdea } from './tradeScannerApi';
 import type { EnhancedSuggestedStock } from '../data/suggestedFinds';
 import type { TradingSignalsResponse } from './tradingSignalsApi';
@@ -620,6 +629,11 @@ export async function processTradeIdeas(
   ideas: TradeIdea[],
   config?: AutoTraderConfig
 ): Promise<ProcessResult[]> {
+  if (!isMarketOpen()) {
+    logEvent('*', 'warning', 'Market not open — skipping scanner trade execution');
+    return [];
+  }
+
   const cfg = config ?? getAutoTraderConfig();
   const results: ProcessResult[] = [];
 
@@ -2022,6 +2036,11 @@ export async function processSuggestedFinds(
   config?: AutoTraderConfig,
   topPickTickers?: Set<string>
 ): Promise<ProcessResult[]> {
+  if (!isMarketOpen()) {
+    logEvent('*', 'warning', 'Market not open — skipping Suggested Finds execution');
+    return [];
+  }
+
   const cfg = config ?? getAutoTraderConfig();
   const results: ProcessResult[] = [];
 

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -4680,9 +4680,13 @@ async function runTradeExecutionOnly(): Promise<void> {
           .sort((a, b) => b.confidence - a.confidence)
           .slice(0, slots);
         for (const idea of qualified) {
-          _processedTickers.add(idea.ticker);
           const result = await executeScannerTrade(idea, config, positions);
           log(`  ${idea.ticker}: ${result}`);
+          // Only mark as processed for non-time-based outcomes so the ticker is retried
+          // when the market-hours window opens (e.g. the 9:30–9:35 first-candle guard).
+          if (result !== 'skipped:outside-market-hours') {
+            _processedTickers.add(idea.ticker);
+          }
           await new Promise(r => setTimeout(r, 2000));
         }
       }
@@ -4919,9 +4923,13 @@ async function runSchedulerCycle(): Promise<void> {
           .slice(0, slots);
 
         for (const idea of qualified) {
-          _processedTickers.add(idea.ticker);
           const result = await executeScannerTrade(idea, config, positions);
           log(`  ${idea.ticker}: ${result}`);
+          // Only mark as processed for non-time-based outcomes so the ticker is retried
+          // when the market-hours window opens (e.g. the 9:30–9:35 first-candle guard).
+          if (result !== 'skipped:outside-market-hours') {
+            _processedTickers.add(idea.ticker);
+          }
           await new Promise(r => setTimeout(r, 2000));
         }
       } else {


### PR DESCRIPTION
## Summary

- **`TradeIdeas.tsx`**: Removed the `useEffect([data])` that auto-called `processTradeIdeas` when scanner data loaded from cache. This was firing at 9:23 AM with yesterday's cached results, hitting IB before market open and producing "DAY order rejected" failures.

- **`scheduler.ts`**: Fixed `_processedTickers` mutation — tickers were added to the set *before* `executeScannerTrade` ran. When the 9:30–9:35 first-candle guard returned `skipped:outside-market-hours`, tickers were permanently locked out. All subsequent cycles (9:45, 10:00, …) skipped them as "already processed", resulting in zero trades all day. Fixed by moving the add to after the call and skipping it for `outside-market-hours` results.

- **`autoTrader.ts`**: Added `isMarketOpen()` guard at the top of both `processTradeIdeas` and `processSuggestedFinds`. This is the deepest enforcement layer — no matter what calls these functions (hook, component, manual button), orders are blocked before 9:30 AM ET or after 4:00 PM ET.

## Test plan
- [ ] Verify no "DAY order rejected" events in activity log at next market open
- [ ] Verify scanner trades execute normally after 9:35 AM
- [ ] Verify `_processedTickers` does not permanently block tickers that were skipped in the 9:30–9:35 window

Made with [Cursor](https://cursor.com)