### PR TITLE
fix: block naked short sells from scanner SELL signals

### DIFF
--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -1770,6 +1770,24 @@ async function processSingleIdea(
 ): Promise<ProcessResult> {
   const { ticker, signal, confidence: scannerConf, mode } = idea;
 
+  // ── 0. Block naked shorts from scanner SELL signals ──
+  // SELL ideas from the scanner are bearish research — not short-sell instructions.
+  // Auto-executing a SELL without an existing long position would open a naked short.
+  // Position management (loss cuts, profit takes) handles closing longs via their own paths.
+  if (signal === 'SELL') {
+    const positions = await getPositions(config.accountId!).catch(() => []);
+    const hasLong = positions.some(p => (p.contractDesc ?? '').toUpperCase() === ticker && p.position > 0);
+    if (!hasLong) {
+      const msg = 'Scanner SELL skipped — no long position to close (would be a naked short)';
+      logEvent(ticker, 'info', msg);
+      persistEvent(ticker, 'info', msg, {
+        action: 'skipped', source: 'scanner', mode, scanner_signal: signal,
+        scanner_confidence: scannerConf, skip_reason: 'no_long_to_sell',
+      });
+      return { ticker, action: 'skipped', reason: msg };
+    }
+  }
+
   // ── 1. Dedup check ──
   const alreadyActive = await hasActiveTrade(ticker);
   if (alreadyActive) {

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -2274,6 +2274,18 @@ async function executeScannerTrade(
   // handles first-candle setups; scanner trades shouldn't race it.
   if (!isMarketHoursET() || getETMinutes() < 9 * 60 + 35) return 'skipped:outside-market-hours';
 
+  // Never auto-short from scanner signals. SELL ideas are bearish research — executing them
+  // without an existing long position would open a naked short, which is not the intent.
+  // The only valid scanner SELL auto-execution would be closing an existing long, but that's
+  // handled by checkLossCutOpportunities / checkProfitTakeOpportunities, not here.
+  if (signal === 'SELL') {
+    const hasLong = positions.some(p => p.symbol.toUpperCase() === ticker && p.position > 0);
+    if (!hasLong) {
+      log(`${ticker}: scanner SELL skipped — no long position to close (would be a naked short)`);
+      return 'skipped:no_long_to_sell';
+    }
+  }
+
   if (await hasActiveTrade(ticker)) return 'skipped:duplicate';
 
   // ── Recent-loss cooldown gate ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Scanner SELL signals (e.g. CRCL, EBAY) were passing through to IB as bracket SELL orders, which would open naked short positions. The intent of a scanner SELL idea is bearish research, not a short-sell instruction.

- **`scheduler.ts`**: Skip SELL in `executeScannerTrade` if no existing IB long position for that ticker
- **`autoTrader.ts`**: Same guard in `processSingleIdea` (browser fallback path)

Position close logic (loss cuts, profit takes) already runs through its own paths and is unaffected.

## Test plan
- [ ] Confirm CRCL/EBAY SELL ideas show as skipped in activity log (no_long_to_sell)
- [ ] Confirm BUY signals still execute normally
- [ ] Confirm existing longs can still be closed via the scanner SELL path if a position is held

Made with [Cursor](https://cursor.com)