### PR TITLE
fix: reduce day trades cache TTL from 390 to 30 minutes

### DIFF
--- a/supabase/functions/trade-scanner/index.ts
+++ b/supabase/functions/trade-scanner/index.ts
@@ -2288,7 +2288,7 @@ Deno.serve(async (req) => {
       // - If Track 2 AI failed but Track 1 produced ideas → still write those to DB
       // - Only fall back to previous DB scan if we truly have nothing at all
       if (dayIdeas.length > 0) {
-        await writeToDB(sb, 'day_trades', dayIdeas, 390);
+        await writeToDB(sb, 'day_trades', dayIdeas, 30);
       } else if (!dayAISucceeded) {
         console.warn('[Trade Scanner] Day AI failed and Track 1 empty — skipping DB write to preserve previous results');
         dayIdeas = dayRow?.data ?? [];


### PR DESCRIPTION
## Summary
The day trades scanner TTL was 390 minutes (whole market day), so it scanned once at open and never refreshed. Fixed to 30 minutes to match the intended refresh cadence.

## Impact
Users will now see new movers that develop mid-session rather than being stuck with the 9:30 AM snapshot all day.

Made with [Cursor](https://cursor.com)