### PR TITLE
fix: correct SELL fill_price, stop-out count gate, block leveraged ETFs

### DIFF
--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -393,6 +393,27 @@ export async function hasRecentLoss(
   return (count ?? 0) > 0;
 }
 
+/**
+ * Returns the number of times a ticker was stopped out (loss cut fired)
+ * within the given lookback window. Used to block repeated re-entry on
+ * structurally broken theses — e.g. POOL stopped out 5+ times.
+ */
+export async function countRecentStopOuts(
+  ticker: string,
+  lookbackDays = 90,
+): Promise<number> {
+  const since = new Date(Date.now() - lookbackDays * 86_400_000).toISOString();
+  const sb = getSupabase();
+  const { count } = await sb
+    .from('paper_trades')
+    .select('id', { count: 'exact', head: true })
+    .eq('ticker', ticker)
+    .eq('signal', 'SELL')
+    .eq('entry_trigger_type', 'loss_cut')
+    .gte('created_at', since);
+  return count ?? 0;
+}
+
 export async function countActivePositions(): Promise<number> {
   const sb = getSupabase();
   const { count } = await sb

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -36,6 +36,7 @@ import {
   getLongTermExposureByTag,
   hasActiveTrade,
   hasRecentLoss,
+  countRecentStopOuts,
   countActivePositions,
   createPaperTrade,
   updatePaperTrade,
@@ -2638,6 +2639,20 @@ async function _executeSuggestedFindTradeInner(
 ): Promise<string> {
   const { ticker, conviction } = stock;
 
+  // ── Leveraged/inverse ETF blocklist ──────────────────────────────────
+  // These instruments have daily volatility reset and compounding decay that
+  // make them structurally incompatible with a quality long-term hold strategy.
+  // High IV makes them attractive to the AI screener but unsuitable for the wheel.
+  const LEVERAGED_ETF_BLOCKLIST = new Set([
+    'SOXL', 'SOXS', 'TQQQ', 'SQQQ', 'SPXL', 'SPXU', 'UVXY', 'SVXY',
+    'LABU', 'LABD', 'NUGT', 'DUST', 'JNUG', 'JDST', 'FAS', 'FAZ',
+    'TNA', 'TZA', 'NAIL', 'DRN', 'DRV', 'DFEN', 'WEBL', 'WEBS',
+  ]);
+  if (LEVERAGED_ETF_BLOCKLIST.has(ticker.toUpperCase())) {
+    log(`${ticker}: LONG_TERM skipped — leveraged/inverse ETF not suitable for wheel strategy`);
+    return 'skipped:leveraged_etf';
+  }
+
   // Hard minimum: never place Suggested Find orders before 9:30 AM ET (belt-and-suspenders).
   // preGenerateSuggestedFinds already checks isMarketHoursET(), but this catches any edge case
   // where that check runs at the boundary (e.g. slow event loop crossing the 9:30 threshold).
@@ -2646,8 +2661,7 @@ async function _executeSuggestedFindTradeInner(
   if (await hasActiveTrade(ticker)) return 'skipped:duplicate';
 
   // ── Recent-loss cooldown gate ─────────────────────────────────────────
-  // LONG_TERM trades use a 21-day lookback. This caught the POOL ×2 scenario
-  // where two consecutive confidence-9 entries both stopped out at -24% and -25%.
+  // LONG_TERM trades use a 21-day lookback.
   if (await hasRecentLoss(ticker, 21)) {
     log(`${ticker}: LONG_TERM skipped — recent loss within 21d cooldown`);
     persistEvent(ticker, 'skipped', `LONG_TERM re-entry blocked — ticker had a loss within 21 days`, {
@@ -2655,6 +2669,22 @@ async function _executeSuggestedFindTradeInner(
       skip_reason: 'recent_loss_cooldown',
     });
     return 'skipped:recent_loss_cooldown';
+  }
+
+  // ── Repeated stop-out gate ────────────────────────────────────────────
+  // If a ticker has been loss-cut 3+ times in the last 90 days, the thesis
+  // is broken regardless of the current conviction score. Block re-entry
+  // indefinitely until the window clears. Prevents POOL/AOS-style churn.
+  {
+    const stopOuts = await countRecentStopOuts(ticker, 90);
+    if (stopOuts >= 3) {
+      log(`${ticker}: LONG_TERM skipped — ${stopOuts} stop-outs in last 90 days (thesis invalidated)`);
+      persistEvent(ticker, 'skipped', `LONG_TERM re-entry blocked — ${stopOuts} stop-outs in 90d`, {
+        action: 'skipped', source: 'suggested_finds', mode: 'LONG_TERM',
+        skip_reason: 'repeated_stop_out',
+      });
+      return 'skipped:repeated_stop_out';
+    }
   }
 
   // Same-day guard: block a second entry for the same ticker on the same ET calendar day.
@@ -3484,7 +3514,13 @@ async function syncPositions(
         if (trade.mode === 'SWING_TRADE' && trade.entry_trigger_type === 'bracket_limit') {
           upsertSwingMetrics({ date: getETDateString(), swing_orders_filled: 1 }).catch(() => {});
         }
-        const fillPrice = ibPos.avgCost;
+        // BUY fills: avgCost is a good proxy for the execution price (IB recalculates after each buy).
+        // SELL fills: avgCost is the cost of the REMAINING long shares — NOT the sale price. Use
+        // entry_price instead, which was set to ibPos.mktPrice at order creation time and closely
+        // approximates the actual execution price for a market sell.
+        const fillPrice = trade.signal === 'SELL'
+          ? (trade.entry_price ?? ibPos.mktPrice)
+          : ibPos.avgCost;
         const updates: Record<string, unknown> = {
           status: 'FILLED',
           fill_price: fillPrice,


### PR DESCRIPTION
## Summary
Three bugs found in the options wheel strategy via party-mode architectural review:

1. **fill_price bug (root cause of P&L blindness):** `syncPositions` used `ibPos.avgCost` for all SELL fill prices. For BUYs this is approximately correct; for SELLs it records the buy cost instead of the actual sale price, making every loss cut appear as zero P&L. `hasRecentLoss` depends on `pnl < 0` — which never fired — allowing POOL/AOS to re-enter indefinitely after stop-outs.
2. **Stop-out count gate:** New `countRecentStopOuts()` function + gate: 3+ stop-outs in 90 days blocks re-entry regardless of time window.
3. **Leveraged ETF blocklist:** SOXL, TQQQ, SQQQ and 20+ others blocked from the Suggested Finds wheel entry path.

Made with [Cursor](https://cursor.com)