### PR TITLE
docs: options wheel bug fixes — 2026-05-04

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -71,6 +71,7 @@ Design sessions and multi-step implementation plans.
 | [Advanced Options + Morning Brief (2026-04-24)](./cursor/2026-04-24-advanced-options-morning-brief.md) | VIX-tiered delta, 200 DMA gate, rolling strategy, CC cost-basis guard, morning brief, full-day scanning |
 | [Trade Scanner — Key Levels (2026-04-20)](./cursor/2026-04-20-trade-scanner-track1-key-levels.md) | Track 1 key levels enhancement design |
 | [SPX Breakout-Retest Strategy (2026-04-27)](./cursor/2026-04-27-spx-breakout-retest-strategy.md) | Somesh's $50 key-level strategy — design decisions and trade-offs |
+| [Options Wheel Bug Fixes (2026-05-04)](./cursor/2026-05-04-options-wheel-bugfixes.md) | fill_price SELL fix, repeated stop-out gate, leveraged ETF blocklist, naked short prevention, signal import constraint fix, trade date extraction |
 
 ## Archive
 Historical planning artifacts and session notes — kept for reference, superseded by implementation.

--- a/docs/cursor/2026-05-04-options-wheel-bugfixes.md
+++ b/docs/cursor/2026-05-04-options-wheel-bugfixes.md
@@ -1,0 +1,100 @@
+# Options Wheel & Auto-Trader Bug Fixes — 2026-05-04
+
+## Goal
+
+Fix a cluster of bugs discovered during a party-mode strategy review that were silently degrading the options wheel / LONG_TERM suggested finds strategy: inaccurate P&L recording, ineffective re-entry guards, and structurally inappropriate instruments entering the universe.
+
+---
+
+## Changes Shipped
+
+### 1. SELL `fill_price` Bug Fix — `auto-trader/src/scheduler.ts`
+
+**Problem:** `syncPositions` used `ibPos.avgCost` for the `fill_price` of SELL records when syncing from `SUBMITTED → FILLED`. `avgCost` is the cost basis of *remaining* shares, not the sale price. All loss-cut and profit-take SELL records showed `fill_price ≈ entry_price`, making closed P&L appear as zero.
+
+**Cascading effect:** The `hasRecentLoss` gate reads `fill_price − entry_price` to determine if a position closed at a loss. With fill_price wrong, no losses were ever detected → tickers could be re-bought immediately after being stopped out.
+
+**Fix:**
+```typescript
+const fillPrice = trade.signal === 'SELL'
+  ? (trade.entry_price ?? ibPos.mktPrice)   // market price at order submission
+  : ibPos.avgCost;                           // cost basis for BUY
+```
+
+---
+
+### 2. Repeated Stop-Out Gate — `auto-trader/src/scheduler.ts` + `auto-trader/src/lib/supabase.ts`
+
+**Problem:** Stocks like POOL were repeatedly bought and stopped out because the 21-day recent-loss gate is time-based only. Once 21 days elapsed, the system re-entered regardless of how many prior stop-outs existed.
+
+**Fix:** New `countRecentStopOuts(ticker, lookbackDays)` function in `supabase.ts` queries `paper_trades` for SELL rows with `entry_trigger_type = 'loss_cut'` within the window. Gate added to `_executeSuggestedFindTradeInner`:
+
+```typescript
+const stopOuts = await countRecentStopOuts(ticker, 90);
+if (stopOuts >= 3) return 'skipped:repeated_stop_out';
+```
+
+---
+
+### 3. Leveraged/Inverse ETF Blocklist — `auto-trader/src/scheduler.ts`
+
+**Problem:** SOXL (3× leveraged ETF) appeared in LONG_TERM open positions. Daily volatility reset and compounding decay make leveraged ETFs structurally incompatible with a buy-and-hold compounding strategy. High IV makes them attractive to the AI screener.
+
+**Fix:** Hardcoded `LEVERAGED_ETF_BLOCKLIST` set checked at entry to `_executeSuggestedFindTradeInner`:
+
+```
+SOXL, SOXS, TQQQ, SQQQ, SPXL, SPXU, UVXY, SVXY,
+LABU, LABD, NUGT, DUST, JNUG, JDST, FAS, FAZ,
+TNA, TZA, NAIL, DRN, DRV, DFEN, WEBL, WEBS
+```
+
+Note: these tickers may still appear in the options wheel watchlist (with special HIGH_VOL parameters). The block only applies to the LONG_TERM buy-and-hold path.
+
+---
+
+### 4. Naked Short Prevention — Scanner SELL Signals
+
+**Problem:** Scanner SELL signals (e.g. CRCL, EBAY) attempted to open short positions when no long position existed.
+
+**Fix:** Added guard in both execution paths:
+- `auto-trader/src/scheduler.ts` → `executeScannerTrade`
+- `app/src/lib/autoTrader.ts` → `processSingleIdea`
+
+If signal is SELL and no IB long position exists → skip with `skipped:no_long_to_sell`.
+
+---
+
+### 5. `import-strategy-signals` — One Row Per Entry Level
+
+**Problem:** For signals with multiple target prices sharing one entry level (e.g. `longTriggerAbove: 414` with targets `[420, 425, 430]`), the function created one DB row per target. This violated the `uq_pending_signal_per_date` unique index on `(ticker, signal, entry_price, execute_on_date)` for PENDING status.
+
+**Fix:** Create exactly one BUY row per `longTriggerAbove` and one SELL row per `shortTriggerBelow`. All targets summarised in the `notes` field (`T1: 420, T2: 425, T3: 430`).
+
+---
+
+### 6. Trade Date Extraction — Day-of-Week Reconciliation
+
+**Problem:** A transcript saying "Monday May 4th" was extracted as "May 5th" because the LLM picked the nearest future instance of May 4.
+
+**Fix:** `extract-strategy-metadata-from-transcript` post-processes the extracted `trade_date` to reconcile against any named weekday in the transcript. If the extracted date's day-of-week doesn't match the named day, the named day wins (adjusted within ±3 days).
+
+---
+
+### 7. Day Trade Cache TTL — 390 → 30 Minutes
+
+**Problem:** `day_trades` results were cached for 390 minutes (full trading day), preventing intraday refreshes.
+
+**Fix:** `trade-scanner/index.ts` `writeToDB` call for `day_trades` changed from `390` to `30` minutes TTL.
+
+---
+
+## Key Files
+
+| File | Change |
+|------|--------|
+| `auto-trader/src/scheduler.ts` | fill_price SELL fix, stop-out gate, leveraged ETF blocklist, naked short guard |
+| `auto-trader/src/lib/supabase.ts` | `countRecentStopOuts()` function added |
+| `app/src/lib/autoTrader.ts` | Naked short guard in browser execution path |
+| `supabase/functions/import-strategy-signals/index.ts` | One row per entry level |
+| `supabase/functions/extract-strategy-metadata-from-transcript/index.ts` | Day-of-week date reconciliation |
+| `supabase/functions/trade-scanner/index.ts` | Cache TTL 390 → 30 min |

--- a/docs/features/auto-trader-execution-paths.md
+++ b/docs/features/auto-trader-execution-paths.md
@@ -1,6 +1,6 @@
 # Auto-Trader Execution Paths
 
-**Date:** 2026-02-23  
+**Date:** 2026-02-23 (last updated 2026-05-04)  
 **Purpose:** Document the three trade execution paths, what checks each applies, and why — so we don't re-add wrong checks.
 
 ---
@@ -23,8 +23,9 @@ Scanner signals come from `trade-scanner` edge function (technical momentum). FA
 
 **Gate order:**
 1. Time gate: must be ≥ 9:35 AM ET (avoids first-candle volatility; added 2026-04-28)
-2. No duplicate active trade for ticker
-3. Day trade only: daily max-loss gate active → skip
+2. **SELL signal guard** (added 2026-05-04): scanner SELL signals blocked unless an existing IB long position exists for the ticker — prevents naked short sells. Scanner SELL ideas are bearish research, not short-sell instructions. Closing longs is handled by loss-cut/profit-take paths.
+3. No duplicate active trade for ticker
+4. Day trade only: daily max-loss gate active → skip
 4. Day trade only: inside ORB (choppy) → skip
 5. **Swing trade quality gates** (added 2026-04-28):
    - `market_condition = 'chop'` → skip (regime not trending)
@@ -69,13 +70,17 @@ Suggested Finds are generated daily by the AI pipeline: HuggingFace candidates �
 - Comparing them directly caused good picks (e.g. NEM conviction 9) to be blocked by swing FA returning 4
 
 **Gate order:**
-1. No duplicate active trade for ticker
-2. Gold Mine only: SPY < SMA200 blocks entry (bear market macro protection)
-3. ~~FA check~~ — **removed** (was wrong tool; AI pipeline is the analysis)
-4. Current price from Finnhub
-5. Gold Mine 40% allocation cap (`0.40 * maxTotalAllocation`)
-6. `runPreTradeChecks` (drawdown, allocation cap, sector exposure, earnings blackout)
-7. IB contract lookup
+1. **Leveraged/inverse ETF blocklist** (added 2026-05-04): SOXL, SOXS, TQQQ, SQQQ, SPXL, SPXU, UVXY, SVXY, LABU, LABD, NUGT, DUST, and 10+ others blocked. Daily volatility decay makes them incompatible with a quality long-term hold thesis.
+2. No duplicate active trade for ticker
+3. **Recent-loss cooldown** (21-day): if ticker had a recorded loss in last 21 days → block
+4. **Repeated stop-out gate** (added 2026-05-04): if ticker was loss-cut ≥ 3 times in last 90 days → block regardless of time. Prevents POOL/AOS-style churn on broken theses.
+5. Same-day duplicate guard
+6. Gold Mine only: SPY < SMA200 blocks entry (bear market macro protection)
+7. ~~FA check~~ — **removed** (was wrong tool; AI pipeline is the analysis)
+8. Current price from Finnhub
+9. Gold Mine 40% allocation cap (`0.40 * maxTotalAllocation`)
+10. `runPreTradeChecks` (drawdown, allocation cap, sector exposure, earnings blackout)
+11. IB contract lookup
 
 **Pre-filtering** (in `preGenerateSuggestedFinds` before execution):
 - Conviction ≥ `minSuggestedFindsConviction`

--- a/docs/features/options-wheel-engine.md
+++ b/docs/features/options-wheel-engine.md
@@ -1,6 +1,6 @@
 # Options Wheel Engine
 
-**Last updated:** 2026-04-24 (end of day — ETF tier + scanner reliability)  
+**Last updated:** 2026-05-04  
 **Status:** Live — paper trading mode (IB paper account DUP876374)  
 **Auto-trade:** ENABLED — `auto_trader_config.options_auto_trade_enabled = true`  
 **Real orders:** Placed via IB Gateway (paper account); falls back to paper-only if IB offline
@@ -183,6 +183,8 @@ Dip entries receive: 0.5% yield grace, +1 contract bonus, SMA20 strike floor exe
 
 Current leveraged ETFs on watchlist: SOXL, TQQQ, NVDL, AAPU, TSLL
 
+> **Note (2026-05-04):** SOXL and similar leveraged/inverse ETFs are **blocked from the LONG_TERM Suggested Finds path** via a hardcoded blocklist in `scheduler.ts`. They may still appear in the options wheel watchlist above (with special parameters), but will never be picked up by the long-term buy-and-hold strategy.
+
 ---
 
 ## Watchlist Tiers
@@ -264,6 +266,19 @@ If options P&L for the calendar month falls below **−5% of options budget** (�
 | `supabase/migrations/20260424000003_options_roll_tracking.sql` | Adds `roll_count`, `rolled_from_id` to `paper_trades` |
 | `supabase/migrations/20260424000002_options_watchlist_sector_source.sql` | Adds `sector` column to `options_watchlist` |
 | `supabase/migrations/20260424000006_options_watchlist_index_etf.sql` | Adds `is_index_etf` column; inserts VPU, VYM, VIG as STABLE tier |
+
+---
+
+## LONG_TERM Position Sync — fill_price Bug Fix (2026-05-04)
+
+When `syncPositions` syncs a `SUBMITTED` trade to `FILLED`, it now sets `fill_price` differently for BUY vs SELL records:
+
+| Signal | `fill_price` source | Rationale |
+|--------|---------------------|-----------|
+| BUY | `ibPos.avgCost` | Cost basis of shares acquired — correct |
+| SELL | `trade.entry_price` (falls back to `ibPos.mktPrice`) | Market price at order submission — the actual sale price. `avgCost` for a SELL is the *remaining* position's cost, not the exit price. |
+
+**Prior to this fix:** all SELL records (loss cuts, profit takes) showed `fill_price = avgCost` of remaining shares, making closed-position P&L appear as zero. This masked real losses and prevented the `hasRecentLoss` gate from triggering re-entry blocks.
 
 ---
 

--- a/docs/features/strategy-video-architecture.md
+++ b/docs/features/strategy-video-architecture.md
@@ -1,6 +1,6 @@
 # Strategy System — Architecture
 
-**Last updated:** 2026-04-22
+**Last updated:** 2026-05-04
 
 ## Overview
 
@@ -75,8 +75,8 @@ Each signal and paper trade carries:
 | `process-strategy-video-queue` | Creates minimal `strategy_videos` row; triggers platform-specific ingest |
 | `fetch-youtube-transcript` | Fetches YouTube captions; calls extract |
 | `trigger-instagram-ingest` | Dispatches GitHub Actions `repository_dispatch` for Instagram/Twitter |
-| `extract-strategy-metadata-from-transcript` | Groq Llama 3.3 70B extracts metadata; triggers `import-strategy-signals` if daily_signal |
-| `import-strategy-signals` | Converts `extracted_signals` → PENDING `external_strategy_signals` (idempotent) |
+| `extract-strategy-metadata-from-transcript` | Groq Llama 3.3 70B extracts metadata; triggers `import-strategy-signals` if daily_signal. Post-processes extracted dates: if the transcript names a weekday (e.g. "Monday") and the extracted date doesn't match that day, the weekday name wins — preventing off-by-one date bugs. |
+| `import-strategy-signals` | Converts `extracted_signals` → PENDING `external_strategy_signals` (idempotent). Creates **one row per entry level** (one BUY per `longTriggerAbove`, one SELL per `shortTriggerBelow`). Multiple targets are summarised in the `notes` field. This avoids `uq_pending_signal_per_date` constraint violations when a signal has several target prices sharing the same entry price. |
 | `fix-unknown-strategy-sources` | Resolves Unknown sources by fetching Instagram og:url |
 | `assign-strategy-videos-to-source` | Manual assignment of Unknown videos to a known source |
 


### PR DESCRIPTION
## Summary

- **fill_price SELL fix** — `syncPositions` now uses `mktPrice` (sale price) instead of `avgCost` for SELL records, so closed-position P&L is accurate
- **Repeated stop-out gate** — blocks LONG_TERM re-entry if a ticker has been stopped out 3+ times in 90 days (`countRecentStopOuts`)
- **Leveraged ETF blocklist** — SOXL, TQQQ, SQQQ and 20+ others excluded from the LONG_TERM buy-and-hold path
- **Naked short prevention** — scanner SELL signals now blocked unless an existing IB long position exists
- **Signal import constraint fix** — `import-strategy-signals` creates one row per entry level (not per target); additional targets go into `notes`
- **Trade date extraction** — day-of-week reconciliation added to `extract-strategy-metadata-from-transcript`
- **Day trades cache TTL** — reduced from 390 min to 30 min for intraday freshness

## Changes

Documentation only — no code changes in this PR.

| Doc | Update |
|-----|--------|
| `docs/features/auto-trader-execution-paths.md` | Scanner SELL guard + LONG_TERM gate order rewrite |
| `docs/features/options-wheel-engine.md` | fill_price bug fix section + leveraged ETF note |
| `docs/features/strategy-video-architecture.md` | import-signals one-row-per-entry + date reconciliation |
| `docs/cursor/2026-05-04-options-wheel-bugfixes.md` | Full session notes (new file) |
| `docs/INDEX.md` | New session notes entry |

Made with [Cursor](https://cursor.com)