### PR TITLE
fix: remove invalid metadata field from createPaperTrade (XOM blocked)

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -2586,9 +2586,6 @@ async function executeScannerTrade(
       pass1_confidence: idea.pass1_confidence,
       entry_trigger_type: 'bracket_limit',
       market_condition: idea.market_condition,
-      ...(candlePatternLog.length > 0 && {
-        metadata: { candle_patterns: candlePatternLog },
-      }),
     });
 
     recordPendingOrder(sizing.dollarSize);


### PR DESCRIPTION
## Summary
- `createPaperTrade()` was receiving a `metadata` field (candle pattern log) that doesn't exist on the `paper_trades` table — only on `auto_trade_events`
- This caused any order where candle patterns were detected to fail with: `Could not find the 'metadata' column of 'paper_trades' in the schema cache`
- Candle patterns are already captured in `auto_trade_events` via `persistEvent()` right below the failing line — no data lost, just remove the erroneous spread

## Impact
- XOM was the only ticker today that passed all gates (ORB, R/R, duplicate, drawdown, confidence) and was ready to trade — this bug killed the order
- Any future trade with candle confirmation (three-candle momentum, etc.) would have silently failed

## Test plan
- [x] Auto-trader rebuilt and restarted
- [x] App build passes

Made with [Cursor](https://cursor.com)