### PR TITLE
fix: allow manual short sells from Get Signal flow

### DIFF
--- a/app/src/components/TradingSignals.tsx
+++ b/app/src/components/TradingSignals.tsx
@@ -563,6 +563,8 @@ export function TradingSignals() {
         stopLoss: result.trade.stopLoss,
         targetPrice: result.trade.targetPrice,
         riskReward: result.trade.riskReward != null ? String(result.trade.riskReward) : null,
+        // User explicitly requested this trade — allow short selling even without a long position
+        allowShort: true,
       };
 
       const results = await processTradeIdeas([idea]);

--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -1774,7 +1774,8 @@ async function processSingleIdea(
   // SELL ideas from the scanner are bearish research — not short-sell instructions.
   // Auto-executing a SELL without an existing long position would open a naked short.
   // Position management (loss cuts, profit takes) handles closing longs via their own paths.
-  if (signal === 'SELL') {
+  // Exception: user-initiated manual trades (allowShort=true) may intentionally short.
+  if (signal === 'SELL' && !idea.allowShort) {
     const positions = await getPositions(config.accountId!).catch(() => []);
     const hasLong = positions.some(p => (p.contractDesc ?? '').toUpperCase() === ticker && p.position > 0);
     if (!hasLong) {

--- a/app/src/lib/tradeScannerApi.ts
+++ b/app/src/lib/tradeScannerApi.ts
@@ -26,6 +26,8 @@ export interface TradeIdea {
   in_play_score?: number;
   pass1_confidence?: number;
   market_condition?: 'trend' | 'chop';
+  /** When true, bypasses the naked-short guard. Set for user-initiated manual trades. */
+  allowShort?: boolean;
 }
 
 export interface KeyLevelSetup {


### PR DESCRIPTION
## Summary
- The naked-short guard blocked manual SELL executions initiated via "Get Signal → Execute" — same check that protects automated scanner trades was firing for user-initiated ones
- Added `allowShort?: boolean` to `TradeIdea`; manual execute path sets it `true`, automated scanner path leaves it unset
- No change to auto-trader behavior — scanner-initiated SELL signals still blocked when no long position exists

## Test plan
- [ ] Get signal for NVDA in SELL mode → execute → should now place the short order instead of showing "no long position" error
- [ ] Auto-trader scanner SELL signals still blocked (allowShort not set in scanner path)

Made with [Cursor](https://cursor.com)