### PR TITLE
feat: Armed/Watching/Blocked status on Trade Idea cards

### DIFF
--- a/app/src/components/TradeIdeas.tsx
+++ b/app/src/components/TradeIdeas.tsx
@@ -17,7 +17,15 @@ import {
   Ban,
 } from 'lucide-react';
 import { cn } from '../lib/utils';
-import { fetchTradeIdeas, type TradeIdea, type ScanResult, type KeyLevelSetup } from '../lib/tradeScannerApi';
+import {
+  fetchTradeIdeas,
+  fetchScanEvaluations,
+  type TradeIdea,
+  type ScanResult,
+  type KeyLevelSetup,
+  type ScanEvaluation,
+  type ScanEvaluations,
+} from '../lib/tradeScannerApi';
 import { getAutoTraderConfig } from '../lib/autoTrader';
 import { getActiveTrades, getAllTrades } from '../lib/paperTradesApi';
 import { Spinner } from './Spinner';
@@ -124,6 +132,7 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [tradedTickers, setTradedTickers] = useState<Set<string>>(new Set());
+  const [evaluations, setEvaluations] = useState<ScanEvaluations>({});
   const [marketOpen, setMarketOpen] = useState(() => isMarketHoursWindow());
 
   // Re-check market hours every minute so the badge updates as windows open/close.
@@ -152,6 +161,16 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
         setTradedTickers(tickers);
       })
       .catch(console.error);
+  }, []);
+
+  // Load auto-trader gate evaluations (Armed / Watching / Blocked) for each idea.
+  // Refreshes every 2 minutes so the UI stays in sync with the scheduler cycle.
+  useEffect(() => {
+    fetchScanEvaluations().then(setEvaluations).catch(() => {});
+    const interval = setInterval(() => {
+      fetchScanEvaluations().then(setEvaluations).catch(() => {});
+    }, 2 * 60 * 1000);
+    return () => clearInterval(interval);
   }, []);
 
   const load = useCallback(async (force = false) => {
@@ -209,8 +228,24 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
   const dayIdeas = data?.dayTrades ?? [];
   const swingIdeas = data?.swingTrades ?? [];
   const gameplanSetups = data?.keyLevelSetups ?? [];
-  const ideas = tab === 'day' ? dayIdeas : tab === 'swing' ? swingIdeas : [];
   const totalCount = dayIdeas.length + swingIdeas.length; // key level setups excluded from badge count
+
+  // Sort order: executed/armed → watching → no-eval → blocked
+  const evalSortWeight = (ticker: string, signal: 'BUY' | 'SELL') => {
+    const ev = evaluations[ticker.toUpperCase()];
+    if (!ev) return signal === 'SELL' ? 3 : 2; // SELL with no eval likely blocked; BUY unknown
+    if (ev.status === 'executed' || ev.status === 'armed') return 0;
+    if (ev.status === 'watching') return 1;
+    return 3; // blocked
+  };
+  const sortedIdeas = (raw: TradeIdea[]) =>
+    [...raw].sort((a, b) => evalSortWeight(a.ticker, a.signal) - evalSortWeight(b.ticker, b.signal));
+
+  const ideas = tab === 'day'
+    ? sortedIdeas(dayIdeas)
+    : tab === 'swing'
+      ? sortedIdeas(swingIdeas)
+      : [];
 
   return (
     <div className="rounded-xl border border-[hsl(var(--border))] bg-white shadow-sm overflow-hidden">
@@ -449,6 +484,7 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
                         idea={idea}
                         traded={tradedTickers.has(idea.ticker.toUpperCase())}
                         hasOpenPosition={idea.signal === 'BUY' || tradedTickers.has(idea.ticker.toUpperCase())}
+                        evaluation={evaluations[idea.ticker.toUpperCase()]}
                         onSelect={onSelectTicker}
                       />
                     ))}
@@ -646,16 +682,21 @@ function IdeaCard({
   idea,
   traded,
   hasOpenPosition = true,
+  evaluation,
   onSelect,
 }: {
   idea: TradeIdea;
   traded: boolean;
   hasOpenPosition?: boolean;
+  evaluation?: ScanEvaluation;
   onSelect: (ticker: string, mode: 'DAY_TRADE' | 'SWING_TRADE') => void;
 }) {
   const isPositive = idea.changePercent >= 0;
   // SELL signal with no matching open position — auto-trader will skip this
   const ineligibleShort = idea.signal === 'SELL' && !hasOpenPosition;
+  const isArmed = evaluation?.status === 'armed' || evaluation?.status === 'executed';
+  const isWatching = evaluation?.status === 'watching';
+  const isBlocked = evaluation?.status === 'blocked' || ineligibleShort;
 
   return (
     <button
@@ -666,9 +707,13 @@ function IdeaCard({
         'hover:shadow-md hover:-translate-y-0.5',
         traded
           ? 'bg-emerald-50/40 border-emerald-300 hover:border-emerald-400'
-          : ineligibleShort
-            ? 'bg-[hsl(var(--secondary))]/60 border-[hsl(var(--border))] opacity-55 hover:opacity-75 hover:border-[hsl(var(--border))]'
-            : 'bg-white border-[hsl(var(--border))] hover:border-[hsl(var(--ring))]'
+          : isArmed
+            ? 'bg-white border-emerald-400 ring-1 ring-emerald-300 hover:border-emerald-500'
+            : isBlocked && !evaluation
+              ? 'bg-[hsl(var(--secondary))]/60 border-[hsl(var(--border))] opacity-55 hover:opacity-75 hover:border-[hsl(var(--border))]'
+              : isBlocked
+                ? 'bg-[hsl(var(--secondary))]/60 border-[hsl(var(--border))] opacity-55 hover:opacity-75 hover:border-[hsl(var(--border))]'
+                : 'bg-white border-[hsl(var(--border))] hover:border-[hsl(var(--ring))]'
       )}
     >
       {/* Traded badge */}
@@ -679,8 +724,8 @@ function IdeaCard({
         </div>
       )}
 
-      {/* Ineligible short badge */}
-      {ineligibleShort && !traded && (
+      {/* Ineligible short badge (no evaluation yet) */}
+      {ineligibleShort && !traded && !evaluation && (
         <div className="absolute top-2 right-2 flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-slate-100 border border-slate-200">
           <Ban className="w-3 h-3 text-slate-400" />
           <span className="text-[9px] font-medium text-slate-500">No position</span>
@@ -733,6 +778,25 @@ function IdeaCard({
               {tag}
             </span>
           ))}
+        </div>
+      )}
+
+      {/* Auto-trade status line */}
+      {evaluation && !traded && (
+        <div className={cn(
+          'flex items-center gap-1 mt-2 text-[10px] font-medium',
+          isArmed    ? 'text-emerald-600' :
+          isWatching ? 'text-amber-600'   :
+                       'text-slate-400'
+        )}>
+          {isArmed    && <Zap         className="w-3 h-3 flex-shrink-0" />}
+          {isWatching && <RefreshCw   className="w-3 h-3 flex-shrink-0" />}
+          {isBlocked  && <Ban         className="w-3 h-3 flex-shrink-0" />}
+          <span className="truncate">
+            {isArmed    ? `Armed` :
+             isWatching ? `Watching · ${evaluation.reason}` :
+                          `Blocked · ${evaluation.reason}`}
+          </span>
         </div>
       )}
 

--- a/app/src/lib/tradeScannerApi.ts
+++ b/app/src/lib/tradeScannerApi.ts
@@ -56,6 +56,35 @@ export interface ScanResult {
   cached?: boolean;
 }
 
+export type ScanEvaluationStatus = 'armed' | 'watching' | 'blocked' | 'executed';
+
+export interface ScanEvaluation {
+  status: ScanEvaluationStatus;
+  reason: string;
+  evaluated_at: string;
+}
+
+/** Keyed by ticker (uppercased). Merged from both day_trades + swing_trades rows. */
+export type ScanEvaluations = Record<string, ScanEvaluation>;
+
+/** Fetch auto-trader gate evaluation results from trade_scans rows directly. */
+export async function fetchScanEvaluations(): Promise<ScanEvaluations> {
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+  const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+  try {
+    const res = await fetch(
+      `${supabaseUrl}/rest/v1/trade_scans?id=in.(day_trades,swing_trades)&select=auto_evaluations`,
+      { headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` } }
+    );
+    if (!res.ok) return {};
+    const rows: Array<{ auto_evaluations: Record<string, ScanEvaluation> }> = await res.json();
+    // Merge both rows into a single ticker-keyed map
+    return rows.reduce<ScanEvaluations>((acc, row) => ({ ...acc, ...row.auto_evaluations }), {});
+  } catch {
+    return {};
+  }
+}
+
 export async function fetchTradeIdeas(
   portfolioTickers?: string[],
   forceRefresh = false,

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -817,6 +817,47 @@ export interface HeartbeatPayload {
  * whether the auto-trader is alive even when the HTTP endpoint is unreachable.
  * Silently swallows errors — a failed heartbeat write must never crash the service.
  */
+// ── Scan Evaluations ──────────────────────────────────────
+// Written by the auto-trader after each evaluation cycle so the UI can
+// show Armed / Watching / Blocked status on Trade Idea cards.
+
+export type ScanEvaluationStatus = 'armed' | 'watching' | 'blocked' | 'executed';
+
+export interface ScanEvaluation {
+  status: ScanEvaluationStatus;
+  reason: string;
+  evaluated_at: string;
+}
+
+export async function writeScanEvaluations(
+  scanId: 'day_trades' | 'swing_trades',
+  evals: Record<string, { status: ScanEvaluationStatus; reason: string }>
+): Promise<void> {
+  if (Object.keys(evals).length === 0) return;
+  try {
+    const sb = getSupabase();
+    const evaluated_at = new Date().toISOString();
+    // Read-merge-write so we don't clobber evaluations from the other scan row.
+    const { data: existing } = await sb
+      .from('trade_scans')
+      .select('auto_evaluations')
+      .eq('id', scanId)
+      .single();
+    const merged: Record<string, ScanEvaluation> = {
+      ...(existing?.auto_evaluations ?? {}),
+      ...Object.fromEntries(
+        Object.entries(evals).map(([ticker, ev]) => [ticker, { ...ev, evaluated_at }])
+      ),
+    };
+    await sb
+      .from('trade_scans')
+      .update({ auto_evaluations: merged })
+      .eq('id', scanId);
+  } catch {
+    // Non-critical — don't let UI sync failure impact trading
+  }
+}
+
 export async function upsertHeartbeat(payload: HeartbeatPayload): Promise<void> {
   try {
     const sb = getSupabase();

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -54,6 +54,8 @@ import {
   savePortfolioSnapshot,
   getPerformance,
   upsertHeartbeat,
+  writeScanEvaluations,
+  type ScanEvaluationStatus,
   type AutoTraderConfig,
   type ExternalStrategySignal,
   type PaperTrade,
@@ -2258,6 +2260,24 @@ function parseRiskReward(rr: string | null | undefined): number | null {
 }
 
 const MIN_DAY_TRADE_RISK_REWARD = 1.8;
+
+/** Map executeScannerTrade result codes → UI status + human reason. */
+function scanResultToEval(result: string): { status: ScanEvaluationStatus; reason: string } {
+  if (result === 'executed')                    return { status: 'executed',  reason: 'Order placed' };
+  if (result === 'skipped:inside_orb')          return { status: 'watching',  reason: 'ORB — waiting for breakout' };
+  if (result === 'skipped:outside-market-hours')return { status: 'watching',  reason: 'Outside market hours' };
+  if (result.startsWith('skipped:rr_'))         return { status: 'watching',  reason: 'R/R too low at current price' };
+  if (result === 'skipped:no_long_to_sell')     return { status: 'blocked',   reason: 'No position to close' };
+  if (result === 'skipped:duplicate')           return { status: 'blocked',   reason: 'Already trading this ticker' };
+  if (result === 'skipped:same_day_duplicate')  return { status: 'blocked',   reason: 'Already traded today' };
+  if (result === 'skipped:recent_loss_cooldown')return { status: 'blocked',   reason: 'Loss cooldown active' };
+  if (result === 'skipped:daily_loss_gate')     return { status: 'blocked',   reason: 'Daily loss limit reached' };
+  if (result === 'skipped:swing_chop')          return { status: 'blocked',   reason: 'Market too choppy' };
+  if (result === 'skipped:pre_trade_check')     return { status: 'blocked',   reason: 'Pre-trade gate failed' };
+  if (result === 'skipped:max_positions')       return { status: 'blocked',   reason: 'Max positions reached' };
+  if (result.startsWith('failed:'))             return { status: 'blocked',   reason: 'Order failed — see logs' };
+  return { status: 'blocked', reason: result.replace(/^skipped:/, '') };
+}
 
 // ── Trade Execution ──────────────────────────────────────
 
@@ -4716,6 +4736,8 @@ async function runTradeExecutionOnly(): Promise<void> {
       !_processedTickers.has(i.ticker) &&
       !genericQueuedTickers.has(i.ticker)
     );
+    const rtDayEvals: Record<string, { status: ScanEvaluationStatus; reason: string }> = {};
+    const rtSwingEvals: Record<string, { status: ScanEvaluationStatus; reason: string }> = {};
     if (newIdeas.length > 0) {
       const activeCount = await countActivePositions();
       const slots = config.maxPositions - activeCount;
@@ -4727,6 +4749,9 @@ async function runTradeExecutionOnly(): Promise<void> {
         for (const idea of qualified) {
           const result = await executeScannerTrade(idea, config, positions);
           log(`  ${idea.ticker}: ${result}`);
+          const ev = scanResultToEval(result);
+          if (idea.mode === 'DAY_TRADE') rtDayEvals[idea.ticker] = ev;
+          else rtSwingEvals[idea.ticker] = ev;
           // Only mark as processed for non-time-based outcomes so the ticker is retried
           // when the market-hours window opens (e.g. the 9:30–9:35 first-candle guard).
           if (result !== 'skipped:outside-market-hours') {
@@ -4736,6 +4761,8 @@ async function runTradeExecutionOnly(): Promise<void> {
         }
       }
     }
+    if (Object.keys(rtDayEvals).length > 0)   writeScanEvaluations('day_trades', rtDayEvals).catch(() => {});
+    if (Object.keys(rtSwingEvals).length > 0)  writeScanEvaluations('swing_trades', rtSwingEvals).catch(() => {});
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
     log(`[Realtime] Trade execution complete (${elapsed}s)`);
   } catch (err) {
@@ -4957,6 +4984,15 @@ async function runSchedulerCycle(): Promise<void> {
       !_processedTickers.has(i.ticker) &&
       !genericQueuedTickers.has(i.ticker)
     );
+    // Collect gate results per scan row for UI status badges
+    const dayEvals: Record<string, { status: ScanEvaluationStatus; reason: string }> = {};
+    const swingEvals: Record<string, { status: ScanEvaluationStatus; reason: string }> = {};
+    const recordEval = (idea: TradeIdea, result: string) => {
+      const ev = scanResultToEval(result);
+      if (idea.mode === 'DAY_TRADE') dayEvals[idea.ticker] = ev;
+      else swingEvals[idea.ticker] = ev;
+    };
+
     if (newIdeas.length > 0) {
       const activeCount = await countActivePositions();
       const slots = config.maxPositions - activeCount;
@@ -4970,6 +5006,7 @@ async function runSchedulerCycle(): Promise<void> {
         for (const idea of qualified) {
           const result = await executeScannerTrade(idea, config, positions);
           log(`  ${idea.ticker}: ${result}`);
+          recordEval(idea, result);
           // Only mark as processed for non-time-based outcomes so the ticker is retried
           // when the market-hours window opens (e.g. the 9:30–9:35 first-candle guard).
           if (result !== 'skipped:outside-market-hours') {
@@ -4979,12 +5016,18 @@ async function runSchedulerCycle(): Promise<void> {
         }
       } else {
         log(`Max positions reached (${config.maxPositions}) — skipping scanner ideas`);
+        // Mark all unprocessed ideas as blocked due to max positions
+        for (const idea of newIdeas) recordEval(idea, 'skipped:max_positions');
       }
     } else if (scannerIdeasLoaded) {
       const msg = allIdeas.length === 0 ? 'No scanner ideas' : `Scanner: ${allIdeas.length} ideas (all filtered or already processed)`;
       log(msg);
       summaryLog(msg);
     }
+
+    // Write evaluation results to DB so the UI can show Armed/Watching/Blocked badges
+    if (Object.keys(dayEvals).length > 0)   writeScanEvaluations('day_trades', dayEvals).catch(() => {});
+    if (Object.keys(swingEvals).length > 0)  writeScanEvaluations('swing_trades', swingEvals).catch(() => {});
 
     // 11. SPX key-level breakout-retest scanner (Somesh's strategy)
     // Watches $50 SPX levels for the break → 2 independent candles → retest pattern.

--- a/supabase/migrations/20260505000001_trade_scans_auto_evaluations.sql
+++ b/supabase/migrations/20260505000001_trade_scans_auto_evaluations.sql
@@ -1,0 +1,10 @@
+-- Add auto_evaluations to trade_scans
+-- Stores auto-trader gate results per ticker so the UI can show
+-- "Armed / Watching / Blocked" status on each Trade Idea card.
+-- Shape: { [ticker]: { status: string, reason: string, evaluated_at: string } }
+
+ALTER TABLE trade_scans
+  ADD COLUMN IF NOT EXISTS auto_evaluations JSONB NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN trade_scans.auto_evaluations IS
+  'Auto-trader gate results per ticker. Shape: { ticker: { status, reason, evaluated_at } }';


### PR DESCRIPTION
## Summary
- Auto-trader writes gate evaluation results to `trade_scans.auto_evaluations` after each cycle — Armed, Watching (ORB, R/R), or Blocked (cooldown, no position, etc.) per ticker
- Frontend reads this every 2 min and shows a one-line status on each Trade Idea card
- Cards sorted: Armed (⚡) → Watching (⏱) → no-eval → Blocked (○)
- Armed cards get a green border ring; Blocked cards stay dimmed

## DB change
`ALTER TABLE trade_scans ADD COLUMN auto_evaluations JSONB NOT NULL DEFAULT '{}'`

## Why
14 signals showed up today, 0 traded — user had no idea why. Now every card explains itself in one line.

Made with [Cursor](https://cursor.com)