### PR TITLE
fix: exclude options positions from all day/swing trade gate functions

### DIFF
--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -355,7 +355,7 @@ export async function getLongTermExposureByTag(): Promise<{
 
 export async function hasActiveTrade(
   ticker: string,
-  opts?: { excludeMode?: 'LONG_TERM'; signal?: 'BUY' | 'SELL' }
+  opts?: { excludeMode?: 'LONG_TERM'; signal?: 'BUY' | 'SELL'; excludeOptions?: boolean }
 ): Promise<boolean> {
   const sb = getSupabase();
   let query = sb
@@ -365,6 +365,9 @@ export async function hasActiveTrade(
     .in('status', ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL']);
   if (opts?.excludeMode) {
     query = query.neq('mode', opts.excludeMode);
+  }
+  if (opts?.excludeOptions) {
+    query = query.not('mode', 'in', '(OPTIONS_PUT,OPTIONS_CALL)');
   }
   if (opts?.signal) {
     query = query.eq('signal', opts.signal);
@@ -381,15 +384,20 @@ export async function hasActiveTrade(
 export async function hasRecentLoss(
   ticker: string,
   lookbackDays = 21,
+  opts?: { excludeOptions?: boolean },
 ): Promise<boolean> {
   const since = new Date(Date.now() - lookbackDays * 86_400_000).toISOString();
   const sb = getSupabase();
-  const { count } = await sb
+  let query = sb
     .from('paper_trades')
     .select('id', { count: 'exact', head: true })
     .eq('ticker', ticker)
     .lt('pnl', 0)
     .gte('closed_at', since);
+  if (opts?.excludeOptions) {
+    query = query.not('mode', 'in', '(OPTIONS_PUT,OPTIONS_CALL)');
+  }
+  const { count } = await query;
   return (count ?? 0) > 0;
 }
 
@@ -401,25 +409,32 @@ export async function hasRecentLoss(
 export async function countRecentStopOuts(
   ticker: string,
   lookbackDays = 90,
+  opts?: { excludeOptions?: boolean },
 ): Promise<number> {
   const since = new Date(Date.now() - lookbackDays * 86_400_000).toISOString();
   const sb = getSupabase();
-  const { count } = await sb
+  let query = sb
     .from('paper_trades')
     .select('id', { count: 'exact', head: true })
     .eq('ticker', ticker)
     .eq('signal', 'SELL')
     .eq('entry_trigger_type', 'loss_cut')
     .gte('created_at', since);
-  return count ?? 0;
+  if (opts?.excludeOptions) {
+    query = query.not('mode', 'in', '(OPTIONS_PUT,OPTIONS_CALL)');
+  }
+  return (await query).count ?? 0;
 }
 
 export async function countActivePositions(): Promise<number> {
   const sb = getSupabase();
+  // Options positions run on their own pipeline and budget — exclude them from
+  // the stock scanner's max-positions slot count so they don't starve day/swing trades.
   const { count } = await sb
     .from('paper_trades')
     .select('id', { count: 'exact', head: true })
-    .in('status', ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL']);
+    .in('status', ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL'])
+    .not('mode', 'in', '(OPTIONS_PUT,OPTIONS_CALL)');
   return count ?? 0;
 }
 

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -1318,7 +1318,7 @@ async function autoQueueGenericSignalsFromTrackedVideos(
   const isActiveTicker = async (ticker: string): Promise<boolean> => {
     const cached = activeTickerCache.get(ticker);
     if (cached != null) return cached;
-    const active = await hasActiveTrade(ticker);
+    const active = await hasActiveTrade(ticker, { excludeOptions: true });
     activeTickerCache.set(ticker, active);
     return active;
   };
@@ -2307,14 +2307,16 @@ async function executeScannerTrade(
     }
   }
 
-  if (await hasActiveTrade(ticker)) return 'skipped:duplicate';
+  // Options positions on the same ticker don't block stock day/swing trades —
+  // they are different instruments and managed by a separate pipeline.
+  if (await hasActiveTrade(ticker, { excludeOptions: true })) return 'skipped:duplicate';
 
   // ── Recent-loss cooldown gate ─────────────────────────────────────────
   // Block re-entry on any ticker that lost money in the last N days.
   // SWING_TRADE uses 14 days; DAY_TRADE uses 5 days (intraday patterns reset faster).
   {
     const lookbackDays = mode === 'SWING_TRADE' ? 14 : 5;
-    if (await hasRecentLoss(ticker, lookbackDays)) {
+    if (await hasRecentLoss(ticker, lookbackDays, { excludeOptions: true })) {
       log(`${ticker}: skipped — recent loss within ${lookbackDays}d cooldown`);
       persistEvent(ticker, 'skipped', `Re-entry blocked — ticker had a loss within ${lookbackDays} days`, {
         action: 'skipped', source: 'scanner', mode, skip_reason: 'recent_loss_cooldown',
@@ -2675,11 +2677,11 @@ async function _executeSuggestedFindTradeInner(
   // where that check runs at the boundary (e.g. slow event loop crossing the 9:30 threshold).
   if (!isMarketHoursET()) return 'skipped:outside-market-hours';
 
-  if (await hasActiveTrade(ticker)) return 'skipped:duplicate';
+  if (await hasActiveTrade(ticker, { excludeOptions: true })) return 'skipped:duplicate';
 
   // ── Recent-loss cooldown gate ─────────────────────────────────────────
   // LONG_TERM trades use a 21-day lookback.
-  if (await hasRecentLoss(ticker, 21)) {
+  if (await hasRecentLoss(ticker, 21, { excludeOptions: true })) {
     log(`${ticker}: LONG_TERM skipped — recent loss within 21d cooldown`);
     persistEvent(ticker, 'skipped', `LONG_TERM re-entry blocked — ticker had a loss within 21 days`, {
       action: 'skipped', source: 'suggested_finds', mode: 'LONG_TERM',
@@ -2693,7 +2695,7 @@ async function _executeSuggestedFindTradeInner(
   // is broken regardless of the current conviction score. Block re-entry
   // indefinitely until the window clears. Prevents POOL/AOS-style churn.
   {
-    const stopOuts = await countRecentStopOuts(ticker, 90);
+    const stopOuts = await countRecentStopOuts(ticker, 90, { excludeOptions: true });
     if (stopOuts >= 3) {
       log(`${ticker}: LONG_TERM skipped — ${stopOuts} stop-outs in last 90 days (thesis invalidated)`);
       persistEvent(ticker, 'skipped', `LONG_TERM re-entry blocked — ${stopOuts} stop-outs in 90d`, {
@@ -2970,6 +2972,7 @@ async function executeExternalStrategySignal(
     } else if (await hasActiveTrade(ticker, {
       ...(signal.mode !== 'LONG_TERM' ? { excludeMode: 'LONG_TERM' as const } : {}),
       signal: signal.signal,
+      excludeOptions: true,
     })) {
       return skipExternalSignal('Duplicate active trade for ticker', 'duplicate_active_trade');
     }
@@ -5061,7 +5064,7 @@ async function runSchedulerCycle(): Promise<void> {
           riskReward: setup.riskReward,
         };
 
-        if (await hasActiveTrade('SPY')) {
+        if (await hasActiveTrade('SPY', { excludeOptions: true })) {
           log(`[SpxScanner] SPY already has an active trade — skipping level ${setup.spxLevel} setup`);
           continue;
         }


### PR DESCRIPTION
## Summary

- **Root cause**: `paper_trades` stores all modes in one table. Gate functions written for DAY_TRADE/SWING_TRADE had no mode filter, so any open options position silently contaminated stock trade gates.
- **When it surfaced**: TSLA today — an open OPTIONS_PUT from May 1 blocked a DAY_TRADE BUY signal.

## Bugs fixed (6 total)

| Location | Bug |
|---|---|
| `isActiveTicker` (scheduler.ts:1321) | Options position excluded ticker from pre-scan allocation cache — fix inside `executeScannerTrade` was unreachable |
| `executeScannerTrade` hasActiveTrade | OPTIONS_PUT/CALL blocked stock day/swing trades (fixed earlier today) |
| `hasRecentLoss` | Options loss triggered 5–14 day cooldown on stock trades for the same ticker |
| `countRecentStopOuts` | Options stop-outs counted against stock stop-out threshold |
| External signal `hasActiveTrade` (line ~2972) | Options position blocked external signal execution |
| SPX scanner `hasActiveTrade('SPY')` | SPY options blocked SPX setup trades |
| `countActivePositions` | Options positions consumed stock scanner's max-positions slot budget |

## Changes

- `auto-trader/src/lib/supabase.ts`: Added `excludeOptions?: boolean` opt to `hasRecentLoss`, `countRecentStopOuts`; updated `countActivePositions` to always exclude options
- `auto-trader/src/scheduler.ts`: Updated all call sites to pass `excludeOptions: true`

## Test

Build passes (`tsc` clean). Auto-trader restarted and running.

Made with [Cursor](https://cursor.com)