### PR TITLE
feat: economic event gate, liquidity filter, penny stock guard

### DIFF
--- a/auto-trader/src/lib/econ-calendar.ts
+++ b/auto-trader/src/lib/econ-calendar.ts
@@ -1,0 +1,102 @@
+/**
+ * Economic Event Calendar Gate
+ *
+ * SMB Capital insight: ~25% of trading days have high-impact economic events
+ * (FOMC, CPI, NFP, PCE, GDP) that cause outsized market volatility. These days
+ * wreck premium-selling and directional day trades alike.
+ *
+ * This module fetches today's economic calendar from Finnhub at market open and
+ * determines whether any high-impact events are scheduled. The scheduler can
+ * then halve day-trade position sizes on those days to reduce risk.
+ */
+
+const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+
+// Events that historically cause outsized intraday volatility.
+// Matched case-insensitively against the Finnhub event description.
+const HIGH_IMPACT_KEYWORDS = [
+  'fomc',
+  'federal funds rate',
+  'interest rate decision',
+  'nonfarm payroll', 'non-farm payroll', 'nfp',
+  'consumer price index', 'cpi',
+  'producer price index', 'ppi',
+  'gross domestic product', 'gdp',
+  'pce price index', 'pce',
+  'unemployment rate',
+  'retail sales',
+  'ism manufacturing',
+  'ism services',
+  'fed chair', 'powell',
+];
+
+export interface EconDayProfile {
+  isHighImpact: boolean;
+  events: Array<{ event: string; time: string; impact: string }>;
+  positionSizeMultiplier: number;  // 1.0 = normal, 0.5 = halved
+}
+
+let _cachedProfile: EconDayProfile | null = null;
+let _cachedDate: string | null = null;
+
+function todayET(): string {
+  return new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+}
+
+/**
+ * Fetch today's economic calendar and classify the day.
+ * Cached per trading day — only one Finnhub call per session.
+ */
+export async function getEconDayProfile(): Promise<EconDayProfile> {
+  const dateStr = todayET();
+  if (_cachedProfile && _cachedDate === dateStr) return _cachedProfile;
+
+  const defaultProfile: EconDayProfile = {
+    isHighImpact: false, events: [], positionSizeMultiplier: 1.0,
+  };
+
+  if (!FINNHUB_KEY) {
+    _cachedProfile = defaultProfile;
+    _cachedDate = dateStr;
+    return defaultProfile;
+  }
+
+  try {
+    const url = `https://finnhub.io/api/v1/calendar/economic?from=${dateStr}&to=${dateStr}&token=${FINNHUB_KEY}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Finnhub econ calendar ${res.status}`);
+
+    const data = await res.json() as {
+      economicCalendar?: Array<{ event: string; time: string; impact?: string }>;
+    };
+
+    const events = (data.economicCalendar ?? []).map(e => ({
+      event: e.event,
+      time: e.time,
+      impact: e.impact ?? 'low',
+    }));
+
+    const highImpactEvents = events.filter(e => {
+      if (e.impact === 'high') return true;
+      const lower = e.event.toLowerCase();
+      return HIGH_IMPACT_KEYWORDS.some(kw => lower.includes(kw));
+    });
+
+    const isHighImpact = highImpactEvents.length > 0;
+
+    const profile: EconDayProfile = {
+      isHighImpact,
+      events: highImpactEvents.length > 0 ? highImpactEvents : events.slice(0, 5),
+      positionSizeMultiplier: isHighImpact ? 0.5 : 1.0,
+    };
+
+    _cachedProfile = profile;
+    _cachedDate = dateStr;
+    return profile;
+  } catch (err) {
+    console.warn(`[EconCalendar] Fetch failed: ${err instanceof Error ? err.message : err}`);
+    _cachedProfile = defaultProfile;
+    _cachedDate = dateStr;
+    return defaultProfile;
+  }
+}

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -78,6 +78,7 @@ import { runDipWatcher } from './lib/dip-watcher.js';
 import { checkSpxLevelSetups } from './lib/spx-level-scanner.js';
 import { isInsideOrb } from './lib/orb.js';
 import { evaluateVwapAlignment, detectVwapReclaim } from './lib/vwap.js';
+import { getEconDayProfile } from './lib/econ-calendar.js';
 import { warmPositionPriceCache } from './routes/positions.js';
 import { generateMorningBrief } from './lib/morning-brief.js';
 import { validateOrder } from './lib/validateOrder.js';
@@ -2275,6 +2276,8 @@ function scanResultToEval(result: string): { status: ScanEvaluationStatus; reaso
   if (result === 'skipped:swing_chop')          return { status: 'blocked',   reason: 'Market too choppy' };
   if (result === 'skipped:pre_trade_check')     return { status: 'blocked',   reason: 'Pre-trade gate failed' };
   if (result === 'skipped:max_positions')       return { status: 'blocked',   reason: 'Max positions reached' };
+  if (result === 'skipped:penny_stock')        return { status: 'blocked',   reason: 'Price below $5 (penny stock)' };
+  if (result === 'skipped:illiquid')           return { status: 'blocked',   reason: 'Illiquid — volume too low' };
   if (result.startsWith('failed:'))             return { status: 'blocked',   reason: 'Order failed — see logs' };
   return { status: 'blocked', reason: result.replace(/^skipped:/, '') };
 }
@@ -2294,6 +2297,27 @@ async function executeScannerTrade(
   // spreads are widest right at open. The dedicated 9:36 first-candle cron
   // handles first-candle setups; scanner trades shouldn't race it.
   if (!isMarketHoursET() || getETMinutes() < 9 * 60 + 35) return 'skipped:outside-market-hours';
+
+  // ── Liquidity gate ─────────────────────────────────────────────────
+  // Block day trades on stocks trading below $5 (penny stocks) or with
+  // abnormally low volume (< 0.15x 10-day avg). Prevents GFAI-type blowups
+  // where thin liquidity causes outsized losses on small-cap garbage.
+  if (mode === 'DAY_TRADE') {
+    if (idea.price < 5) {
+      log(`${ticker}: skipped — price $${idea.price.toFixed(2)} below $5 minimum (penny stock filter)`);
+      persistEvent(ticker, 'skipped', `Penny stock filter: price $${idea.price.toFixed(2)} < $5`, {
+        action: 'skipped', source: 'scanner', mode, skip_reason: 'penny_stock',
+      });
+      return 'skipped:penny_stock';
+    }
+    if (idea.volumeVs10dAvg != null && idea.volumeVs10dAvg < 0.15) {
+      log(`${ticker}: skipped — volume ${idea.volumeVs10dAvg.toFixed(2)}x avg (< 0.15x, illiquid)`);
+      persistEvent(ticker, 'skipped', `Illiquid: volume ${idea.volumeVs10dAvg.toFixed(2)}x 10d avg`, {
+        action: 'skipped', source: 'scanner', mode, skip_reason: 'illiquid',
+      });
+      return 'skipped:illiquid';
+    }
+  }
 
   // For SWING_TRADE SELL signals: block unless we already hold a long to close.
   // Multi-day shorts from scanner signals are too risky to auto-execute.
@@ -2532,9 +2556,18 @@ async function executeScannerTrade(
   const dd = assessDrawdownMultiplier(positions);
   const kellyMult = await calculateKellyMultiplier(config);
   const vixMult = await getVixRegimeMultiplier();
+
+  // High-impact economic event days (FOMC, CPI, NFP, etc.) → halve position size.
+  // These days produce outsized volatility that wrecks directional day trades.
+  const econProfile = mode === 'DAY_TRADE' ? await getEconDayProfile() : null;
+  const econMult = econProfile?.positionSizeMultiplier ?? 1.0;
+  if (econProfile?.isHighImpact && econMult < 1.0) {
+    log(`${ticker}: high-impact econ day — position size ×${econMult} (${econProfile.events.map(e => e.event).join(', ')})`);
+  }
+
   const sizingRaw = calculatePositionSize(config, {
     price: entryPrice, mode, entryPrice, stopLoss,
-    drawdownMultiplier: dd.multiplier * kellyMult * vixMult,
+    drawdownMultiplier: dd.multiplier * kellyMult * vixMult * econMult,
   });
   // Scanner trades (AI-generated, not expert-vetted) must be capped at positionSize.
   // Dynamic sizing can produce 200-400 share positions when the stop is very tight —


### PR DESCRIPTION
## Summary

Three profitability improvements based on trade performance analysis showing:
- Feb/Mar day trades lost money (-$2,134 combined)
- Apr day trades made +$5,758 after gates were added
- A single GFAI trade (-$3,030) in Feb wiped out weeks of gains

### Changes

1. **Economic event calendar gate** (`econ-calendar.ts`)
   - Fetches Finnhub economic calendar, identifies FOMC/CPI/NFP/GDP/PCE days
   - Halves day trade position sizes on high-impact days
   - Cached per trading day (one API call per session)

2. **Penny stock filter** (scheduler.ts)
   - Blocks day trades on stocks < $5
   - Prevents micro-cap blowups like GFAI

3. **Liquidity gate** (scheduler.ts)
   - Blocks day trades when volume < 0.15x 10-day average
   - Prevents trading into thin markets with gap-through risk

## Test plan

- [x] `tsc` clean build
- [x] Auto-trader restarted and running
- New skip reasons show in auto_trade_events and UI eval badges

Made with [Cursor](https://cursor.com)