### PR TITLE
feat: scale position size by scanner confidence for BUY signals

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -2590,7 +2590,18 @@ async function executeScannerTrade(
   // Scanner trades (AI-generated, not expert-vetted) must be capped at positionSize.
   // Dynamic sizing can produce 200-400 share positions when the stop is very tight —
   // a gap-through on a volatile open turns a $300 expected loss into a $1,500+ wipeout.
-  const scannerPositionCap = config.positionSize > 0 ? config.positionSize : 5000;
+  //
+  // Confidence-based sizing: high-confidence BUY signals get larger positions.
+  // Data shows conf 9 BUY = 72% WR / $174 avg, conf 8 BUY = 69% WR / $60 avg,
+  // while conf 7 and SELLs don't benefit from increased size.
+  const baseCap = config.positionSize > 0 ? config.positionSize : 5000;
+  const confMultiplier = (signal === 'BUY' && scannerConf >= 9) ? 2.0
+    : (signal === 'BUY' && scannerConf >= 8) ? 1.5
+    : 1.0;
+  const scannerPositionCap = baseCap * confMultiplier;
+  if (confMultiplier > 1.0) {
+    log(`${ticker}: confidence sizing — conf ${scannerConf} ${signal} → ${confMultiplier}x cap ($${scannerPositionCap.toFixed(0)})`);
+  }
   const cappedDollarSize = Math.min(sizingRaw.dollarSize, scannerPositionCap);
   const sizing = {
     dollarSize: cappedDollarSize,


### PR DESCRIPTION
## Summary
- High-confidence BUY signals now get larger position sizes:
  - **Conf 9 BUY → $10,000** (2x base cap)
  - **Conf 8 BUY → $7,500** (1.5x base cap)
  - **Conf 7 or any SELL → $5,000** (unchanged)
- Data-driven: last 30 days, conf 8+ BUY trades had **69-72% win rate** and produced **+$4,580** in profit, while conf <8 BUY trades had 42% WR and lost -$1,395.
- Logged when the multiplier activates so we can track the impact.

## Test plan
- [x] `tsc` builds clean
- [x] Auto-trader restarted and running

Made with [Cursor](https://cursor.com)