### PR TITLE
feat: add Dip Discovery (Fortune 500) to Suggested Finds

### DIFF
--- a/auto-trader/src/lib/discovery.ts
+++ b/auto-trader/src/lib/discovery.ts
@@ -23,18 +23,22 @@ interface ThemeData {
 interface SuggestedStock {
   ticker: string;
   name: string;
-  tag: 'Steady Compounder' | 'Gold Mine';
+  tag: 'Steady Compounder' | 'Gold Mine' | 'Dip Discovery';
   reason: string;
   category?: string;
   conviction?: number;
   valuationTag?: string;
   whyGreat: string[];
   metrics: { label: string; value: string }[];
+  high52w?: number;
+  drawdownPct?: number;
+  sector?: string;
 }
 
 interface DiscoveryResult {
   compounders: SuggestedStock[];
   goldMines: SuggestedStock[];
+  dipDiscoveries: SuggestedStock[];
   currentTheme: ThemeData;
   timestamp: string;
 }
@@ -68,7 +72,7 @@ interface MarketNewsItem {
 
 async function callHuggingFace(
   prompt: string,
-  type: 'discover_compounders' | 'discover_goldmines' | 'analyze_themes',
+  type: 'discover_compounders' | 'discover_goldmines' | 'discover_dips' | 'analyze_themes',
   temperature = 0.4,
   maxOutputTokens = 4000,
   retries = 3,
@@ -513,6 +517,236 @@ function parseGoldMineCandidates(raw: string): {
   return { theme, candidates };
 }
 
+// ── Dip Discovery Pipeline ───────────────────────────────
+// Finds S&P 500 / Fortune 500 stocks that have dropped 30-50% from their
+// 52-week high and show signs of stabilization (price > 10-day SMA).
+// AI identifies candidates; Finnhub data verifies drawdown and stabilization.
+
+const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+
+interface DipCandidate {
+  ticker: string;
+  name: string;
+  reason: string;
+  sector: string;
+}
+
+async function finnhubGet<T>(path: string): Promise<T | null> {
+  try {
+    const res = await fetch(`https://finnhub.io/api/v1${path}&token=${FINNHUB_KEY}`);
+    if (!res.ok) return null;
+    return await res.json() as T;
+  } catch { return null; }
+}
+
+function buildDipCandidatePrompt(): string {
+  return `You are a quantitative equity screener. Identify US-listed S&P 500 or Fortune 500 companies whose stock price has FALLEN 30% to 50% from its 52-week high.
+
+Requirements:
+- Must be an S&P 500 constituent OR a Fortune 500 company (market cap > $10B)
+- Current price is 30-50% BELOW the stock's 52-week high (a significant drawdown)
+- The decline should be RECENT (within the last 4-16 weeks, not a slow multi-year bleed)
+- The reason for the dip should be TEMPORARY — earnings miss with intact guidance, sector rotation, macro selloff, tariff fear, management transition with strong successor
+- EXCLUDE stocks where the dip is STRUCTURAL — accounting fraud, secular industry decline, credit downgrade to junk, product safety crisis, terminal business model
+
+Return ONLY a JSON array of objects with these fields:
+{
+  "candidates": [
+    { "ticker": "XYZ", "name": "Company Name", "reason": "Brief reason for the dip", "sector": "GICS sector" }
+  ]
+}
+
+Return 5-15 candidates. No explanations outside the JSON.`;
+}
+
+function buildDipCatalystPrompt(candidates: Array<{ ticker: string; name: string; reason: string; drawdownPct: number }>): string {
+  const stockList = candidates.map(c =>
+    `${c.ticker} (${c.name}): Down ${c.drawdownPct.toFixed(0)}% — ${c.reason}`
+  ).join('\n');
+
+  return `You are an experienced equity analyst. For each stock below, determine whether the dip is a BUYING OPPORTUNITY or a VALUE TRAP.
+
+Stocks:
+${stockList}
+
+For each stock, analyze:
+1. Is the reason for the dip temporary or structural?
+2. Does the company have strong fundamentals to recover (market position, cash flow, management)?
+3. What is the realistic recovery timeline?
+
+Return ONLY a JSON array:
+{
+  "stocks": [
+    {
+      "ticker": "XYZ",
+      "name": "Company Name",
+      "verdict": "BUY" or "AVOID",
+      "conviction": 1-10,
+      "reason": "One-sentence thesis for buy/avoid",
+      "whyGreat": ["point 1", "point 2", "point 3"],
+      "metrics": [{"label": "P/E", "value": "12.3"}, {"label": "Market Cap", "value": "$45B"}, {"label": "Drawdown", "value": "-35%"}],
+      "valuationTag": "Deep Value" or "Undervalued" or "Fair Value"
+    }
+  ]
+}`;
+}
+
+function parseDipCandidates(raw: string): DipCandidate[] {
+  const cleaned = cleanJSON(raw);
+  try {
+    const parsed = JSON.parse(cleaned);
+    const arr = parsed.candidates || parsed.stocks || parsed;
+    if (!Array.isArray(arr)) return [];
+    return arr
+      .filter((c: Record<string, unknown>) => c.ticker && typeof c.ticker === 'string')
+      .map((c: Record<string, unknown>) => ({
+        ticker: String(c.ticker).toUpperCase(),
+        name: String(c.name || ''),
+        reason: String(c.reason || ''),
+        sector: String(c.sector || 'Unknown'),
+      }));
+  } catch {
+    const matches = cleaned.match(/\b[A-Z]{1,5}\b/g);
+    if (matches && matches.length >= 3) {
+      const skipWords = new Set(['THE', 'AND', 'FOR', 'NOT', 'ARE', 'BUT', 'JSON', 'ONLY', 'ALSO', 'WITH', 'FROM']);
+      return matches.filter(m => !skipWords.has(m)).slice(0, 15).map(t => ({
+        ticker: t, name: '', reason: '', sector: 'Unknown',
+      }));
+    }
+    return [];
+  }
+}
+
+function parseDipAnalysis(raw: string): SuggestedStock[] {
+  const cleaned = cleanJSON(raw);
+  const parsed = JSON.parse(cleaned);
+  const stocks = parsed.stocks || parsed;
+  if (!Array.isArray(stocks)) return [];
+
+  return stocks
+    .filter((s: Record<string, unknown>) => String(s.verdict || '').toUpperCase() === 'BUY')
+    .map((s: Record<string, unknown>) => ({
+      ticker: String(s.ticker || '').toUpperCase(),
+      name: String(s.name || ''),
+      tag: 'Dip Discovery' as const,
+      reason: String(s.reason || ''),
+      conviction: typeof s.conviction === 'number' ? s.conviction : 7,
+      valuationTag: s.valuationTag ? String(s.valuationTag) : 'Deep Value',
+      whyGreat: Array.isArray(s.whyGreat) ? s.whyGreat.map(String) : [],
+      metrics: Array.isArray(s.metrics)
+        ? (s.metrics as Array<{ label: string; value: string }>).map(m => ({
+            label: String(m.label || ''),
+            value: String(m.value || ''),
+          }))
+        : [],
+    }))
+    .sort((a, b) => (b.conviction ?? 0) - (a.conviction ?? 0));
+}
+
+export async function discoverDipStocks(): Promise<SuggestedStock[]> {
+  if (!FINNHUB_KEY) {
+    console.warn('[DipDiscovery] No FINNHUB_API_KEY — skipping');
+    return [];
+  }
+
+  console.log('[DipDiscovery] Step 1: AI identifying dip candidates...');
+  const candidateRaw = await callHuggingFace(buildDipCandidatePrompt(), 'discover_dips', 0.3, 2000);
+  const candidates = parseDipCandidates(candidateRaw);
+  console.log(`[DipDiscovery] AI suggested ${candidates.length} candidates: ${candidates.map(c => c.ticker).join(', ')}`);
+
+  if (candidates.length === 0) return [];
+
+  // Step 2: Verify drawdown with Finnhub data
+  console.log('[DipDiscovery] Step 2: Verifying drawdown with Finnhub data...');
+  const verified: Array<DipCandidate & { high52w: number; price: number; drawdownPct: number; marketCap: number; eps: number }> = [];
+
+  for (let i = 0; i < candidates.length; i += 3) {
+    const batch = candidates.slice(i, i + 3);
+    const results = await Promise.all(batch.map(async (c) => {
+      const [metrics, quote] = await Promise.all([
+        finnhubGet<{ metric?: Record<string, number> }>(`/stock/metric?symbol=${c.ticker}&metric=all`),
+        finnhubGet<{ c?: number }>(`/quote?symbol=${c.ticker}`),
+      ]);
+
+      const m = metrics?.metric ?? {};
+      const high52w = m['52WeekHigh'] ?? 0;
+      const price = quote?.c ?? 0;
+      const marketCap = m.marketCapitalization ?? 0;
+      const eps = m.epsTTM ?? m.epsAnnual ?? 0;
+
+      if (!high52w || !price || high52w <= 0 || price <= 0) return null;
+
+      const drawdownPct = ((high52w - price) / high52w) * 100;
+      if (drawdownPct < 30 || drawdownPct > 50) return null;
+      if (marketCap < 10000) return null; // < $10B (Finnhub reports in millions)
+      if (eps <= 0) return null;
+
+      return { ...c, high52w, price, drawdownPct, marketCap, eps };
+    }));
+
+    verified.push(...results.filter((r): r is NonNullable<typeof results[number]> => r !== null));
+    if (i + 3 < candidates.length) await sleep(400);
+  }
+
+  console.log(`[DipDiscovery] ${verified.length} pass drawdown/fundamentals filter: ${verified.map(v => `${v.ticker}(-${v.drawdownPct.toFixed(0)}%)`).join(', ')}`);
+  if (verified.length === 0) return [];
+
+  // Step 3: Check 10-day SMA stabilization
+  console.log('[DipDiscovery] Step 3: Checking 10-day SMA stabilization...');
+  const stabilized: typeof verified = [];
+
+  for (const stock of verified) {
+    const to = Math.floor(Date.now() / 1000);
+    const from = to - 86400 * 25; // ~25 calendar days for 10 trading days + buffer
+    const candles = await finnhubGet<{ c?: number[] }>(`/stock/candle?symbol=${stock.ticker}&resolution=D&from=${from}&to=${to}`);
+    const closes = candles?.c?.filter((v): v is number => v != null && v > 0) ?? [];
+
+    if (closes.length < 10) {
+      console.log(`  ${stock.ticker}: insufficient candle data (${closes.length} bars)`);
+      continue;
+    }
+
+    const last10 = closes.slice(-10);
+    const sma10 = last10.reduce((a, b) => a + b, 0) / last10.length;
+    const currentClose = closes[closes.length - 1];
+
+    if (currentClose < sma10) {
+      console.log(`  ${stock.ticker}: below 10-day SMA ($${currentClose.toFixed(2)} < $${sma10.toFixed(2)}) — still bleeding`);
+      continue;
+    }
+
+    console.log(`  ${stock.ticker}: above 10-day SMA ($${currentClose.toFixed(2)} > $${sma10.toFixed(2)}) — stabilized`);
+    stabilized.push(stock);
+    await sleep(300);
+  }
+
+  if (stabilized.length === 0) {
+    console.log('[DipDiscovery] No candidates passed SMA stabilization check');
+    return [];
+  }
+
+  // Step 4: AI catalyst analysis — buy or avoid?
+  console.log(`[DipDiscovery] Step 4: AI catalyst analysis for ${stabilized.length} stocks...`);
+  const catalystRaw = await callHuggingFace(
+    buildDipCatalystPrompt(stabilized),
+    'discover_dips', 0.3, 4000,
+  );
+  const analyzed = parseDipAnalysis(catalystRaw);
+
+  // Attach Finnhub-verified data to the results
+  for (const stock of analyzed) {
+    const match = stabilized.find(s => s.ticker === stock.ticker);
+    if (match) {
+      stock.high52w = match.high52w;
+      stock.drawdownPct = match.drawdownPct;
+      stock.sector = match.sector;
+    }
+  }
+
+  console.log(`[DipDiscovery] Final: ${analyzed.length} buy candidates — ${analyzed.map(s => s.ticker).join(', ')}`);
+  return analyzed;
+}
+
 // ── Cache writer ─────────────────────────────────────────
 
 async function storeServerCache(data: DiscoveryResult): Promise<void> {
@@ -581,11 +815,21 @@ export async function generateSuggestedFinds(): Promise<DiscoveryResult> {
   );
   const goldMines = parseStocksResponse(goldMineRaw, 'Gold Mine');
 
-  console.log(`[Discovery] Done: ${compounders.length} compounders, ${goldMines.length} gold mines (${currentTheme.name})`);
+  // ── DIP DISCOVERY PIPELINE ──
+  console.log('[Discovery] Step 6: Dip Discovery scan...');
+  let dipDiscoveries: SuggestedStock[] = [];
+  try {
+    dipDiscoveries = await discoverDipStocks();
+  } catch (err) {
+    console.warn(`[Discovery] Dip Discovery failed (non-blocking): ${err instanceof Error ? err.message : 'unknown'}`);
+  }
+
+  console.log(`[Discovery] Done: ${compounders.length} compounders, ${goldMines.length} gold mines (${currentTheme.name}), ${dipDiscoveries.length} dip discoveries`);
 
   const result: DiscoveryResult = {
     compounders,
     goldMines,
+    dipDiscoveries,
     currentTheme,
     timestamp: new Date().toISOString(),
   };

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -322,35 +322,50 @@ export async function getActiveTrades(): Promise<PaperTrade[]> {
   return (data ?? []) as PaperTrade[];
 }
 
-/** Get LONG_TERM exposure by tag (Gold Mine vs Compounders) for tag-level caps. */
+/** Get LONG_TERM exposure by tag (Gold Mine vs Compounders vs Dip Discovery) for tag-level caps. */
 export async function getLongTermExposureByTag(): Promise<{
   totalGoldMineExposure: number;
   totalCompounderExposure: number;
+  totalDipDiscoveryExposure: number;
+  dipDiscoveryCount: number;
+  dipDiscoverySectors: Set<string>;
   longTermTotal: number;
 }> {
   const activeTrades = await getActiveTrades();
   const longTerm = activeTrades.filter(t => t.mode === 'LONG_TERM');
 
-  const tagByTicker = new Map<string, 'Gold Mine' | 'Compounder'>();
+  const tagByTicker = new Map<string, 'Gold Mine' | 'Compounder' | 'Dip Discovery'>();
   for (const t of longTerm) {
     if ((t.notes ?? '').startsWith('Dip buy')) continue;
     if (!tagByTicker.has(t.ticker)) {
-      const isGoldMine = /Gold Mine/i.test((t.notes ?? '') + (t.scanner_reason ?? ''));
-      tagByTicker.set(t.ticker, isGoldMine ? 'Gold Mine' : 'Compounder');
+      const notes = (t.notes ?? '') + (t.scanner_reason ?? '');
+      const isDipDiscovery = /Dip Discovery/i.test(notes);
+      const isGoldMine = /Gold Mine/i.test(notes);
+      tagByTicker.set(t.ticker, isDipDiscovery ? 'Dip Discovery' : isGoldMine ? 'Gold Mine' : 'Compounder');
     }
   }
 
   let totalGoldMineExposure = 0;
   let totalCompounderExposure = 0;
+  let totalDipDiscoveryExposure = 0;
+  let dipDiscoveryCount = 0;
+  const dipDiscoverySectors = new Set<string>();
+
   for (const t of longTerm) {
     const tag = tagByTicker.get(t.ticker);
     if (!tag) continue;
     const size = t.position_size ?? 0;
     if (tag === 'Gold Mine') totalGoldMineExposure += size;
+    else if (tag === 'Dip Discovery') {
+      totalDipDiscoveryExposure += size;
+      dipDiscoveryCount++;
+      const sectorMatch = (t.notes ?? '').match(/Sector:\s*([^|]+)/);
+      if (sectorMatch) dipDiscoverySectors.add(sectorMatch[1].trim());
+    }
     else totalCompounderExposure += size;
   }
-  const longTermTotal = totalGoldMineExposure + totalCompounderExposure;
-  return { totalGoldMineExposure, totalCompounderExposure, longTermTotal };
+  const longTermTotal = totalGoldMineExposure + totalCompounderExposure + totalDipDiscoveryExposure;
+  return { totalGoldMineExposure, totalCompounderExposure, totalDipDiscoveryExposure, dipDiscoveryCount, dipDiscoverySectors, longTermTotal };
 }
 
 export async function hasActiveTrade(

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -139,7 +139,10 @@ interface SuggestedStock {
   valuationTag: string;
   tag: string;
   reason: string;
-  archetype?: string; // Gold Mine archetype: 'Tech/Semi' | 'Defense' | 'Energy' | 'Financials'
+  archetype?: string;
+  high52w?: number;
+  drawdownPct?: number;
+  sector?: string;
 }
 
 interface DailyVideoSignal {
@@ -1865,20 +1868,21 @@ async function fetchDailySuggestions(): Promise<SuggestedStock[] | null> {
     });
     const data = await res.json() as {
       cached: boolean;
-      data?: { compounders?: SuggestedStock[]; goldMines?: SuggestedStock[] };
+      data?: { compounders?: SuggestedStock[]; goldMines?: SuggestedStock[]; dipDiscoveries?: SuggestedStock[] };
     };
     if (!data.cached || !data.data) return null;
     return [
       ...(data.data.compounders ?? []),
       ...(data.data.goldMines ?? []),
+      ...(data.data.dipDiscoveries ?? []),
     ];
   } catch { return null; }
 }
 
 // ── Position Sizing ──────────────────────────────────────
 
-/** Gold Mine: cap at 1.25x. Steady Compounder: full up to 1.5x. */
-function convictionMultiplier(conv: number, suggestedFindTag?: 'Steady Compounder' | 'Gold Mine'): number {
+/** Gold Mine: cap at 1.25x. Steady Compounder: full up to 1.5x. Dip Discovery: cap at 1.0x. */
+function convictionMultiplier(conv: number, suggestedFindTag?: 'Steady Compounder' | 'Gold Mine' | 'Dip Discovery'): number {
   let mult: number;
   if (conv >= 10) mult = 1.5;
   else if (conv >= 9) mult = 1.25;
@@ -1886,6 +1890,7 @@ function convictionMultiplier(conv: number, suggestedFindTag?: 'Steady Compounde
   else if (conv >= 7) mult = 0.75;
   else mult = 0.5;
   if (suggestedFindTag === 'Gold Mine') mult = Math.min(mult, 1.25);
+  if (suggestedFindTag === 'Dip Discovery') mult = Math.min(mult, 1.0);
   return mult;
 }
 
@@ -1895,7 +1900,7 @@ function calculatePositionSize(
     price: number;
     mode: 'LONG_TERM' | 'DAY_TRADE' | 'SWING_TRADE' | 'OPTIONS_PUT' | 'OPTIONS_CALL';
     conviction?: number;
-    suggestedFindTag?: 'Steady Compounder' | 'Gold Mine';
+    suggestedFindTag?: 'Steady Compounder' | 'Gold Mine' | 'Dip Discovery';
     entryPrice?: number;
     stopLoss?: number;
     regimeMultiplier?: number;
@@ -1932,6 +1937,7 @@ function calculatePositionSize(
     // Compounders historically lose money on big positions (>$5K: 20% WR, -$928)
     // but are profitable on small ones (<=$5K: 78% WR, +$1,589). Hard-cap at $3K.
     if (suggestedFindTag === 'Steady Compounder') dollarSize = Math.min(dollarSize, 3000);
+    if (suggestedFindTag === 'Dip Discovery') dollarSize = Math.min(dollarSize, 5000);
   } else if (stopLoss && entryPrice && Math.abs(entryPrice - stopLoss) > 0) {
     const riskBudget = alloc * (config.riskPerTradePct / 100);
     const riskPerShare = Math.abs(entryPrice - stopLoss);
@@ -2811,6 +2817,8 @@ async function _executeSuggestedFindTradeInner(
   // Regime gate — Steady Compounders: SKIP entirely in a bear market (SPY < SMA200).
   // Buying long-term holds into a downtrend catches falling knives and produces the
   // worst outcomes. Only accumulate compounders when the macro trend is intact.
+  // Dip Discovery is EXEMPT — we explicitly want to buy quality stocks at deep discounts,
+  // which often happens during broad market downturns.
   if (stock.tag === 'Steady Compounder') {
     const bearMarket = await isSpyBelowSma200();
     if (bearMarket) {
@@ -2820,6 +2828,20 @@ async function _executeSuggestedFindTradeInner(
         skip_reason: 'bear_market_gate',
       });
       return 'skipped:bear_market';
+    }
+  }
+
+  // Dip Discovery: max 3 concurrent positions, max 1 per GICS sector
+  if (stock.tag === 'Dip Discovery') {
+    const { dipDiscoveryCount, dipDiscoverySectors } = await getLongTermExposureByTag();
+    if (dipDiscoveryCount >= 3) {
+      log(`${ticker}: Dip Discovery — already at max 3 concurrent positions, skipping`);
+      return 'skipped:dip_discovery_cap';
+    }
+    const sector = stock.sector ?? 'Unknown';
+    if (sector !== 'Unknown' && dipDiscoverySectors.has(sector)) {
+      log(`${ticker}: Dip Discovery — already have a position in ${sector} sector, skipping`);
+      return 'skipped:dip_discovery_sector_cap';
     }
   }
 
@@ -2878,7 +2900,7 @@ async function _executeSuggestedFindTradeInner(
   if (goldMineBelowSma200) log(`${ticker}: Gold Mine — SPY below SMA200, buying at 50% size`);
   const sizing = calculatePositionSize(config, {
     price: currentPrice, mode: 'LONG_TERM', conviction,
-    suggestedFindTag: (stock.tag === 'Gold Mine' || stock.tag === 'Steady Compounder') ? stock.tag : undefined,
+    suggestedFindTag: (stock.tag === 'Gold Mine' || stock.tag === 'Steady Compounder' || stock.tag === 'Dip Discovery') ? stock.tag as 'Gold Mine' | 'Steady Compounder' | 'Dip Discovery' : undefined,
     regimeMultiplier: sma200Multiplier,
     drawdownMultiplier: 1.0,
   });
@@ -2922,6 +2944,9 @@ async function _executeSuggestedFindTradeInner(
         stock.archetype ? `Archetype: ${stock.archetype}` : null,
         `Conviction: ${conviction}/10`,
         stock.valuationTag,
+        stock.tag === 'Dip Discovery' && stock.high52w ? `52wHigh: ${stock.high52w.toFixed(2)}` : null,
+        stock.tag === 'Dip Discovery' && stock.drawdownPct ? `Drawdown: ${stock.drawdownPct.toFixed(1)}%` : null,
+        stock.tag === 'Dip Discovery' && stock.sector ? `Sector: ${stock.sector}` : null,
       ].filter(Boolean).join(' | '),
       entry_trigger_type: 'market',
     });
@@ -4176,9 +4201,32 @@ async function checkLongTermAutoSell(
     const everAboveEntry = effectivePeak > entryPrice * 1.001;
 
     let reason: string | null = null;
-    const isGoldMine = /Gold Mine/i.test(`${trade.notes ?? ''} ${trade.scanner_reason ?? ''}`);
+    const tradeNotes = `${trade.notes ?? ''} ${trade.scanner_reason ?? ''}`;
+    const isGoldMine = /Gold Mine/i.test(tradeNotes);
+    const isDipDiscovery = /Dip Discovery/i.test(tradeNotes);
 
-    if (isGoldMine) {
+    if (isDipDiscovery) {
+      // ── Dip Discovery: mean-reversion exit rules ────────────────────────
+      // Take-profit = 40% recovery of the drawdown from 52-week high.
+      // Parse stored 52-week high from notes to compute the dynamic target.
+      const high52wMatch = tradeNotes.match(/52wHigh:\s*([\d.]+)/);
+      const high52w = high52wMatch ? parseFloat(high52wMatch[1]) : 0;
+
+      let dipTpPct = 20; // fallback: +20% from entry
+      if (high52w > 0 && entryPrice > 0 && high52w > entryPrice) {
+        const drawdownDollars = high52w - entryPrice;
+        const recoveryTarget = entryPrice + drawdownDollars * 0.40;
+        dipTpPct = ((recoveryTarget - entryPrice) / entryPrice) * 100;
+      }
+
+      if (gainPct >= dipTpPct) {
+        reason = `dd_profit_take:+${gainPct.toFixed(1)}%>=${dipTpPct.toFixed(1)}% (40% recovery)`;
+      } else if (gainPct <= -15) {
+        reason = `dd_stop_loss:${gainPct.toFixed(1)}%<=-15%`;
+      } else if (daysHeld >= 120) {
+        reason = `dd_max_hold:${daysHeld.toFixed(0)}d>=120d`;
+      }
+    } else if (isGoldMine) {
       // ── Gold Mine: archetype-specific exit rules ──────────────────────────
       const archetype = detectGoldMineArchetype(trade.notes ?? null, trade.scanner_reason ?? null);
       let rules = GM_ARCHETYPE_RULES[archetype];
@@ -4262,7 +4310,10 @@ async function checkLongTermAutoSell(
       });
 
       const emoji = gainPct >= 0 ? '✅' : '🛑';
-      const label = reason.startsWith('gm_profit_take') ? 'GM profit-take'
+      const label = reason.startsWith('dd_profit_take') ? 'Dip Discovery profit-take'
+        : reason.startsWith('dd_stop_loss')    ? 'Dip Discovery stop-loss'
+        : reason.startsWith('dd_max_hold')     ? 'Dip Discovery max-hold exit'
+        : reason.startsWith('gm_profit_take')  ? 'GM profit-take'
         : reason.startsWith('gm_entry_lock')   ? 'GM entry-lock exit'
         : reason.startsWith('gm_hard_stop')    ? 'GM hard stop (no bounce)'
         : reason.startsWith('gm_max_hold')     ? 'GM max-hold exit'
@@ -4725,14 +4776,17 @@ async function preGenerateSuggestedFinds(
       log('No cached Suggested Finds — generating server-side...');
       try {
         const result = await generateSuggestedFinds();
-        stocks = [...result.compounders, ...result.goldMines].map(s => ({
+        stocks = [...result.compounders, ...result.goldMines, ...(result.dipDiscoveries ?? [])].map(s => ({
           ticker: s.ticker,
           conviction: s.conviction ?? 0,
           valuationTag: s.valuationTag ?? '',
           tag: s.tag,
           reason: s.reason,
+          high52w: s.high52w,
+          drawdownPct: s.drawdownPct,
+          sector: s.sector,
         }));
-        log(`Generated ${stocks.length} Suggested Finds (${result.compounders.length} compounders, ${result.goldMines.length} gold mines)`);
+        log(`Generated ${stocks.length} Suggested Finds (${result.compounders.length} compounders, ${result.goldMines.length} gold mines, ${(result.dipDiscoveries ?? []).length} dip discoveries)`);
       } catch (genErr) {
         log(`Server-side discovery failed: ${genErr instanceof Error ? genErr.message : 'unknown'}`);
         _lastSuggestedFindsDate = today; // Don't retry — avoid exhausting AI keys
@@ -4768,6 +4822,7 @@ async function preGenerateSuggestedFinds(
         if (conv < minConv) return false;
         if (seenTickers.has(s.ticker)) return false;
         seenTickers.add(s.ticker);
+        if (s.tag === 'Dip Discovery') return true;
         if (topTickers.has(s.ticker)) return true;
         const tag = (s.valuationTag ?? '').toLowerCase();
         return tag === 'deep value' || tag === 'undervalued';

--- a/docs/cursor/2026-05-05-dip-discovery-strategy.md
+++ b/docs/cursor/2026-05-05-dip-discovery-strategy.md
@@ -1,0 +1,46 @@
+# Dip Discovery — Suggested Finds Category
+
+**Date:** 2026-05-05
+**Status:** Implementing
+
+## Goal
+
+Add a "Dip Discovery" category to Suggested Finds that buys quality blue-chip stocks (S&P 500 / Fortune 500) when they've dropped 30-50% from their 52-week high and show signs of stabilization. This targets mean-reversion on proven companies at deep discounts.
+
+## Why
+
+Current Suggested Finds BUYs (Compounders + Gold Mines) have 0-19% win rates — they pick "good companies" at whatever price. Dip Discovery flips the model: buy *known* quality at a *proven discount*. The system's SELL signals (100% WR) prove it can time reversals; Dip Discovery is the mirror image.
+
+## Entry Criteria
+
+- **Universe:** S&P 500 member, market cap > $10B, trailing 12-month EPS > 0, avg daily volume > $50M notional
+- **Drawdown:** -30% to -50% from 52-week high
+- **Stabilization:** Price above 10-day SMA (confirms bleeding has stopped)
+- **Timeframe:** Drop occurred within 4-16 weeks (sharp drawdown, not slow bleed)
+- **Catalyst check:** AI reviews *why* it dipped — skip if structural (fraud, secular disruption, junk downgrade); buy if temporary (earnings miss with intact guidance, sector rotation, macro selloff)
+
+## Position Sizing
+
+- Standard: $3,000-$5,000
+- Max 3 concurrent Dip Discovery positions
+- Max 1 per GICS sector
+
+## Exit Rules
+
+- **Take-profit:** 40% recovery of the drawdown (e.g., drops from $100 → $60, TP at $76)
+- **Stop-loss:** -15% from entry price
+- **Max hold:** 120 calendar days
+- Risk/reward: risking ~$450-750 to make ~$480-800 per trade
+
+## Architecture (per Winston)
+
+- New tag `"Dip Discovery"` flows through existing `executeSuggestedFindTrade()` pipeline
+- Own allocation bucket (separate from Compounders and Gold Mines)
+- Exit rules parameterized per category in the long-term auto-sell loop
+- Universe filter + drawdown calculation is the new scanner logic
+
+## Key Decisions
+
+- 30-50% drawdown range (user preference — more conservative than the 15-35% institutional default)
+- Sits alongside existing categories, not replacing them
+- AI catalyst check distinguishes "overreaction" from "broken company"

--- a/supabase/functions/huggingface-proxy/index.ts
+++ b/supabase/functions/huggingface-proxy/index.ts
@@ -20,7 +20,7 @@ const GROQ_MODELS = [
 
 interface RequestPayload {
   prompt: string;
-  type: 'discover_compounders' | 'discover_goldmines' | 'analyze_themes';
+  type: 'discover_compounders' | 'discover_goldmines' | 'discover_dips' | 'analyze_themes';
   temperature?: number;
   maxOutputTokens?: number;
 }
@@ -50,7 +50,7 @@ Deno.serve(async (req) => {
       );
     }
 
-    const validTypes = ['discover_compounders', 'discover_goldmines', 'analyze_themes'];
+    const validTypes = ['discover_compounders', 'discover_goldmines', 'discover_dips', 'analyze_themes'];
     if (!validTypes.includes(type)) {
       return new Response(
         JSON.stringify({ error: `Invalid type. Must be one of: ${validTypes.join(', ')}` }),


### PR DESCRIPTION
## Summary
- Adds a new **"Dip Discovery"** category to the Suggested Finds pipeline, targeting S&P 500 / Fortune 500 stocks that have dropped 30-50% from their 52-week high
- AI identifies candidates → Finnhub verifies drawdown, market cap, EPS → 10-day SMA checks stabilization → AI catalyst check filters structural vs temporary dips
- Custom exit rules: 40% drawdown recovery take-profit, -15% stop-loss, 120-day max hold
- Position limits: $3-5K per position, max 3 concurrent, max 1 per GICS sector
- Bear market exempt — buying deep discounts on proven companies is the strategy

## Test plan
- [x] `npx tsc --noEmit` passes for both auto-trader and app
- [x] `npm run build` passes for app
- [x] Auto-trader rebuilt and restarted
- [x] HuggingFace proxy edge function deployed with `discover_dips` type
- [ ] Monitor next trading day for Dip Discovery candidates in auto-trader logs
- [ ] Verify sector/position limits prevent over-allocation


Made with [Cursor](https://cursor.com)