### PR TITLE
feat: add Dip Discovery UI section and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AI-powered stock signals — skip the noise, catch the plays.
 |---|---|
 | **My Portfolio** `/` | Conviction scoring (0-100), AI BUY/SELL signals, risk profiles, brokerage sync (SnapTrade), CSV import, news, daily P&L |
 | **Trade Signals** `/signals` | AI scanner finds day/swing setups → full analysis with indicators, scenarios, dual targets, charts, long-term outlook |
-| **Suggested Finds** `/finds` | Quiet Compounders (quality + valuation ranked) and Gold Mines (macro-theme opportunities) discovered daily by AI, with "Owned" badge for stocks in portfolio |
+| **Suggested Finds** `/finds` | Dip Discovery (blue-chip stocks 30-50% off 52w high), Quiet Compounders (quality + valuation ranked), and Gold Mines (macro-theme opportunities) discovered daily by AI, with "Owned" badge for stocks in portfolio |
 | **Paper Trading** `/paper-trading` | Auto-executes high-confidence signals on IB paper account, tracks P&L, AI learns from outcomes |
 | **Market Movers** `/movers` | Top 25 gainers/losers from Yahoo Finance |
 
@@ -36,6 +36,7 @@ AI-powered stock signals — skip the noise, catch the plays.
 
 ### Suggested Finds
 
+- **Dip Discovery** — Fortune 500 / S&P 500 stocks down 30-50% from 52-week high, verified with Finnhub data, AI catalyst check filters out structural damage. Position size $3-5K, max 3 concurrent, max 1 per sector. Exit: 40% drawdown recovery TP, -15% stop, 120-day max hold
 - **Quiet Compounders** — Quality stocks ranked by conviction (1-10), valuation tags (Deep Value → Fully Valued), filterable by industry
 - **Gold Mines** — Macro-theme-driven opportunities across the value chain, with conviction scores and valuation tags
 - **Top Pick** badge on highest-conviction stock per category
@@ -106,6 +107,7 @@ Browser (React 19 · Vite 7 · TypeScript 5.9 · Tailwind CSS 4)
 | Trade Signals | Gemini (rotated) | Full analysis: indicators, scenarios, targets, long-term outlook |
 | Quiet Compounders | HuggingFace (Qwen2.5-72B) | Discover quality stocks, rank by conviction + valuation |
 | Gold Mines | HuggingFace (Qwen2.5-72B) | Macro-theme opportunities from news + fundamentals |
+| Dip Discovery | HuggingFace + Finnhub | Blue-chip dip-buying: AI candidates → drawdown verification → catalyst check |
 | Paper Trading | Gemini (via scanner + FA) | Auto-execute signals → IB bracket orders |
 | AI Feedback Loop | Heuristic | Analyze trade outcomes → pattern recognition |
 
@@ -176,6 +178,7 @@ npm run lint     # ESLint
 | [`docs/INSTAGRAM-STRATEGY-ARCHITECTURE.md`](docs/INSTAGRAM-STRATEGY-ARCHITECTURE.md) | External strategy signals from videos |
 | [`supabase/functions/README.md`](supabase/functions/README.md) | Edge functions, prompts, API keys |
 | [`auto-trader/README.md`](auto-trader/README.md) | IB Gateway setup, scheduler |
+| [`docs/cursor/2026-05-05-dip-discovery-strategy.md`](docs/cursor/2026-05-05-dip-discovery-strategy.md) | Dip Discovery strategy design (entry, sizing, exits) |
 
 ## Commit Conventions
 

--- a/app/src/components/SuggestedFinds.tsx
+++ b/app/src/components/SuggestedFinds.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import {
   TrendingUp,
+  TrendingDown,
   Gem,
   ChevronDown,
   ChevronUp,
@@ -30,6 +31,7 @@ export function SuggestedFinds({ existingTickers }: SuggestedFindsProps) {
     displayedCompounders,
     goldMines,
     displayedGoldMines,
+    dipDiscoveries,
     currentTheme,
     isLoading,
     error,
@@ -264,6 +266,38 @@ export function SuggestedFinds({ existingTickers }: SuggestedFindsProps) {
             : `Auto-buy enabled — conviction ${getAutoTraderConfig().minSuggestedFindsConviction}+ Undervalued/Deep Value + all Top Picks`
           }
         </div>
+      )}
+
+      {/* Dip Discovery — blue-chip stocks buying the dip */}
+      {dipDiscoveries.length > 0 && (
+        <section>
+          <div className="flex items-center gap-3 mb-3">
+            <div className="p-2 rounded-lg bg-indigo-50">
+              <TrendingDown className="w-4 h-4 text-indigo-600" />
+            </div>
+            <div className="flex-1">
+              <div className="flex items-center gap-2">
+                <h3 className="font-semibold text-[hsl(var(--foreground))]">Dip Discovery</h3>
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-600 text-[10px] font-medium">
+                  Blue-Chip Dips
+                </span>
+              </div>
+              <p className="text-sm text-[hsl(var(--muted-foreground))]">
+                Fortune 500 stocks down 30-50% from 52-week highs — buying quality on sale
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {dipDiscoveries.map((stock) => (
+              <DipDiscoveryCard
+                key={stock.ticker}
+                stock={stock}
+                isOwned={ownedTickers.has(stock.ticker)}
+              />
+            ))}
+          </div>
+        </section>
       )}
 
       {/* Steady Compounders */}
@@ -653,6 +687,131 @@ function ValuationPill({ tag }: { tag: string }) {
     <span className={cn('text-[10px] px-2 py-0.5 rounded-full font-medium', style)}>
       {tag}
     </span>
+  );
+}
+
+// ──────────────────────────────────────────────────────────
+// Dip Discovery card — shows drawdown & recovery target
+// ──────────────────────────────────────────────────────────
+
+function DipDiscoveryCard({ stock, isOwned }: { stock: EnhancedSuggestedStock; isOwned?: boolean }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const drawdown = (stock as unknown as Record<string, unknown>).drawdownPct as number | undefined;
+  const high52w = (stock as unknown as Record<string, unknown>).high52w as number | undefined;
+  const sector = (stock as unknown as Record<string, unknown>).sector as string | undefined;
+
+  return (
+    <div
+      className={cn(
+        'bg-white rounded-2xl border border-[hsl(var(--border))] p-5 transition-all shadow-sm relative',
+        'hover:border-indigo-200',
+        isExpanded && 'shadow-md'
+      )}
+    >
+      {isOwned && (
+        <div className="absolute -top-2.5 left-4 inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-500 text-white text-[10px] font-semibold shadow-sm">
+          <CheckCircle2 className="w-3 h-3" />
+          Owned
+        </div>
+      )}
+
+      <div className="flex items-start justify-between mb-2">
+        <TickerLabel ticker={stock.ticker} name={stock.name} />
+        {stock.conviction != null && <ConvictionBadge score={stock.conviction} />}
+      </div>
+
+      {/* Drawdown + sector badges */}
+      <div className="flex flex-wrap gap-1.5 mb-2">
+        {drawdown != null && (
+          <span className="text-[10px] px-2 py-0.5 rounded-full font-medium bg-red-50 text-red-700">
+            {drawdown.toFixed(0)}% off 52w high
+          </span>
+        )}
+        {sector && (
+          <span className="text-[10px] px-2 py-0.5 rounded-full font-medium bg-indigo-50 text-indigo-700">
+            {sector}
+          </span>
+        )}
+      </div>
+
+      {stock.valuationTag && (
+        <div className="flex flex-wrap gap-1 mb-2">
+          <ValuationPill tag={stock.valuationTag} />
+        </div>
+      )}
+
+      <p className="text-sm text-[hsl(var(--muted-foreground))] leading-relaxed mb-3">
+        {stock.reason}
+      </p>
+
+      {/* Key metrics */}
+      <div className="flex flex-wrap gap-1.5 mb-3">
+        {high52w != null && (
+          <span className="text-[11px] px-2 py-0.5 bg-[hsl(var(--secondary))] rounded-full">
+            <span className="text-[hsl(var(--muted-foreground))]">52w High:</span>{' '}
+            <span className="font-semibold text-[hsl(var(--foreground))]">${high52w.toFixed(2)}</span>
+          </span>
+        )}
+        {stock.metrics?.slice(0, 2).map((metric) => (
+          <span
+            key={metric.label}
+            className="text-[11px] px-2 py-0.5 bg-[hsl(var(--secondary))] rounded-full"
+          >
+            <span className="text-[hsl(var(--muted-foreground))]">{metric.label}:</span>{' '}
+            <span className="font-semibold text-[hsl(var(--foreground))]">{metric.value}</span>
+          </span>
+        ))}
+      </div>
+
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="text-xs text-[hsl(var(--muted-foreground))] hover:text-[hsl(var(--foreground))] flex items-center gap-1 transition-colors"
+      >
+        {isExpanded ? (
+          <>
+            <ChevronUp className="w-3.5 h-3.5" />
+            Less
+          </>
+        ) : (
+          <>
+            <ChevronDown className="w-3.5 h-3.5" />
+            Why this dip?
+          </>
+        )}
+      </button>
+
+      {isExpanded && (
+        <div className="mt-3 pt-3 border-t border-[hsl(var(--border))]">
+          {stock.metrics && stock.metrics.length > 2 && (
+            <div className="flex flex-wrap gap-1.5 mb-3">
+              {stock.metrics.slice(2).map((metric) => (
+                <span
+                  key={metric.label}
+                  className="text-[11px] px-2 py-0.5 bg-[hsl(var(--secondary))] rounded-full"
+                >
+                  <span className="text-[hsl(var(--muted-foreground))]">{metric.label}:</span>{' '}
+                  <span className="font-semibold text-[hsl(var(--foreground))]">{metric.value}</span>
+                </span>
+              ))}
+            </div>
+          )}
+
+          <ul className="space-y-1.5">
+            {stock.whyGreat.map((point, index) => (
+              <li key={index} className="flex items-start gap-2 text-sm">
+                <span className="mt-1.5 w-1.5 h-1.5 rounded-full flex-shrink-0 bg-indigo-500" />
+                <span className="text-[hsl(var(--muted-foreground))]">{point}</span>
+              </li>
+            ))}
+          </ul>
+
+          <p className="text-[10px] text-[hsl(var(--muted-foreground))]/50 mt-3 flex items-center gap-1">
+            <Sparkles className="w-2.5 h-2.5" />
+            AI-generated insight — verify before investing
+          </p>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/app/src/hooks/useSuggestedFinds.ts
+++ b/app/src/hooks/useSuggestedFinds.ts
@@ -38,6 +38,7 @@ export interface UseSuggestedFindsResult {
   displayedCompounders: EnhancedSuggestedStock[];
   goldMines: EnhancedSuggestedStock[];
   displayedGoldMines: EnhancedSuggestedStock[];
+  dipDiscoveries: EnhancedSuggestedStock[];
   currentTheme: ThemeData | null;
   isLoading: boolean;
   error: string | null;
@@ -66,6 +67,7 @@ export interface UseSuggestedFindsResult {
 export function useSuggestedFinds(existingTickers: string[]): UseSuggestedFindsResult {
   const [compounders, setCompounders] = useState<EnhancedSuggestedStock[]>([]);
   const [goldMines, setGoldMines] = useState<EnhancedSuggestedStock[]>([]);
+  const [dipDiscoveries, setDipDiscoveries] = useState<EnhancedSuggestedStock[]>([]);
   const [currentTheme, setCurrentTheme] = useState<ThemeData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -93,6 +95,7 @@ export function useSuggestedFinds(existingTickers: string[]): UseSuggestedFindsR
   const applyResult = useCallback((result: DiscoveryResult) => {
     setCompounders(result.compounders);
     setGoldMines(result.goldMines);
+    setDipDiscoveries(result.dipDiscoveries ?? []);
     setCurrentTheme(result.currentTheme);
     setLastUpdated(result.timestamp);
     setError(null);
@@ -253,6 +256,7 @@ export function useSuggestedFinds(existingTickers: string[]): UseSuggestedFindsR
     displayedCompounders,
     goldMines,
     displayedGoldMines,
+    dipDiscoveries,
     currentTheme,
     isLoading,
     error,

--- a/app/src/lib/aiSuggestedFinds.ts
+++ b/app/src/lib/aiSuggestedFinds.ts
@@ -42,6 +42,7 @@ export interface ThemeData {
 export interface DiscoveryResult {
   compounders: EnhancedSuggestedStock[];
   goldMines: EnhancedSuggestedStock[];
+  dipDiscoveries?: EnhancedSuggestedStock[];
   currentTheme: ThemeData;
   timestamp: string;
 }

--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -872,7 +872,7 @@ async function checkAllocationCap(
 /** Conviction multiplier for long-term holds.
  *  Gold Mine: capped at 1.25x (even if conviction = 10).
  *  Steady Compounder: full multiplier up to 1.5x. */
-function convictionMultiplier(conviction: number, suggestedFindTag?: 'Steady Compounder' | 'Gold Mine'): number {
+function convictionMultiplier(conviction: number, suggestedFindTag?: 'Steady Compounder' | 'Gold Mine' | 'Dip Discovery'): number {
   let mult: number;
   if (conviction >= 10) mult = 1.5;
   else if (conviction >= 9) mult = 1.25;
@@ -890,7 +890,7 @@ export function calculatePositionSize(
     price: number;
     mode: 'LONG_TERM' | 'DAY_TRADE' | 'SWING_TRADE';
     conviction?: number;      // for long-term holds
-    suggestedFindTag?: 'Steady Compounder' | 'Gold Mine';  // for LONG_TERM: Gold Mine → 0.75x final (after conviction)
+    suggestedFindTag?: 'Steady Compounder' | 'Gold Mine' | 'Dip Discovery';
     entryPrice?: number;      // for scanner trades
     stopLoss?: number;        // for scanner trades (risk-based sizing)
     regimeMultiplier?: number; // from market regime check

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -81,7 +81,7 @@ export interface ConvictionResult {
 export interface SuggestedStock {
   ticker: string;
   name: string;
-  tag: 'Steady Compounder' | 'Gold Mine';
+  tag: 'Steady Compounder' | 'Gold Mine' | 'Dip Discovery';
   reason: string;
   /** Gold Mine only — macro theme category driving exit rule selection */
   archetype?: 'Tech/Semi' | 'Defense' | 'Energy' | 'Financials';

--- a/docs/cursor/2026-05-05-dip-discovery-strategy.md
+++ b/docs/cursor/2026-05-05-dip-discovery-strategy.md
@@ -1,7 +1,7 @@
 # Dip Discovery — Suggested Finds Category
 
 **Date:** 2026-05-05
-**Status:** Implementing
+**Status:** Shipped
 
 ## Goal
 
@@ -44,3 +44,16 @@ Current Suggested Finds BUYs (Compounders + Gold Mines) have 0-19% win rates —
 - 30-50% drawdown range (user preference — more conservative than the 15-35% institutional default)
 - Sits alongside existing categories, not replacing them
 - AI catalyst check distinguishes "overreaction" from "broken company"
+
+## Files Changed
+
+| File | What |
+|---|---|
+| `auto-trader/src/lib/discovery.ts` | New `discoverDipStocks()` pipeline: AI candidates → Finnhub drawdown verify → SMA stabilization → AI catalyst check |
+| `auto-trader/src/lib/supabase.ts` | `getLongTermExposureByTag()` tracks Dip Discovery exposure, count, and sector set |
+| `auto-trader/src/scheduler.ts` | Dip Discovery integration: fetching, position sizing ($5K cap), allocation gates (max 3, max 1/sector), custom exit rules (40% recovery TP, -15% SL, 120-day max hold) |
+| `supabase/functions/huggingface-proxy/index.ts` | Added `discover_dips` to valid prompt types |
+| `app/src/types/index.ts` | `SuggestedStock.tag` includes `'Dip Discovery'` |
+| `app/src/lib/aiSuggestedFinds.ts` | `DiscoveryResult.dipDiscoveries` field |
+| `app/src/hooks/useSuggestedFinds.ts` | Exposes `dipDiscoveries` state from hook |
+| `app/src/components/SuggestedFinds.tsx` | Dip Discovery section (top of page) with `DipDiscoveryCard` showing drawdown, sector, 52w high |

--- a/supabase/functions/README.md
+++ b/supabase/functions/README.md
@@ -115,7 +115,10 @@ Updates `strategy_type` or source on an existing `strategy_videos` row.
 ### Other Functions
 
 #### `daily-suggestions`
-Long-term AI stock suggestions (Quiet Compounders / Gold Mines). Uses HuggingFace.
+Long-term AI stock suggestions (Dip Discovery / Quiet Compounders / Gold Mines). Uses HuggingFace + Finnhub.
+
+#### `huggingface-proxy`
+Secure HuggingFace/Groq proxy. Supports `discover_dips` type for the Dip Discovery pipeline alongside existing compounders/gold-mines prompts.
 
 #### `fetch-yahoo-news` / `scrape-market-movers`
 News and market movers data.


### PR DESCRIPTION
## Summary
- Adds **Dip Discovery** section to the top of the Suggested Finds page with a custom `DipDiscoveryCard` showing drawdown %, sector badge, and 52-week high
- Wires `dipDiscoveries` through the frontend: types → `DiscoveryResult` → `useSuggestedFinds` hook → component
- Fixes `suggestedFindTag` type in `autoTrader.ts` to include `'Dip Discovery'`
- Updates README, supabase functions README, and strategy planning doc

## Test plan
- [ ] Open Suggested Finds tab — Dip Discovery section should appear at the top (when data exists)
- [ ] Cards show drawdown %, sector, 52w high, conviction, and expand with thesis
- [ ] Steady Compounders and Gold Mines sections still render correctly below
- [ ] Build passes (`npm run build`)


Made with [Cursor](https://cursor.com)