### PR TITLE
fix: filter Gold Mines below conviction 7 from display

### DIFF
--- a/app/src/hooks/useSuggestedFinds.ts
+++ b/app/src/hooks/useSuggestedFinds.ts
@@ -205,14 +205,19 @@ export function useSuggestedFinds(existingTickers: string[]): UseSuggestedFindsR
   // - Category selected + focused results exist: show focused results
   // - Category selected + no focused results: filter main gold mines by category
   const displayedGoldMines = useMemo(() => {
-    if (!selectedGoldMineCategory) return goldMines;
-    if (goldMineCategoryStocks.length > 0) return goldMineCategoryStocks;
-
-    const catLower = selectedGoldMineCategory.toLowerCase();
-    return goldMines.filter((s) =>
-      s.category?.toLowerCase().includes(catLower) ||
-      catLower.includes(s.category?.toLowerCase() ?? '')
-    );
+    const minConviction = 7;
+    const base = !selectedGoldMineCategory
+      ? goldMines
+      : goldMineCategoryStocks.length > 0
+        ? goldMineCategoryStocks
+        : (() => {
+            const catLower = selectedGoldMineCategory.toLowerCase();
+            return goldMines.filter((s) =>
+              s.category?.toLowerCase().includes(catLower) ||
+              catLower.includes(s.category?.toLowerCase() ?? '')
+            );
+          })();
+    return base.filter((s) => (s.conviction ?? 0) >= minConviction);
   }, [selectedGoldMineCategory, goldMines, goldMineCategoryStocks]);
 
   // Compute displayed compounders:


### PR DESCRIPTION
## Summary
- Filters out Gold Mine stocks with conviction below 7 from the Suggested Finds display
- Stocks like MATX (6) and NUE (5) were cluttering the Gold Mines section with low-confidence picks
- Matches the auto-trade conviction threshold (7+)

## Test plan
- [ ] Gold Mines section only shows conviction 7+ stocks
- [ ] Category-filtered and category-discovered Gold Mines also respect the 7+ floor


Made with [Cursor](https://cursor.com)