### PR TITLE
fix: prevent IB contract lookup failures from blocking trade execution

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -16,6 +16,7 @@ const IB_CLIENT_ID = parseInt(process.env.IB_CLIENT_ID ?? '1', 10);
 
 const RECONNECT_BASE_MS = 2_000;
 const RECONNECT_MAX_MS = 60_000;
+const MAX_CONCURRENT_REQUESTS = 8;
 
 // ── State ────────────────────────────────────────────────
 
@@ -26,6 +27,38 @@ let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let accounts: string[] = [];
 let nextOrderId = 0;
 let connectionListeners: Array<(state: boolean) => void> = [];
+
+// Per-request error routing: when IB sends error code 200 for a specific reqId,
+// resolve the pending promise immediately instead of waiting for timeout.
+const _pendingReqCallbacks = new Map<number, (code: number, msg: string) => void>();
+
+// Semaphore to limit concurrent IB API requests and prevent flooding
+let _activeRequests = 0;
+const _requestQueue: Array<() => void> = [];
+
+export async function acquireRequestSlot(): Promise<void> {
+  if (_activeRequests < MAX_CONCURRENT_REQUESTS) {
+    _activeRequests++;
+    return;
+  }
+  return new Promise<void>(resolve => {
+    _requestQueue.push(() => { _activeRequests++; resolve(); });
+  });
+}
+
+export function releaseRequestSlot(): void {
+  _activeRequests--;
+  const next = _requestQueue.shift();
+  if (next) next();
+}
+
+export function registerReqErrorCallback(reqId: number, cb: (code: number, msg: string) => void): void {
+  _pendingReqCallbacks.set(reqId, cb);
+}
+
+export function unregisterReqErrorCallback(reqId: number): void {
+  _pendingReqCallbacks.delete(reqId);
+}
 
 // ── Public API ───────────────────────────────────────────
 
@@ -95,6 +128,15 @@ export function connect(): void {
       return;
     }
 
+    // Route per-request errors (e.g. code 200 "No security definition") to the
+    // waiting promise so it resolves immediately instead of waiting for timeout.
+    if (reqId != null && code != null && _pendingReqCallbacks.has(reqId)) {
+      const cb = _pendingReqCallbacks.get(reqId)!;
+      _pendingReqCallbacks.delete(reqId);
+      cb(code, err.message);
+      return;
+    }
+
     console.error(`[IB] Error (code=${code}, reqId=${reqId}): ${err.message}`);
 
     if (code === 1100) {
@@ -159,51 +201,76 @@ export interface ContractSearchResult {
   description: string;
 }
 
-export function searchContract(symbol: string): Promise<ContractSearchResult | null> {
-  return new Promise((resolve, reject) => {
-    if (!ib || !connected) {
-      return reject(new Error('Not connected to IB Gateway'));
-    }
+export async function searchContract(symbol: string): Promise<ContractSearchResult | null> {
+  if (!ib || !connected) {
+    throw new Error('Not connected to IB Gateway');
+  }
 
-    const reqId = getNextOrderId();
-    const contract = createStockContract(symbol);
-    let resolved = false;
+  await acquireRequestSlot();
+  try {
+    return await new Promise<ContractSearchResult | null>((resolve) => {
+      const reqId = getNextOrderId();
+      // Use empty exchange for contract detail lookups — SMART is a routing strategy
+      // and reqContractDetails can return empty results when exchange is set to SMART.
+      const contract: Contract = {
+        symbol: symbol.toUpperCase(),
+        secType: SecType.STK,
+        currency: 'USD',
+      };
+      let resolved = false;
 
-    const timeout = setTimeout(() => {
-      if (!resolved) {
+      const cleanup = () => {
+        unregisterReqErrorCallback(reqId);
+      };
+
+      const timeout = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          cleanup();
+          resolve(null);
+        }
+      }, 10_000);
+
+      // Register per-request error handler (e.g. code 200 = no security definition)
+      registerReqErrorCallback(reqId, (_code: number, _msg: string) => {
+        if (resolved) return;
         resolved = true;
+        clearTimeout(timeout);
         resolve(null);
-      }
-    }, 10_000);
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const emitter = ib as any;
-
-    // Use reqContractDetails to get full contract info including conId
-    emitter.on(EventName.contractDetails, (rId: number, details: { contract: { conId?: number; symbol?: string; secType?: string; primaryExch?: string; currency?: string }; longName?: string }) => {
-      if (rId !== reqId || resolved) return;
-      resolved = true;
-      clearTimeout(timeout);
-
-      resolve({
-        conId: details.contract.conId ?? 0,
-        symbol: details.contract.symbol ?? symbol,
-        secType: details.contract.secType ?? 'STK',
-        primaryExch: details.contract.primaryExch ?? '',
-        currency: details.contract.currency ?? 'USD',
-        description: details.longName ?? '',
       });
-    });
 
-    emitter.on(EventName.contractDetailsEnd, (rId: number) => {
-      if (rId !== reqId || resolved) return;
-      resolved = true;
-      clearTimeout(timeout);
-      resolve(null);
-    });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const emitter = ib as any;
 
-    ib.reqContractDetails(reqId, contract);
-  });
+      emitter.on(EventName.contractDetails, (rId: number, details: { contract: { conId?: number; symbol?: string; secType?: string; primaryExch?: string; currency?: string }; longName?: string }) => {
+        if (rId !== reqId || resolved) return;
+        resolved = true;
+        clearTimeout(timeout);
+        cleanup();
+
+        resolve({
+          conId: details.contract.conId ?? 0,
+          symbol: details.contract.symbol ?? symbol,
+          secType: details.contract.secType ?? 'STK',
+          primaryExch: details.contract.primaryExch ?? '',
+          currency: details.contract.currency ?? 'USD',
+          description: details.longName ?? '',
+        });
+      });
+
+      emitter.on(EventName.contractDetailsEnd, (rId: number) => {
+        if (rId !== reqId || resolved) return;
+        resolved = true;
+        clearTimeout(timeout);
+        cleanup();
+        resolve(null);
+      });
+
+      ib!.reqContractDetails(reqId, contract);
+    });
+  } finally {
+    releaseRequestSlot();
+  }
 }
 
 // ── Place Bracket Order ──────────────────────────────────

--- a/auto-trader/src/lib/options-chain.ts
+++ b/auto-trader/src/lib/options-chain.ts
@@ -12,7 +12,7 @@
  */
 
 import { EventName, SecType, OptionType, type Contract } from '@stoqey/ib';
-import { getIBApi, getNextOrderId, isConnected, searchContract } from '../ib-connection.js';
+import { getIBApi, getNextOrderId, isConnected, searchContract, acquireRequestSlot, releaseRequestSlot, registerReqErrorCallback, unregisterReqErrorCallback } from '../ib-connection.js';
 import { estimateHistoricalVol } from './yahoo-finance.js';
 
 // ── Types ────────────────────────────────────────────────
@@ -223,168 +223,175 @@ interface OptionParams {
   tradingClass: string;
 }
 
-function getOptionChainParams(conId: number, symbol: string): Promise<OptionParams | null> {
-  return new Promise((resolve) => {
-    const ib = getIBApi();
-    if (!ib || !isConnected()) return resolve(null);
+async function getOptionChainParams(conId: number, symbol: string): Promise<OptionParams | null> {
+  const ib = getIBApi();
+  if (!ib || !isConnected()) return null;
 
-    const reqId = getNextOrderId();
-    const emitter = ib as unknown as NodeJS.EventEmitter;
-    let resolved = false;
-    const allParams: OptionParams[] = [];
+  await acquireRequestSlot();
+  try {
+    return await new Promise<OptionParams | null>((resolve) => {
+      const reqId = getNextOrderId();
+      const emitter = ib as unknown as NodeJS.EventEmitter;
+      let resolved = false;
+      const allParams: OptionParams[] = [];
 
-    const timeout = setTimeout(() => {
-      if (!resolved) { resolved = true; emitter.off(EventName.securityDefinitionOptionParameter, paramHandler); emitter.off(EventName.securityDefinitionOptionParameterEnd, endHandler); resolve(allParams[0] ?? null); }
-    }, 15_000);
+      const finish = (result: OptionParams | null) => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timeout);
+        unregisterReqErrorCallback(reqId);
+        emitter.off(EventName.securityDefinitionOptionParameter, paramHandler);
+        emitter.off(EventName.securityDefinitionOptionParameterEnd, endHandler);
+        resolve(result);
+      };
 
-    const paramHandler = (rId: number, exchange: string, _conId: number, tradingClass: string, multiplier: string, expirations: string[], strikes: number[]) => {
-      if (rId !== reqId) return;
-      // Prefer SMART exchange data
-      if (exchange === 'SMART' || allParams.length === 0) {
-        allParams.unshift({ expirations: Array.from(expirations).sort(), strikes: Array.from(strikes).sort((a, b) => a - b), multiplier, tradingClass });
-      } else {
-        allParams.push({ expirations: Array.from(expirations).sort(), strikes: Array.from(strikes).sort((a, b) => a - b), multiplier, tradingClass });
-      }
-    };
+      const timeout = setTimeout(() => finish(allParams[0] ?? null), 15_000);
 
-    const endHandler = (rId: number) => {
-      if (rId !== reqId || resolved) return;
-      resolved = true;
-      clearTimeout(timeout);
-      emitter.off(EventName.securityDefinitionOptionParameter, paramHandler);
-      emitter.off(EventName.securityDefinitionOptionParameterEnd, endHandler);
-      resolve(allParams[0] ?? null);
-    };
+      registerReqErrorCallback(reqId, () => finish(null));
 
-    emitter.on(EventName.securityDefinitionOptionParameter, paramHandler);
-    emitter.on(EventName.securityDefinitionOptionParameterEnd, endHandler);
+      const paramHandler = (rId: number, exchange: string, _conId: number, tradingClass: string, multiplier: string, expirations: string[], strikes: number[]) => {
+        if (rId !== reqId) return;
+        if (exchange === 'SMART' || allParams.length === 0) {
+          allParams.unshift({ expirations: Array.from(expirations).sort(), strikes: Array.from(strikes).sort((a, b) => a - b), multiplier, tradingClass });
+        } else {
+          allParams.push({ expirations: Array.from(expirations).sort(), strikes: Array.from(strikes).sort((a, b) => a - b), multiplier, tradingClass });
+        }
+      };
 
-    (ib as unknown as { reqSecDefOptParams: (reqId: number, symbol: string, exchange: string, secType: string, conId: number) => void })
-      .reqSecDefOptParams(reqId, symbol.toUpperCase(), '', 'STK', conId);
-  });
+      const endHandler = (rId: number) => {
+        if (rId !== reqId || resolved) return;
+        finish(allParams[0] ?? null);
+      };
+
+      emitter.on(EventName.securityDefinitionOptionParameter, paramHandler);
+      emitter.on(EventName.securityDefinitionOptionParameterEnd, endHandler);
+
+      (ib as unknown as { reqSecDefOptParams: (reqId: number, symbol: string, exchange: string, secType: string, conId: number) => void })
+        .reqSecDefOptParams(reqId, symbol.toUpperCase(), '', 'STK', conId);
+    });
+  } finally {
+    releaseRequestSlot();
+  }
 }
 
 // ── Get Greeks for a Specific Option Contract ─────────────
 
-function getOptionGreeksForContract(
+async function getOptionGreeksForContract(
   symbol: string,
   strike: number,
   expiry: string,
   optionType: 'P' | 'C',
   underlyingPrice: number,
 ): Promise<OptionGreeks | null> {
-  return new Promise((resolve) => {
-    const ib = getIBApi();
-    if (!ib || !isConnected()) return resolve(null);
+  const ib = getIBApi();
+  if (!ib || !isConnected()) return null;
 
-    const reqId = getNextOrderId();
-    const emitter = ib as unknown as NodeJS.EventEmitter;
-    let resolved = false;
-    let bidPrice = -1, askPrice = -1;
-    let impliedVol = 0, delta = 0, theta = 0, gamma = 0, vega = 0;
+  await acquireRequestSlot();
+  try {
+    return await new Promise<OptionGreeks | null>((resolve) => {
+      const reqId = getNextOrderId();
+      const emitter = ib as unknown as NodeJS.EventEmitter;
+      let resolved = false;
+      let bidPrice = -1, askPrice = -1;
+      let impliedVol = 0, delta = 0, theta = 0, gamma = 0, vega = 0;
 
-    const contract: Contract = {
-      symbol: symbol.toUpperCase(),
-      secType: SecType.OPT,
-      exchange: 'SMART',
-      currency: 'USD',
-      strike,
-      right: optionType === 'P' ? OptionType.Put : OptionType.Call,
-      lastTradeDateOrContractMonth: expiry,
-      multiplier: 100,
-    };
-
-    const timeout = setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        cleanup();
-        if (impliedVol > 0 && delta !== 0) {
-          resolve(buildResult());
-        } else {
-          resolve(null);
-        }
-      }
-    }, 12_000);
-
-    function cleanup() {
-      emitter.off(EventName.tickOptionComputation, greeksHandler);
-      emitter.off(EventName.tickPrice, priceHandler);
-      emitter.off(EventName.error, errorHandler);
-      try { (ib as unknown as { cancelMktData: (id: number) => void }).cancelMktData(reqId); } catch { /* ignore */ }
-    }
-
-    function buildResult(): OptionGreeks {
-      const mid = bidPrice >= 0 && askPrice >= 0 ? (bidPrice + askPrice) / 2 : Math.max(bidPrice, askPrice, 0);
-      // Simulate realistic fill at mid - $0.05
-      const realisticMid = Math.max(mid - 0.05, 0.01);
-      const dte = daysToExpiry(expiry);
-      const annualYield = dte > 0 ? (realisticMid / strike) * (365 / dte) * 100 : 0;
-      const absDelta = Math.abs(delta);
-      const probProfit = (1 - absDelta) * 100;
-
-      return {
-        strike, expiry,
-        optionType,
-        bid: bidPrice >= 0 ? bidPrice : 0,
-        ask: askPrice >= 0 ? askPrice : 0,
-        mid: realisticMid,
-        impliedVol,
-        delta,
-        theta,
-        gamma,
-        vega,
-        probProfit,
-        annualYield,
+      const contract: Contract = {
+        symbol: symbol.toUpperCase(),
+        secType: SecType.OPT,
+        exchange: 'SMART',
+        currency: 'USD',
+        strike,
+        right: optionType === 'P' ? OptionType.Put : OptionType.Call,
+        lastTradeDateOrContractMonth: expiry,
+        multiplier: 100,
       };
-    }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const greeksHandler = (tickerId: number, _tickType: number, _tickAttrib: number, iv: number, d: number, _optPrice: number, _pvDiv: number, g: number, v: number, t: number, _undPrice: number) => {
-      if (tickerId !== reqId) return;
-      if (iv && iv > 0 && iv < 5) impliedVol = iv;  // sanity check: IV as decimal
-      if (d && d !== 0 && Math.abs(d) <= 1) delta = d;
-      if (t && t !== 0) theta = t;
-      if (g && g !== 0) gamma = g;
-      if (v && v !== 0) vega = v;
-
-      // Resolve once we have IV + delta + both prices
-      if (!resolved && impliedVol > 0 && delta !== 0 && bidPrice >= 0 && askPrice >= 0) {
+      function finish(result: OptionGreeks | null) {
+        if (resolved) return;
         resolved = true;
         clearTimeout(timeout);
-        cleanup();
-        resolve(buildResult());
+        unregisterReqErrorCallback(reqId);
+        emitter.off(EventName.tickOptionComputation, greeksHandler);
+        emitter.off(EventName.tickPrice, priceHandler);
+        emitter.off(EventName.error, errorHandler);
+        try { (ib as unknown as { cancelMktData: (id: number) => void }).cancelMktData(reqId); } catch { /* ignore */ }
+        resolve(result);
       }
-    };
 
-    const priceHandler = (tickerId: number, tickType: number, price: number) => {
-      if (tickerId !== reqId) return;
-      if (tickType === 1) bidPrice = price;  // BID
-      if (tickType === 2) askPrice = price;  // ASK
-    };
+      function buildResult(): OptionGreeks {
+        const mid = bidPrice >= 0 && askPrice >= 0 ? (bidPrice + askPrice) / 2 : Math.max(bidPrice, askPrice, 0);
+        const realisticMid = Math.max(mid - 0.05, 0.01);
+        const dte = daysToExpiry(expiry);
+        const annualYield = dte > 0 ? (realisticMid / strike) * (365 / dte) * 100 : 0;
+        const absDelta = Math.abs(delta);
+        const probProfit = (1 - absDelta) * 100;
 
-    // Immediately bail on "not subscribed" errors — no point waiting 12 s per strike.
-    // IB error event signature: (err: Error, code: number, reqId: number)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const errorHandler = (_err: any, code: number, id: number) => {
-      if (id !== reqId) return;
-      // 354 = not subscribed, 10091 = needs additional subscription
-      if ((code === 354 || code === 10091) && !resolved) {
-        resolved = true;
-        clearTimeout(timeout);
-        cleanup();
-        resolve(null);
+        return {
+          strike, expiry,
+          optionType,
+          bid: bidPrice >= 0 ? bidPrice : 0,
+          ask: askPrice >= 0 ? askPrice : 0,
+          mid: realisticMid,
+          impliedVol,
+          delta,
+          theta,
+          gamma,
+          vega,
+          probProfit,
+          annualYield,
+        };
       }
-    };
 
-    emitter.on(EventName.tickOptionComputation, greeksHandler);
-    emitter.on(EventName.tickPrice, priceHandler);
-    emitter.on(EventName.error, errorHandler);
+      const timeout = setTimeout(() => {
+        if (impliedVol > 0 && delta !== 0) {
+          finish(buildResult());
+        } else {
+          finish(null);
+        }
+      }, 12_000);
 
-    // Request market data — for OPT contracts tickOptionComputation fires automatically;
-    // generic tick 13 is invalid for options, so use empty string to avoid IB error 321.
-    (ib as unknown as { reqMktData: (id: number, c: Contract, genericTicks: string, snapshot: boolean, regulatory: boolean, options: unknown[]) => void })
-      .reqMktData(reqId, contract, '', false, false, []);
-  });
+      // Centralized per-request error routing (handles code 200 "no security definition")
+      registerReqErrorCallback(reqId, () => finish(null));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const greeksHandler = (tickerId: number, _tickType: number, _tickAttrib: number, iv: number, d: number, _optPrice: number, _pvDiv: number, g: number, v: number, t: number, _undPrice: number) => {
+        if (tickerId !== reqId) return;
+        if (iv && iv > 0 && iv < 5) impliedVol = iv;
+        if (d && d !== 0 && Math.abs(d) <= 1) delta = d;
+        if (t && t !== 0) theta = t;
+        if (g && g !== 0) gamma = g;
+        if (v && v !== 0) vega = v;
+
+        if (!resolved && impliedVol > 0 && delta !== 0 && bidPrice >= 0 && askPrice >= 0) {
+          finish(buildResult());
+        }
+      };
+
+      const priceHandler = (tickerId: number, tickType: number, price: number) => {
+        if (tickerId !== reqId) return;
+        if (tickType === 1) bidPrice = price;
+        if (tickType === 2) askPrice = price;
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const errorHandler = (_err: any, code: number, id: number) => {
+        if (id !== reqId) return;
+        // 200 = no security definition, 354 = not subscribed, 10091 = needs subscription
+        if ((code === 200 || code === 354 || code === 10091) && !resolved) {
+          finish(null);
+        }
+      };
+
+      emitter.on(EventName.tickOptionComputation, greeksHandler);
+      emitter.on(EventName.tickPrice, priceHandler);
+      emitter.on(EventName.error, errorHandler);
+
+      (ib as unknown as { reqMktData: (id: number, c: Contract, genericTicks: string, snapshot: boolean, regulatory: boolean, options: unknown[]) => void })
+        .reqMktData(reqId, contract, '', false, false, []);
+    });
+  } finally {
+    releaseRequestSlot();
+  }
 }
 
 // ── Find Best Put Strike ──────────────────────────────────

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -18,7 +18,6 @@ import { fileURLToPath } from 'node:url';
 import {
   isConnected,
   requestPositions,
-  searchContract,
   placeBracketOrder,
   placeMarketOrder,
   cancelOrder,
@@ -485,9 +484,8 @@ async function closeAllDayTrades(config: AutoTraderConfig): Promise<void> {
   log(`EOD sweep: ${dayTrades.length} open day trade(s) to close`);
   for (const trade of dayTrades) {
     try {
-      const contract = await searchContract(trade.ticker);
-      if (!contract) {
-        log(`EOD sweep: ${trade.ticker} — no IB contract found, skipping`);
+      if (!isConnected()) {
+        log(`EOD sweep: ${trade.ticker} — IB not connected, skipping`);
         continue;
       }
       const closeSide = trade.signal === 'BUY' ? 'SELL' : 'BUY';
@@ -2690,8 +2688,10 @@ async function executeScannerTrade(
     log(`${ticker}: order validation OK — ${orderCheck.reason}`);
   }
 
-  const contract = await searchContract(ticker);
-  if (!contract) return 'failed:no_contract';
+  // Verify IB connection is live before attempting order placement.
+  // We skip reqContractDetails for STK orders — it can fail transiently (empty
+  // results with SMART routing) while placeOrder handles contract resolution itself.
+  if (!isConnected()) return 'failed:no_contract';
 
   // SWING only: skip if price too far from entry (entry precision matters)
   if (mode === 'SWING_TRADE' && entryPrice > 0) {
@@ -2719,8 +2719,8 @@ async function executeScannerTrade(
 
     await createPaperTrade({
       ticker, mode, signal,
-      scanner_confidence: effectiveScannerConf,
-      fa_confidence: faConf,
+      scanner_confidence: Math.round(effectiveScannerConf),
+      fa_confidence: faConf != null ? Math.round(faConf) : null,
       fa_recommendation: faRec,
       entry_price: entryPrice,
       stop_loss: stopLoss,
@@ -2956,8 +2956,7 @@ async function _executeSuggestedFindTradeInner(
     return 'skipped:pre_trade_check';
   }
 
-  const contract = await searchContract(ticker);
-  if (!contract) return 'failed:no_contract';
+  if (!isConnected()) return 'failed:no_contract';
 
   try {
     const result = await placeMarketOrder({
@@ -3321,11 +3320,10 @@ async function executeExternalStrategySignal(
     return 'skipped';
   }
 
-  const contract = await searchContract(ticker);
-  if (!contract) {
+  if (!isConnected()) {
     await updateExternalStrategySignal(signal.id, {
       status: 'FAILED',
-      failure_reason: 'Ticker not found in IB contract search',
+      failure_reason: 'IB Gateway not connected',
     });
     return 'failed';
   }
@@ -4053,8 +4051,7 @@ async function checkDipBuyOpportunities(
     if (!(await checkAllocationCap(config, addOnDollar, ticker, positions, 'LONG_TERM'))) continue;
 
     try {
-      const contract = await searchContract(ticker);
-      if (!contract) continue;
+      if (!isConnected()) continue;
 
       const result = await placeMarketOrder({
         symbol: ticker, side: 'BUY', quantity: addOnQty,
@@ -4469,8 +4466,7 @@ async function checkProfitTakeOpportunities(
     if (actualTrimQty < 1) continue;
 
     try {
-      const contract = await searchContract(trade.ticker);
-      if (!contract) continue;
+      if (!isConnected()) continue;
 
       await placeMarketOrder({
         symbol: trade.ticker, side: 'SELL', quantity: actualTrimQty,
@@ -4652,8 +4648,7 @@ async function checkLossCutOpportunities(
     if (sellQty < 1) continue;
 
     try {
-      const contract = await searchContract(trade.ticker);
-      if (!contract) continue;
+      if (!isConnected()) continue;
 
       const side = ibPos.position > 0 ? 'SELL' : 'BUY';
       await placeMarketOrder({ symbol: trade.ticker, side: side as 'BUY' | 'SELL', quantity: sellQty });
@@ -5417,6 +5412,9 @@ No new options positions will be opened until next month. Existing positions con
       } catch (err) {
         log(`Options scan error: ${err instanceof Error ? err.message : 'unknown'}`);
       }
+      // Drain delay: let IB Gateway clear any pending responses before next cycle's
+      // day-trade contract lookups. Prevents no_contract failures after heavy scans.
+      await new Promise(r => setTimeout(r, 5_000));
     }
 
     // 15. Daily rehydration (after 4:15 PM ET)

--- a/supabase/functions/trade-scanner/index.ts
+++ b/supabase/functions/trade-scanner/index.ts
@@ -2417,8 +2417,11 @@ Deno.serve(async (req) => {
         if (swingIdeas.length > 0) {
           await writeToDB(sb, 'swing_trades', swingIdeas, 360);
         } else {
-          console.log('[Trade Scanner] Swing scan produced 0 ideas — preserving previous scan results');
-          swingIdeas = swingRow?.data ?? [];
+          console.log('[Trade Scanner] Swing scan produced 0 ideas — updating timestamp, preserving previous data');
+          // Update scanned_at so the user knows the scan ran (even with 0 new results)
+          const prevData = swingRow?.data ?? [];
+          await writeToDB(sb, 'swing_trades', prevData, 360);
+          swingIdeas = prevData;
         }
       } else {
         console.warn('[Trade Scanner] Swing AI failed — skipping DB write to preserve previous results');


### PR DESCRIPTION
## Summary
- Options Scanner was flooding IB Gateway with hundreds of concurrent requests, causing day trade contract lookups to time out (`failed:no_contract` for TSLA, AAPL, GOOGL, etc.)
- Added request semaphore (max 8 concurrent IB API calls) and per-request error routing
- Replaced unnecessary `searchContract` validation gate with `isConnected()` check for stock orders
- Fixed swing_trades timestamp not updating when 0 results found

## Test plan
- [x] Auto-trader builds clean (`npm run build`)
- [x] Service restarted and confirmed placing orders (TSLA, AAPL, GOOGL, IWM, GDX all executed)
- [x] No new errors in stderr after restart
- [x] trade-scanner edge function deployed


Made with [Cursor](https://cursor.com)