### PR TITLE
fix: round confidence values in persistEvent

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -2746,8 +2746,8 @@ async function executeScannerTrade(
     }
     persistEvent(ticker, 'success', `Order placed: ${signal} ${sizing.quantity} @ $${entryPrice}`, {
       action: 'executed', source: 'scanner', mode,
-      scanner_signal: signal, scanner_confidence: effectiveScannerConf,
-      fa_recommendation: faRec, fa_confidence: faConf,
+      scanner_signal: signal, scanner_confidence: Math.round(effectiveScannerConf),
+      fa_recommendation: faRec, fa_confidence: faConf != null ? Math.round(faConf) : null,
       ...(candlePatternLog.length > 0 && { candle_patterns: candlePatternLog }),
     });
     return 'executed';


### PR DESCRIPTION
## Summary
- Same float-to-int bug that broke `createPaperTrade` was also silently failing `persistEvent`
- This caused executed trades (TSLA, AAPL, GOOGL) to not appear in Today's Activity dashboard

## Fix
- `Math.round()` on `scanner_confidence` and `fa_confidence` before writing to `auto_trade_events`


Made with [Cursor](https://cursor.com)