### PR TITLE
fix: invalidate local cache when dipDiscoveries is missing

### DIFF
--- a/app/src/lib/aiSuggestedFinds.ts
+++ b/app/src/lib/aiSuggestedFinds.ts
@@ -885,6 +885,9 @@ function getLocalCachedDiscovery(): CachedDiscovery | null {
     const cached: CachedDiscovery = JSON.parse(raw);
     const cachedDay = cached.suggestionDateEt ?? formatInstantToEtYmd(cached.timestamp);
     if (cachedDay !== todayEt) return null;
+    // If dipDiscoveries key is absent, the cache was written before the dip scan ran.
+    // Fall through to server which may have been patched with dip results since.
+    if (!('dipDiscoveries' in cached.data)) return null;
     return cached;
   } catch { /* invalid cache */ }
   return null;


### PR DESCRIPTION
## Summary
- Browser localStorage cache from earlier today didn't have `dipDiscoveries` key (browser has no dip pipeline)
- Even after auto-trader patched the server cache with ADBE dip discovery, browser kept serving stale local data
- Now treats localStorage as stale when `dipDiscoveries` key is absent, falls through to server

## Result
- Refresh Suggested Finds page → ADBE shows in Dip Discovery section


Made with [Cursor](https://cursor.com)