### PR TITLE
fix: retry ORB-blocked tickers + Paper Trading perf improvements

### DIFF
--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   Bot,
   Wifi,
@@ -63,10 +63,10 @@ import {
   getTodaysExecutedEvents,
   getDayTradeValidationReport,
   getSwingTradeValidationReport,
+  clearSharedTradesCache,
 } from '../../lib/paperTradesApi';
 import { getTotalDeployed, getMarketRegime, calculateKellyMultiplier, type MarketRegime } from '../../lib/autoTrader';
 import { Spinner } from '../Spinner';
-import { analyzeUnreviewedTrades, updatePerformancePatterns } from '../../lib/aiFeedback';
 import { fmtUsd } from './utils';
 import { StatCard } from './shared';
 import {
@@ -82,79 +82,104 @@ import {
 
 export type Tab = 'portfolio' | 'today' | 'smart' | 'strategies' | 'validation' | 'history' | 'performance' | 'settings';
 
+// Module-level cache: survives unmount so navigating back is instant
+const PAGE_CACHE_TTL = 2 * 60 * 1000; // 2 minutes
+interface PageCache {
+  ts: number;
+  performance: TradePerformance | null;
+  persistedEvents: AutoTradeEventRecord[];
+  todaysExecuted: AutoTradeEventRecord[];
+  ibPositions: IBPosition[];
+  ibOrders: IBLiveOrder[];
+  allTrades: PaperTrade[];
+  pendingSignals: PendingStrategySignal[];
+  todaySignalsForExecute: PendingStrategySignal[];
+  categoryPerf: CategoryPerformance[];
+  sourcePerf: StrategySourcePerformance[];
+  videoPerf: StrategyVideoPerformance[];
+  strategyStatuses: StrategySignalStatusSummary[];
+  validationReport: DayTradeValidationReport | null;
+  swingValidationReport: SwingTradeValidationReport | null;
+  totalDeployed: number;
+  marketRegime: MarketRegime | null;
+  kellyMultiplier: number;
+  lastCycleSummary: string[];
+  fetchedGroups: string[];
+}
+let _pageCache: PageCache | null = null;
+
 export function PaperTrading() {
+  const cached = _pageCache && Date.now() - _pageCache.ts < PAGE_CACHE_TTL ? _pageCache : null;
+
   const [config, setConfig] = useState<AutoTraderConfig>(getAutoTraderConfig);
   const [connected, setConnected] = useState(isIBConnected());
   const [events, setEvents] = useState<AutoTradeEvent[]>(getEventLog());
-  const [allTrades, setAllTrades] = useState<PaperTrade[]>([]);
-  const [performance, setPerformance] = useState<TradePerformance | null>(null);
-  const [ibPositions, setIbPositions] = useState<IBPosition[]>([]);
-  const [ibOrders, setIbOrders] = useState<IBLiveOrder[]>([]);
-  const [persistedEvents, setPersistedEvents] = useState<AutoTradeEventRecord[]>([]);
-  const [todaysExecuted, setTodaysExecuted] = useState<AutoTradeEventRecord[]>([]);
-  const [categoryPerf, setCategoryPerf] = useState<CategoryPerformance[]>([]);
-  const [sourcePerf, setSourcePerf] = useState<StrategySourcePerformance[]>([]);
-  const [videoPerf, setVideoPerf] = useState<StrategyVideoPerformance[]>([]);
-  const [strategyStatuses, setStrategyStatuses] = useState<StrategySignalStatusSummary[]>([]);
-  const [pendingSignals, setPendingSignals] = useState<PendingStrategySignal[]>([]);
-  const [todaySignalsForExecute, setTodaySignalsForExecute] = useState<PendingStrategySignal[]>([]);
-  const [validationReport, setValidationReport] = useState<DayTradeValidationReport | null>(null);
-  const [swingValidationReport, setSwingValidationReport] = useState<SwingTradeValidationReport | null>(null);
-  const [totalDeployed, setTotalDeployed] = useState(0);
-  const [lastCycleSummary, setLastCycleSummary] = useState<string[]>([]);
-  const [marketRegime, setMarketRegime] = useState<MarketRegime | null>(null);
-  const [kellyMultiplier, setKellyMultiplier] = useState<number>(1.0);
+  const [allTrades, setAllTrades] = useState<PaperTrade[]>(cached?.allTrades ?? []);
+  const [performance, setPerformance] = useState<TradePerformance | null>(cached?.performance ?? null);
+  const [ibPositions, setIbPositions] = useState<IBPosition[]>(cached?.ibPositions ?? []);
+  const [ibOrders, setIbOrders] = useState<IBLiveOrder[]>(cached?.ibOrders ?? []);
+  const [persistedEvents, setPersistedEvents] = useState<AutoTradeEventRecord[]>(cached?.persistedEvents ?? []);
+  const [todaysExecuted, setTodaysExecuted] = useState<AutoTradeEventRecord[]>(cached?.todaysExecuted ?? []);
+  const [categoryPerf, setCategoryPerf] = useState<CategoryPerformance[]>(cached?.categoryPerf ?? []);
+  const [sourcePerf, setSourcePerf] = useState<StrategySourcePerformance[]>(cached?.sourcePerf ?? []);
+  const [videoPerf, setVideoPerf] = useState<StrategyVideoPerformance[]>(cached?.videoPerf ?? []);
+  const [strategyStatuses, setStrategyStatuses] = useState<StrategySignalStatusSummary[]>(cached?.strategyStatuses ?? []);
+  const [pendingSignals, setPendingSignals] = useState<PendingStrategySignal[]>(cached?.pendingSignals ?? []);
+  const [todaySignalsForExecute, setTodaySignalsForExecute] = useState<PendingStrategySignal[]>(cached?.todaySignalsForExecute ?? []);
+  const [validationReport, setValidationReport] = useState<DayTradeValidationReport | null>(cached?.validationReport ?? null);
+  const [swingValidationReport, setSwingValidationReport] = useState<SwingTradeValidationReport | null>(cached?.swingValidationReport ?? null);
+  const [totalDeployed, setTotalDeployed] = useState(cached?.totalDeployed ?? 0);
+  const [lastCycleSummary, setLastCycleSummary] = useState<string[]>(cached?.lastCycleSummary ?? []);
+  const [marketRegime, setMarketRegime] = useState<MarketRegime | null>(cached?.marketRegime ?? null);
+  const [kellyMultiplier, setKellyMultiplier] = useState<number>(cached?.kellyMultiplier ?? 1.0);
   const [tab, setTab] = useState<Tab>('portfolio');
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!cached);
+  const [tabLoading, setTabLoading] = useState(false);
   const [syncing, setSyncing] = useState(false);
 
-  const loadData = useCallback(async () => {
-    setLoading(true);
-    try {
-      const [all, perf, savedEvents, todayEvents, catPerf, srcPerf, vidPerf, signalStatuses, pending, todayForExecute, deployed, regime, kelly, validation, swingValidation] = await Promise.all([
-        getAllTrades(500),
-        getPerformance(),
-        getAutoTradeEvents(100),
-        getTodaysExecutedEvents(),
-        recalculatePerformanceByCategory(),
-        recalculatePerformanceByStrategySource(),
-        recalculatePerformanceByStrategyVideo(),
-        getStrategySignalStatusSummaries(),
-        getPendingStrategySignals(300),
-        getTodaySignalsForManualExecute(),
-        getTotalDeployed(),
-        getMarketRegime(config),
-        calculateKellyMultiplier(config),
-        getDayTradeValidationReport(),
-        getSwingTradeValidationReport(),
-      ]);
-      setAllTrades(all);
-      setPerformance(perf);
-      setPersistedEvents(savedEvents);
-      setTodaysExecuted(todayEvents);
-      setCategoryPerf(catPerf);
-      setSourcePerf(srcPerf);
-      setVideoPerf(vidPerf);
-      setStrategyStatuses(signalStatuses);
-      setPendingSignals(pending);
-      setTodaySignalsForExecute(todayForExecute);
-      setTotalDeployed(deployed);
-      setMarketRegime(regime);
-      setKellyMultiplier(kelly);
-      setValidationReport(validation);
-      setSwingValidationReport(swingValidation);
-      // Fetch scheduler status (last cycle summary) from auto-trader
-      fetch('http://localhost:3001/api/scheduler/status')
-        .then((r) => r.json())
-        .then((d) => setLastCycleSummary(d.lastCycleSummary ?? []))
-        .catch(() => setLastCycleSummary([]));
-    } catch (err) {
-      console.error('Failed to load paper trading data:', err);
-    } finally {
-      setLoading(false);
-    }
-  }, [config]);
+  // Track which data groups have been fetched so we don't re-fetch on tab switch
+  const fetchedRef = useRef(new Set<string>(cached?.fetchedGroups ?? []));
+  const configRef = useRef(config);
+  useEffect(() => { configRef.current = config; }, [config]);
 
+  // Refs for cache snapshot on unmount
+  const stateRef = useRef({
+    performance, persistedEvents, todaysExecuted, ibPositions, ibOrders,
+    allTrades, pendingSignals, todaySignalsForExecute, categoryPerf,
+    sourcePerf, videoPerf, strategyStatuses, validationReport,
+    swingValidationReport, totalDeployed, marketRegime, kellyMultiplier, lastCycleSummary,
+  });
+  useEffect(() => {
+    stateRef.current = {
+      performance, persistedEvents, todaysExecuted, ibPositions, ibOrders,
+      allTrades, pendingSignals, todaySignalsForExecute, categoryPerf,
+      sourcePerf, videoPerf, strategyStatuses, validationReport,
+      swingValidationReport, totalDeployed, marketRegime, kellyMultiplier, lastCycleSummary,
+    };
+  });
+  useEffect(() => {
+    return () => {
+      _pageCache = { ts: Date.now(), ...stateRef.current, fetchedGroups: [...fetchedRef.current] };
+    };
+  }, []);
+
+  // ── Core data: header stats + activity log (always visible) ──
+  const loadCoreData = useCallback(async () => {
+    const [perf, savedEvents, todayEvents] = await Promise.all([
+      getPerformance(),
+      getAutoTradeEvents(100),
+      getTodaysExecutedEvents(),
+    ]);
+    setPerformance(perf);
+    setPersistedEvents(savedEvents);
+    setTodaysExecuted(todayEvents);
+    fetch('http://localhost:3001/api/scheduler/status')
+      .then((r) => r.json())
+      .then((d) => setLastCycleSummary(d.lastCycleSummary ?? []))
+      .catch(() => setLastCycleSummary([]));
+  }, []);
+
+  // ── IB data: positions + orders for header stats ──
   const loadIBData = useCallback(async () => {
     if (!connected) return;
     try {
@@ -169,24 +194,98 @@ export function PaperTrading() {
     }
   }, [connected, config.accountId]);
 
-  useEffect(() => { loadData(); }, [loadData]);
+  // ── Tab-specific data: loaded lazily on first visit, cached ──
+  const TAB_GROUPS: Record<Tab, string[]> = useMemo(() => ({
+    portfolio:   ['pendingSignals'],
+    today:       ['allTrades', 'todaySignals'],
+    history:     ['allTrades', 'pendingSignals'],
+    performance: ['categoryPerf', 'totalDeployed'],
+    strategies:  ['strategyPerf'],
+    validation:  ['validationReports'],
+    smart:       ['totalDeployed', 'smartTrading'],
+    settings:    [],
+  }), []);
+
+  const loadTabData = useCallback(async (t: Tab, force = false) => {
+    const groups = TAB_GROUPS[t];
+    const needed = force ? groups : groups.filter(g => !fetchedRef.current.has(g));
+    if (needed.length === 0) return;
+
+    setTabLoading(true);
+    try {
+      const promises: Promise<void>[] = [];
+      for (const group of needed) {
+        switch (group) {
+          case 'allTrades':
+            promises.push(getAllTrades(500).then(d => { setAllTrades(d); }));
+            break;
+          case 'pendingSignals':
+            promises.push(getPendingStrategySignals(300).then(d => { setPendingSignals(d); }));
+            break;
+          case 'todaySignals':
+            promises.push(getTodaySignalsForManualExecute().then(d => { setTodaySignalsForExecute(d); }));
+            break;
+          case 'categoryPerf':
+            promises.push(recalculatePerformanceByCategory().then(d => { setCategoryPerf(d); }));
+            break;
+          case 'totalDeployed':
+            promises.push(getTotalDeployed().then(d => { setTotalDeployed(d); }));
+            break;
+          case 'strategyPerf':
+            promises.push(Promise.all([
+              recalculatePerformanceByStrategySource().then(d => { setSourcePerf(d); }),
+              recalculatePerformanceByStrategyVideo().then(d => { setVideoPerf(d); }),
+              getStrategySignalStatusSummaries().then(d => { setStrategyStatuses(d); }),
+            ]).then(() => {}));
+            break;
+          case 'validationReports':
+            promises.push(Promise.all([
+              getDayTradeValidationReport().then(d => { setValidationReport(d); }),
+              getSwingTradeValidationReport().then(d => { setSwingValidationReport(d); }),
+            ]).then(() => {}));
+            break;
+          case 'smartTrading':
+            promises.push(Promise.all([
+              getMarketRegime(configRef.current).then(d => { setMarketRegime(d); }),
+              calculateKellyMultiplier(configRef.current).then(d => { setKellyMultiplier(d); }),
+            ]).then(() => {}));
+            break;
+        }
+        fetchedRef.current.add(group);
+      }
+      await Promise.all(promises);
+    } finally {
+      setTabLoading(false);
+    }
+  }, [TAB_GROUPS]);
+
+  // ── Mount: load core + IB + initial tab in parallel (skip if cache is fresh) ──
+  useEffect(() => {
+    if (cached) return;
+    let mounted = true;
+    (async () => {
+      setLoading(true);
+      try {
+        await Promise.all([loadCoreData(), loadIBData(), loadTabData('portfolio')]);
+      } catch (err) {
+        console.error('Failed to load paper trading data:', err);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Re-load IB data when connection or account changes
   useEffect(() => { loadIBData(); }, [loadIBData]);
 
-  useEffect(() => {
-    loadAutoTraderConfig().then(setConfig);
-  }, []);
+  useEffect(() => { loadAutoTraderConfig().then(setConfig); }, []);
 
+  // Load tab data lazily when the user switches tabs
   useEffect(() => {
-    analyzeUnreviewedTrades()
-      .then(count => {
-        if (count > 0) {
-          console.log(`[PaperTrading] Analyzed ${count} new trades`);
-          updatePerformancePatterns().catch(console.error);
-          loadData();
-        }
-      })
-      .catch(console.error);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    if (loading) return;
+    loadTabData(tab);
+  }, [tab]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const unsub = onConnectionChange(setConnected);
@@ -224,20 +323,34 @@ export function PaperTrading() {
     setConfig(updated);
   };
 
+  // Full refresh: clear all caches, reload core + current tab
   const handleSync = async () => {
     setSyncing(true);
+    fetchedRef.current.clear();
+    clearSharedTradesCache();
+    _pageCache = null;
     try {
       if (config.accountId) {
         await syncPositions(config.accountId);
         await recalculatePerformance();
       }
-      await Promise.all([loadData(), loadIBData()]);
+      await Promise.all([loadCoreData(), loadIBData()]);
+      await loadTabData(tab, true);
     } catch (err) {
       console.error('Sync failed:', err);
     } finally {
       setSyncing(false);
     }
   };
+
+  // Refresh after executing a signal or action (reloads core + current tab data)
+  const refreshAfterAction = useCallback(async () => {
+    fetchedRef.current.delete('allTrades');
+    fetchedRef.current.delete('todaySignals');
+    clearSharedTradesCache();
+    await Promise.all([loadCoreData(), loadIBData()]);
+    await loadTabData(tab, true);
+  }, [loadCoreData, loadIBData, loadTabData, tab]);
 
   const updateConfig = async (updates: Partial<AutoTraderConfig>) => {
     const updated = await saveAutoTraderConfig(updates);
@@ -466,6 +579,10 @@ export function PaperTrading() {
         <div className="flex items-center justify-center py-12">
           <Spinner size="lg" />
         </div>
+      ) : tabLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <Spinner size="md" />
+        </div>
       ) : (
         <>
           {tab === 'portfolio' && (
@@ -482,7 +599,7 @@ export function PaperTrading() {
               events={dedupedToday}
               trades={allTrades}
               todaySignalsForExecute={todaySignalsForExecute}
-              onExecuteSignal={loadData}
+              onExecuteSignal={refreshAfterAction}
             />
           )}
           {tab === 'smart' && (
@@ -497,13 +614,13 @@ export function PaperTrading() {
             />
           )}
           {tab === 'strategies' && (
-            <StrategyPerformanceTab sources={sourcePerf} videos={videoPerf} statuses={strategyStatuses} onRefresh={loadData} />
+            <StrategyPerformanceTab sources={sourcePerf} videos={videoPerf} statuses={strategyStatuses} onRefresh={() => loadTabData('strategies', true)} />
           )}
           {tab === 'validation' && (
             <ValidationTab
               dayReport={validationReport}
               swingReport={swingValidationReport}
-              onRefresh={loadData}
+              onRefresh={() => loadTabData('validation', true)}
             />
           )}
           {tab === 'history' && (

--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -502,8 +502,13 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
                 : event.mode === 'LONG_TERM' ? 'Long Term'
                 : isSystemClose ? 'Close' : '—';
 
-              const signalLabel = event.scanner_signal ?? (isSystemClose ? '—' : 'BUY');
-              const signalColor = event.scanner_signal === 'SELL' ? 'bg-red-100 text-red-700'
+              const SELL_SOURCES = new Set(['loss_cut', 'profit_take', 'lt_auto_sell']);
+              const inferredSignal = isSystemClose ? '—'
+                : SELL_SOURCES.has(event.source ?? '') ? 'SELL'
+                : 'BUY';
+              const signalLabel = event.scanner_signal ?? inferredSignal;
+              const isSell = signalLabel === 'SELL';
+              const signalColor = isSell ? 'bg-red-100 text-red-700'
                 : isSystemClose ? 'bg-slate-100 text-slate-600'
                 : 'bg-emerald-100 text-emerald-700';
 

--- a/app/src/components/TradeIdeas.tsx
+++ b/app/src/components/TradeIdeas.tsx
@@ -145,18 +145,17 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
   // Intentionally excludes long-term holds, options, and external signals so the
   // "TRADED" badge only lights up when the scanner actually acted on this idea today.
   useEffect(() => {
-    const todayPrefix = new Date().toISOString().slice(0, 10); // "YYYY-MM-DD"
+    const todayET = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
     Promise.all([getActiveTrades(), getAllTrades(50)])
       .then(([active, all]) => {
         const relevantModes = new Set(['DAY_TRADE', 'SWING_TRADE']);
         const tickers = new Set<string>();
-        // Active trades: only day/swing
-        active
-          .filter(t => relevantModes.has(t.mode ?? ''))
-          .forEach(t => tickers.add(t.ticker.toUpperCase()));
-        // Recent trades: only day/swing placed today
-        all
-          .filter(t => relevantModes.has(t.mode ?? '') && (t.opened_at ?? '').startsWith(todayPrefix))
+        // Only include active or recent trades that were actually opened today
+        [...active, ...all]
+          .filter(t =>
+            relevantModes.has(t.mode ?? '') &&
+            (t.opened_at ?? '').startsWith(todayET)
+          )
           .forEach(t => tickers.add(t.ticker.toUpperCase()));
         setTradedTickers(tickers);
       })

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -6,6 +6,58 @@
 import { supabase } from './supabaseClient';
 import { getExemptFromAutoDeactivationSources } from './strategyVideosApi';
 
+// ── Shared cache: dedup parallel paper_trades fetches ────
+// The recalculate*() functions all query paper_trades independently.
+// This cache ensures only one round-trip happens when they run in parallel.
+
+let _sharedTradesInflight: Promise<PaperTrade[]> | null = null;
+let _sharedTradesCache: { data: PaperTrade[]; ts: number } | null = null;
+
+let _exemptInflight: Promise<Set<string>> | null = null;
+let _exemptCache: { data: Set<string>; ts: number } | null = null;
+
+const SHARED_CACHE_TTL = 30_000;
+
+async function getSharedTrades(): Promise<PaperTrade[]> {
+  if (_sharedTradesCache && Date.now() - _sharedTradesCache.ts < SHARED_CACHE_TTL) {
+    return _sharedTradesCache.data;
+  }
+  if (_sharedTradesInflight) return _sharedTradesInflight;
+  _sharedTradesInflight = (async () => {
+    const { data, error } = await supabase
+      .from('paper_trades')
+      .select('*')
+      .limit(2000);
+    _sharedTradesInflight = null;
+    if (error) throw new Error(`Failed to fetch trades: ${error.message}`);
+    const trades = (data ?? []) as PaperTrade[];
+    _sharedTradesCache = { data: trades, ts: Date.now() };
+    return trades;
+  })();
+  return _sharedTradesInflight;
+}
+
+async function getCachedExemptSources(): Promise<Set<string>> {
+  if (_exemptCache && Date.now() - _exemptCache.ts < SHARED_CACHE_TTL * 2) {
+    return _exemptCache.data;
+  }
+  if (_exemptInflight) return _exemptInflight;
+  _exemptInflight = (async () => {
+    const result = await getExemptFromAutoDeactivationSources();
+    _exemptInflight = null;
+    _exemptCache = { data: result, ts: Date.now() };
+    return result;
+  })();
+  return _exemptInflight;
+}
+
+export function clearSharedTradesCache(): void {
+  _sharedTradesCache = null;
+  _sharedTradesInflight = null;
+  _exemptCache = null;
+  _exemptInflight = null;
+}
+
 // ── Types ────────────────────────────────────────────────
 
 export type TradeStatus =
@@ -816,13 +868,12 @@ export interface PendingStrategySignal {
  * - profit_take: profit take trims (portfolio management)
  */
 export async function recalculatePerformanceByCategory(): Promise<CategoryPerformance[]> {
-  const { data: allTrades, error } = await supabase
-    .from('paper_trades')
-    .select('*')
-    .limit(2000);
-
-  if (error || !allTrades) return [];
-  const trades = allTrades as PaperTrade[];
+  let trades: PaperTrade[];
+  try {
+    trades = await getSharedTrades();
+  } catch {
+    return [];
+  }
 
   const categories: Array<{
     key: CategoryPerformance['category'];
@@ -924,14 +975,14 @@ export async function recalculatePerformanceByCategory(): Promise<CategoryPerfor
 }
 
 export async function recalculatePerformanceByStrategySource(): Promise<StrategySourcePerformance[]> {
-  const exemptSources = await getExemptFromAutoDeactivationSources();
-  const { data: allTrades, error } = await supabase
-    .from('paper_trades')
-    .select('*')
-    .not('strategy_source', 'is', null);
-
-  if (error || !allTrades) return [];
-  const trades = allTrades as PaperTrade[];
+  let allTrades: PaperTrade[];
+  let exemptSources: Set<string>;
+  try {
+    [allTrades, exemptSources] = await Promise.all([getSharedTrades(), getCachedExemptSources()]);
+  } catch {
+    return [];
+  }
+  const trades = allTrades.filter(t => t.strategy_source != null);
 
   const activeStatuses = new Set(['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL']);
   const closedStatuses = new Set(['STOPPED', 'TARGET_HIT', 'CLOSED']);
@@ -1028,14 +1079,14 @@ export async function recalculatePerformanceByStrategySource(): Promise<Strategy
 }
 
 export async function recalculatePerformanceByStrategyVideo(): Promise<StrategyVideoPerformance[]> {
-  const exemptSources = await getExemptFromAutoDeactivationSources();
-  const { data: allTrades, error } = await supabase
-    .from('paper_trades')
-    .select('*')
-    .not('strategy_source', 'is', null);
-
-  if (error || !allTrades) return [];
-  const trades = allTrades as PaperTrade[];
+  let allTrades: PaperTrade[];
+  let exemptSources: Set<string>;
+  try {
+    [allTrades, exemptSources] = await Promise.all([getSharedTrades(), getCachedExemptSources()]);
+  } catch {
+    return [];
+  }
+  const trades = allTrades.filter(t => t.strategy_source != null);
 
   const activeStatuses = new Set(['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL']);
   const closedStatuses = new Set(['STOPPED', 'TARGET_HIT', 'CLOSED']);

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -195,6 +195,23 @@ let _dailyDeployedDate = '';
 const _processedTickers = new Set<string>();
 let _processedTickersDate = '';
 
+/** Skip results that are time-dependent — the ticker should be retried in later cycles
+ *  because market conditions (ORB breakout, volume, price movement) can change. */
+const RETRYABLE_SKIP_PREFIXES = [
+  'skipped:outside-market-hours',
+  'skipped:inside_orb',
+  'skipped:illiquid',
+  'skipped:rr_',
+  'skipped:price_too_far',
+  'skipped:swing_chop',
+  'skipped:swing_low_volume',
+  'skipped:swing_volume_divergence',
+];
+
+function isRetryableSkip(result: string): boolean {
+  return RETRYABLE_SKIP_PREFIXES.some(p => result.startsWith(p));
+}
+
 const FINNHUB_BASE = 'https://finnhub.io/api/v1';
 const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -5006,9 +5023,10 @@ async function runTradeExecutionOnly(): Promise<void> {
           const ev = scanResultToEval(result);
           if (idea.mode === 'DAY_TRADE') rtDayEvals[idea.ticker] = ev;
           else rtSwingEvals[idea.ticker] = ev;
-          // Only mark as processed for non-time-based outcomes so the ticker is retried
-          // when the market-hours window opens (e.g. the 9:30–9:35 first-candle guard).
-          if (result !== 'skipped:outside-market-hours') {
+          // Don't mark time-dependent skips as processed — conditions change throughout the day.
+          // ORB status changes as price breaks out, volume increases fix illiquidity,
+          // and price movement changes R/R ratios.
+          if (!isRetryableSkip(result)) {
             _processedTickers.add(idea.ticker);
           }
           await new Promise(r => setTimeout(r, 2000));
@@ -5261,9 +5279,8 @@ async function runSchedulerCycle(): Promise<void> {
           const result = await executeScannerTrade(idea, config, positions);
           log(`  ${idea.ticker}: ${result}`);
           recordEval(idea, result);
-          // Only mark as processed for non-time-based outcomes so the ticker is retried
-          // when the market-hours window opens (e.g. the 9:30–9:35 first-candle guard).
-          if (result !== 'skipped:outside-market-hours') {
+          // Don't mark time-dependent skips as processed — conditions change throughout the day.
+          if (!isRetryableSkip(result)) {
             _processedTickers.add(idea.ticker);
           }
           await new Promise(r => setTimeout(r, 2000));

--- a/docs/cursor/2026-05-07-paper-trading-perf-and-orb-retry.md
+++ b/docs/cursor/2026-05-07-paper-trading-perf-and-orb-retry.md
@@ -1,0 +1,56 @@
+# Paper Trading Page Performance + ORB Retry Fix
+
+> 2026-05-07
+
+## Goal
+
+1. Fix slow Paper Trading page load times (~15 parallel API requests on every visit)
+2. Fix UI discrepancies (incorrect TRADED badges, wrong BUY/SELL labels)
+3. Fix auto-trader executing zero day trades on choppy-open days
+
+## Changes
+
+### 1. Paper Trading page performance (`app/src/components/PaperTrading/index.tsx`)
+
+- **Lazy tab loading**: Split monolithic `loadData()` into `loadCoreData()` (header stats, activity log), `loadIBData()` (positions/orders), and `loadTabData(tab)` (fetched on first tab visit). Initial API calls reduced from ~15 to ~6.
+- **Module-level page cache**: `_pageCache` persists component state across unmounts with a 2-minute TTL. Navigating back to the page is instant — no re-fetch.
+- **Removed `analyzeUnreviewedTrades`** from the render path — it could trigger expensive AI calls + a full page reload on every visit.
+
+### 2. Shared API caching (`app/src/lib/paperTradesApi.ts`)
+
+- `getSharedTrades()` / `getCachedExemptSources()`: Module-level cache + request deduplication for `paper_trades` and `exempt_from_auto_deactivation` sources. Multiple components calling the same data only trigger one Supabase query.
+- `clearSharedTradesCache()`: Called by `handleSync` to force a full refresh.
+
+### 3. TRADED badge fix (`app/src/components/TradeIdeas.tsx`)
+
+The scanner page showed "TRADED" for stocks with active positions from previous days. Fixed by filtering `opened_at` against the current date in Eastern Time — only trades opened *today* show the badge.
+
+### 4. BUY/SELL label fix (`app/src/components/PaperTrading/tabs/TodayActivityTab.tsx`)
+
+Portfolio management actions (loss cut, profit take, lt_auto_sell) showed "BUY" because `scanner_signal` was null and the default was "BUY". Added a `SELL_SOURCES` set to correctly infer "SELL" for these events.
+
+### 5. ORB retryable skip fix (`auto-trader/src/scheduler.ts`)
+
+**Root cause of zero day trades**: `_processedTickers` permanently blocked tickers after any skip (except `outside-market-hours`). On a choppy-open day:
+1. Cycle #5 (~9:45 AM): 12 tickers hit `inside_orb` with "VWAP reclaim: insufficient bars" (not enough data yet)
+2. All 12 permanently marked as processed → never retried
+3. Cycles #6–#24+: "all filtered or already processed" — even though stocks broke out of ORB later
+
+**Fix**: Added `isRetryableSkip()` function. Time-dependent conditions (`inside_orb`, `illiquid`, `rr_*`, `price_too_far`, `swing_chop`, `swing_low_volume`, `swing_volume_divergence`) no longer mark tickers as processed. They're re-evaluated every cycle until conditions change or a non-retryable outcome occurs.
+
+## Key Decisions
+
+- **Retryable vs. permanent skips**: Permanent skips (`duplicate`, `recent_loss_cooldown`, `poor_win_rate`, `pre_trade_check`, etc.) still mark tickers as processed since they won't change within the same day. Only market-condition-based skips are retryable.
+- **No throttle on retries**: ORB/VWAP caches (5-min / 3-min TTL) naturally prevent redundant API calls. Each cycle gets fresh data, which is what we want.
+- **Cancelled column-select optimization**: The architectural refactors already yielded major performance gains; further micro-optimizations carried disproportionate complexity.
+
+## Files Changed
+
+| File | What |
+|------|------|
+| `app/src/components/PaperTrading/index.tsx` | Lazy loading, page cache, granular data loaders |
+| `app/src/lib/paperTradesApi.ts` | Shared trades cache + deduplication |
+| `app/src/components/TradeIdeas.tsx` | TRADED badge ET date filtering |
+| `app/src/components/PaperTrading/tabs/TodayActivityTab.tsx` | SELL inference for portfolio management events |
+| `auto-trader/src/scheduler.ts` | `isRetryableSkip()` + retryable skip prefixes |
+| `docs/features/orb-chop-filter.md` | Updated with retryable skip documentation |

--- a/docs/features/orb-chop-filter.md
+++ b/docs/features/orb-chop-filter.md
@@ -42,6 +42,10 @@ Before placing any `DAY_TRADE` scanner order, the ticker's ORB is checked:
 
 The check runs for all scanner-sourced day trades. Influencer signals and Suggested Finds are exempt (they have their own entry logic).
 
+**Retryable skip**: `inside_orb` is a time-dependent condition — the ticker is **not** marked as permanently processed. It will be re-evaluated in every subsequent scheduler cycle because stocks break out of their opening range throughout the day. This also applies to other market-condition-based skips (`illiquid`, `rr_*`, `price_too_far`, `swing_chop`, `swing_low_volume`, `swing_volume_divergence`). See `isRetryableSkip()` in `scheduler.ts`.
+
+> **Bug fixed 2026-05-07**: Previously, `inside_orb` skips permanently marked the ticker as processed, meaning a stock blocked at 9:45 AM (when VWAP data was insufficient for reclaim detection) would never be retried — even if it broke out of its ORB hours later. This caused zero day trades on choppy-open days.
+
 ### 2. SPX level scanner gate (`spx-level-scanner.ts → checkSpxLevelSetups`)
 
 When an SPX breakout-retest setup triggers, the SPX index itself is checked against its ORB before generating a SPY order:


### PR DESCRIPTION
## Summary

- **ORB retryable skips**: Tickers blocked by `inside_orb` were permanently marked as processed — a stock blocked at 9:45 AM (VWAP data insufficient) was never retried even after breaking out of its ORB. Added `isRetryableSkip()` to re-evaluate time-dependent conditions (`inside_orb`, `illiquid`, `rr_*`, `price_too_far`, `swing_chop`, `swing_low_volume`, `swing_volume_divergence`) every cycle. Root cause of zero day trades on choppy-open days.
- **Paper Trading page perf**: Lazy tab loading, module-level page cache (2-min TTL), shared API deduplication. Initial requests reduced from ~15 to ~6. Navigating back to the page is instant.
- **TRADED badge fix**: Scanner page showed "TRADED" for positions opened on prior days. Now filters by ET date.
- **BUY/SELL label fix**: Loss cut, profit take, lt_auto_sell events showed "BUY" instead of "SELL".

## Test plan

- [x] Frontend builds cleanly (`npm run build`)
- [x] Auto-trader builds cleanly (`npm run build`)
- [x] Verified retryable skips work: tickers blocked by `inside_orb` in cycle #1 were retried in cycle #4
- [ ] Monitor tomorrow's trading session for day trade execution on choppy-open


Made with [Cursor](https://cursor.com)