### PR TITLE
fix: source realized P&L from IB and fix silent event drops

### DIFF
--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -38,7 +38,7 @@ import {
   syncPositions,
   scheduleDayTradeAutoClose,
 } from '../../lib/autoTrader';
-import { getAccounts, getPositions, getLiveOrders, type IBPosition, type IBLiveOrder } from '../../lib/ibClient';
+import { getAccounts, getPositions, getLiveOrders, getAccountPnL, type IBPosition, type IBLiveOrder, type AccountPnL } from '../../lib/ibClient';
 import {
   type PaperTrade,
   type TradePerformance,
@@ -104,6 +104,7 @@ interface PageCache {
   marketRegime: MarketRegime | null;
   kellyMultiplier: number;
   lastCycleSummary: string[];
+  ibAccountPnl: AccountPnL | null;
   fetchedGroups: string[];
 }
 let _pageCache: PageCache | null = null;
@@ -130,6 +131,7 @@ export function PaperTrading() {
   const [swingValidationReport, setSwingValidationReport] = useState<SwingTradeValidationReport | null>(cached?.swingValidationReport ?? null);
   const [totalDeployed, setTotalDeployed] = useState(cached?.totalDeployed ?? 0);
   const [lastCycleSummary, setLastCycleSummary] = useState<string[]>(cached?.lastCycleSummary ?? []);
+  const [ibAccountPnl, setIbAccountPnl] = useState<AccountPnL | null>(cached?.ibAccountPnl ?? null);
   const [marketRegime, setMarketRegime] = useState<MarketRegime | null>(cached?.marketRegime ?? null);
   const [kellyMultiplier, setKellyMultiplier] = useState<number>(cached?.kellyMultiplier ?? 1.0);
   const [tab, setTab] = useState<Tab>('portfolio');
@@ -148,6 +150,7 @@ export function PaperTrading() {
     allTrades, pendingSignals, todaySignalsForExecute, categoryPerf,
     sourcePerf, videoPerf, strategyStatuses, validationReport,
     swingValidationReport, totalDeployed, marketRegime, kellyMultiplier, lastCycleSummary,
+    ibAccountPnl,
   });
   useEffect(() => {
     stateRef.current = {
@@ -155,6 +158,7 @@ export function PaperTrading() {
       allTrades, pendingSignals, todaySignalsForExecute, categoryPerf,
       sourcePerf, videoPerf, strategyStatuses, validationReport,
       swingValidationReport, totalDeployed, marketRegime, kellyMultiplier, lastCycleSummary,
+      ibAccountPnl,
     };
   });
   useEffect(() => {
@@ -179,16 +183,18 @@ export function PaperTrading() {
       .catch(() => setLastCycleSummary([]));
   }, []);
 
-  // ── IB data: positions + orders for header stats ──
+  // ── IB data: positions + orders + account P&L for header stats ──
   const loadIBData = useCallback(async () => {
     if (!connected) return;
     try {
-      const [positions, orders] = await Promise.all([
+      const [positions, orders, pnl] = await Promise.all([
         getPositions(config.accountId ?? ''),
         getLiveOrders(),
+        getAccountPnL(),
       ]);
       setIbPositions(positions);
       setIbOrders(orders);
+      setIbAccountPnl(pnl);
     } catch (err) {
       console.error('Failed to load IB data:', err);
     }
@@ -600,6 +606,7 @@ export function PaperTrading() {
               trades={allTrades}
               todaySignalsForExecute={todaySignalsForExecute}
               onExecuteSignal={refreshAfterAction}
+              ibRealizedPnl={ibAccountPnl?.realizedPnL ?? null}
             />
           )}
           {tab === 'smart' && (

--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -200,9 +200,10 @@ export interface TodayActivityTabProps {
   trades: PaperTrade[];
   todaySignalsForExecute?: PendingStrategySignal[];
   onExecuteSignal?: () => void;
+  ibRealizedPnl?: number | null;
 }
 
-export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], onExecuteSignal }: TodayActivityTabProps) {
+export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], onExecuteSignal, ibRealizedPnl }: TodayActivityTabProps) {
   const [executingId, setExecutingId] = useState<string | null>(null);
   const [executingAll, setExecutingAll] = useState(false);
   const [scannerTickers, setScannerTickers] = useState<Set<string>>(new Set());
@@ -394,7 +395,7 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
     );
   }
 
-  const todayPnl = (() => {
+  const eventBasedPnl = (() => {
     const countedTradeIds = new Set<string>();
     let sum = 0;
     for (const ev of events) {
@@ -416,11 +417,19 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
     return sum;
   })();
 
+  const useIbPnl = ibRealizedPnl != null;
+  const todayPnl = useIbPnl ? ibRealizedPnl : eventBasedPnl;
+
   return (
     <div className="space-y-3">
       {todayPnl !== 0 && (
         <div className="flex items-center justify-between rounded-lg bg-[hsl(var(--secondary))] px-4 py-2.5">
-          <span className="text-sm font-medium text-[hsl(var(--muted-foreground))]">Today&apos;s Realized P&L</span>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-[hsl(var(--muted-foreground))]">Today&apos;s Realized P&L</span>
+            {useIbPnl && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 font-medium">IB</span>
+            )}
+          </div>
           <span className={cn('text-sm font-bold tabular-nums', todayPnl > 0 ? 'text-emerald-600' : todayPnl < 0 ? 'text-red-600' : '')}>
             {fmtUsd(todayPnl, 2, true)}
           </span>

--- a/app/src/lib/ibClient.ts
+++ b/app/src/lib/ibClient.ts
@@ -143,6 +143,23 @@ export async function getAccounts(): Promise<string[]> {
   return data.accounts ?? [];
 }
 
+// ── Account P&L ──────────────────────────────────────────
+
+export interface AccountPnL {
+  dailyPnL: number | null;
+  unrealizedPnL: number | null;
+  realizedPnL: number | null;
+}
+
+/** Get IB's daily P&L (realized + unrealized) from the reqPnL subscription */
+export async function getAccountPnL(): Promise<AccountPnL> {
+  try {
+    return await ibFetch<AccountPnL>('/account-pnl');
+  } catch {
+    return { dailyPnL: null, unrealizedPnL: null, realizedPnL: null };
+  }
+}
+
 // ── Contract Search ──────────────────────────────────────
 
 /** Search for a stock contract by ticker symbol */

--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -28,6 +28,12 @@ let accounts: string[] = [];
 let nextOrderId = 0;
 let connectionListeners: Array<(state: boolean) => void> = [];
 
+// ── Account-level daily P&L (via reqPnL subscription) ───
+let _pnlReqId = 0;
+let _dailyPnL: number | null = null;
+let _unrealizedPnL: number | null = null;
+let _realizedPnL: number | null = null;
+
 // Per-request error routing: when IB sends error code 200 for a specific reqId,
 // resolve the pending promise immediately instead of waiting for timeout.
 const _pendingReqCallbacks = new Map<number, (code: number, msg: string) => void>();
@@ -89,6 +95,16 @@ export function onConnectionChange(fn: (state: boolean) => void): () => void {
   };
 }
 
+export interface AccountPnL {
+  dailyPnL: number | null;
+  unrealizedPnL: number | null;
+  realizedPnL: number | null;
+}
+
+export function getDailyPnL(): AccountPnL {
+  return { dailyPnL: _dailyPnL, unrealizedPnL: _unrealizedPnL, realizedPnL: _realizedPnL };
+}
+
 // ── Connect ──────────────────────────────────────────────
 
 export function connect(): void {
@@ -148,11 +164,32 @@ export function connect(): void {
   ib.on(EventName.managedAccounts, (accountsList: string) => {
     accounts = accountsList.split(',').map(a => a.trim()).filter(Boolean);
     console.log(`[IB] Managed accounts: ${accounts.join(', ')}`);
+
+    // Subscribe to account-level daily P&L once we have the account ID
+    if (accounts[0] && ib) {
+      _pnlReqId = getNextOrderId();
+      _dailyPnL = null;
+      _unrealizedPnL = null;
+      _realizedPnL = null;
+      try {
+        ib.reqPnL(_pnlReqId, accounts[0], '');
+        console.log(`[IB] Subscribed to account PnL (reqId=${_pnlReqId}, account=${accounts[0]})`);
+      } catch (err) {
+        console.warn(`[IB] reqPnL failed:`, err instanceof Error ? err.message : err);
+      }
+    }
   });
 
   ib.on(EventName.nextValidId, (orderId: number) => {
     nextOrderId = orderId;
     console.log(`[IB] Next valid order ID: ${nextOrderId}`);
+  });
+
+  ib.on(EventName.pnl, (reqId: number, dailyPnL: number, unrealizedPnL?: number, realizedPnL?: number) => {
+    if (reqId !== _pnlReqId) return;
+    _dailyPnL = dailyPnL;
+    _unrealizedPnL = unrealizedPnL ?? null;
+    _realizedPnL = realizedPnL ?? null;
   });
 
   // Connect
@@ -609,8 +646,14 @@ export function disconnect(): void {
     reconnectTimer = null;
   }
   if (ib) {
+    if (_pnlReqId) {
+      try { ib.cancelPnL(_pnlReqId); } catch { /* ignore */ }
+    }
     try { ib.disconnect(); } catch { /* ignore */ }
     ib = null;
   }
+  _dailyPnL = null;
+  _unrealizedPnL = null;
+  _realizedPnL = null;
   connected = false;
 }

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -757,9 +757,12 @@ export async function createAutoTradeEvent(
 ): Promise<void> {
   try {
     const sb = getSupabase();
-    await sb.from('auto_trade_events').insert(event);
-  } catch {
-    // fire-and-forget
+    const { error } = await sb.from('auto_trade_events').insert(event);
+    if (error) {
+      console.warn(`[Supabase] Failed to persist event for ${event.ticker}: ${error.message}`);
+    }
+  } catch (err) {
+    console.warn(`[Supabase] createAutoTradeEvent threw:`, err instanceof Error ? err.message : err);
   }
 }
 

--- a/auto-trader/src/routes/status.ts
+++ b/auto-trader/src/routes/status.ts
@@ -3,7 +3,7 @@
  */
 
 import { Router } from 'express';
-import { isConnected, getAccounts, getDefaultAccount } from '../ib-connection.js';
+import { isConnected, getAccounts, getDefaultAccount, getDailyPnL } from '../ib-connection.js';
 
 const router = Router();
 
@@ -13,9 +13,16 @@ router.get('/status', (_req, res) => {
     connected: isConnected(),
     accounts: getAccounts(),
     defaultAccount: account,
-    // Map to the shape the web app expects (IBAuthStatus)
     authenticated: isConnected(),
   });
+});
+
+router.get('/account-pnl', (_req, res) => {
+  if (!isConnected()) {
+    res.json({ dailyPnL: null, unrealizedPnL: null, realizedPnL: null });
+    return;
+  }
+  res.json(getDailyPnL());
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- **Fix silent event drops**: `createAutoTradeEvent` now checks for Supabase insert errors and logs warnings instead of silently swallowing failures (root cause of missing SMH/DG/TJX events)
- **IB P&L integration**: Subscribe to IB's `reqPnL` for real-time account-level daily P&L, exposed via new `GET /api/account-pnl` endpoint
- **Frontend P&L display**: Today's Activity now shows IB's realized P&L (with "IB" badge) when available, falling back to event-based calculation otherwise

## Test plan
- [ ] Verify auto-trader starts and logs `Subscribed to account PnL`
- [ ] Hit `GET http://localhost:3001/api/account-pnl` and confirm non-null values when IB Gateway is connected
- [ ] Check Today's Activity tab shows P&L with "IB" badge
- [ ] Disconnect IB Gateway and verify fallback to event-based P&L (no badge)


Made with [Cursor](https://cursor.com)