### PR TITLE
fix: revert to event-based realized P&L

### DIFF
--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -606,7 +606,6 @@ export function PaperTrading() {
               trades={allTrades}
               todaySignalsForExecute={todaySignalsForExecute}
               onExecuteSignal={refreshAfterAction}
-              ibRealizedPnl={ibAccountPnl?.realizedPnL ?? null}
             />
           )}
           {tab === 'smart' && (

--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -203,7 +203,7 @@ export interface TodayActivityTabProps {
   ibRealizedPnl?: number | null;
 }
 
-export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], onExecuteSignal, ibRealizedPnl }: TodayActivityTabProps) {
+export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], onExecuteSignal }: TodayActivityTabProps) {
   const [executingId, setExecutingId] = useState<string | null>(null);
   const [executingAll, setExecutingAll] = useState(false);
   const [scannerTickers, setScannerTickers] = useState<Set<string>>(new Set());
@@ -417,19 +417,13 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
     return sum;
   })();
 
-  const useIbPnl = ibRealizedPnl != null;
-  const todayPnl = useIbPnl ? ibRealizedPnl : eventBasedPnl;
+  const todayPnl = eventBasedPnl;
 
   return (
     <div className="space-y-3">
       {todayPnl !== 0 && (
         <div className="flex items-center justify-between rounded-lg bg-[hsl(var(--secondary))] px-4 py-2.5">
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-[hsl(var(--muted-foreground))]">Today&apos;s Realized P&L</span>
-            {useIbPnl && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 font-medium">IB</span>
-            )}
-          </div>
+          <span className="text-sm font-medium text-[hsl(var(--muted-foreground))]">Today&apos;s Realized P&L</span>
           <span className={cn('text-sm font-bold tabular-nums', todayPnl > 0 ? 'text-emerald-600' : todayPnl < 0 ? 'text-red-600' : '')}>
             {fmtUsd(todayPnl, 2, true)}
           </span>


### PR DESCRIPTION
## Summary
- IB's `reqPnL.realizedPnL` is cumulative and includes new purchase costs (buying RTX showed as -$1K loss), not today's closed-trade P&L
- Revert Today's Activity P&L to event-based calculation which only counts actually closed positions
- The `persistEvent` reliability fix from PR #193 ensures events won't be silently dropped

## Test plan
- [ ] Open Today's Activity — P&L should only reflect closed trades, not new purchases


Made with [Cursor](https://cursor.com)