### PR TITLE
fix: Today's Realized P&L was counting old trades

### DIFF
--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -288,8 +288,12 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
         : `All skipped:\n${skipReasons.slice(0, 5).join('\n')}${skipReasons.length > 5 ? '\n...' : ''}`);
     }
   };
+  const todayISO = todayStart.toISOString();
   const tradesByTicker = new Map<string, PaperTrade[]>();
   for (const t of trades) {
+    const openedToday = t.opened_at && t.opened_at >= todayISO;
+    const closedToday = t.closed_at && t.closed_at >= todayISO;
+    if (!openedToday && !closedToday) continue;
     const arr = tradesByTicker.get(t.ticker) || [];
     arr.push(t);
     tradesByTicker.set(t.ticker, arr);


### PR DESCRIPTION
## Summary
- `tradesByTicker` included ALL trades, not just today's
- Events for tickers like QQQ/SPY matched older profitable trades, inflating the P&L
- Now only trades opened or closed today are matched

## Test plan
- [ ] Verify Today's Realized P&L reflects only today's closed trade P&L


Made with [Cursor](https://cursor.com)