### PR TITLE
fix: use actual IB fill prices instead of blended avgCost for P&L

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -34,6 +34,10 @@ let _dailyPnL: number | null = null;
 let _unrealizedPnL: number | null = null;
 let _realizedPnL: number | null = null;
 
+// ── Order fill prices (from orderStatus events) ─────────
+// Maps orderId → avgFillPrice. Populated when IB reports a Filled status.
+const _orderFillPrices = new Map<number, number>();
+
 // Per-request error routing: when IB sends error code 200 for a specific reqId,
 // resolve the pending promise immediately instead of waiting for timeout.
 const _pendingReqCallbacks = new Map<number, (code: number, msg: string) => void>();
@@ -103,6 +107,14 @@ export interface AccountPnL {
 
 export function getDailyPnL(): AccountPnL {
   return { dailyPnL: _dailyPnL, unrealizedPnL: _unrealizedPnL, realizedPnL: _realizedPnL };
+}
+
+/**
+ * Get the actual IB fill price for an order. Returns undefined if no fill was
+ * received (order not yet filled, or filled before we started listening).
+ */
+export function getOrderFillPrice(orderId: number): number | undefined {
+  return _orderFillPrices.get(orderId);
 }
 
 // ── Connect ──────────────────────────────────────────────
@@ -190,6 +202,16 @@ export function connect(): void {
     _dailyPnL = dailyPnL;
     _unrealizedPnL = unrealizedPnL ?? null;
     _realizedPnL = realizedPnL ?? null;
+  });
+
+  ib.on(EventName.orderStatus, (
+    orderId: number, status: string, filled: number,
+    _remaining: number, avgFillPrice: number,
+  ) => {
+    if (status === 'Filled' && avgFillPrice > 0) {
+      _orderFillPrices.set(orderId, avgFillPrice);
+      console.log(`[IB] Order ${orderId} filled @ $${avgFillPrice.toFixed(4)}`);
+    }
   });
 
   // Connect

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -218,6 +218,8 @@ export interface PaperTrade {
   quantity: number | null;
   position_size: number | null;
   ib_order_id: string | null;
+  ib_tp_order_id: string | null;
+  ib_sl_order_id: string | null;
   status: string;
   fill_price: number | null;
   close_price: number | null;

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -21,6 +21,7 @@ import {
   placeBracketOrder,
   placeMarketOrder,
   cancelOrder,
+  getOrderFillPrice,
   type PositionData,
 } from './ib-connection.js';
 import {
@@ -2791,6 +2792,8 @@ async function executeScannerTrade(
       quantity: sizing.quantity,
       position_size: sizing.dollarSize,
       ib_order_id: String(result.parentOrderId),
+      ib_tp_order_id: String(result.takeProfitOrderId),
+      ib_sl_order_id: String(result.stopLossOrderId),
       status: 'SUBMITTED',
       scanner_reason: idea.reason,
       fa_rationale: null,
@@ -3444,6 +3447,8 @@ async function executeExternalStrategySignal(
       ? ` | allocation ${allocationIndex}/${allocationSplit}`
       : '';
 
+    let ibTpOrderId: string | undefined;
+    let ibSlOrderId: string | undefined;
     if (hasBracketLevels) {
       const result = await placeBracketOrder({
         symbol: ticker,
@@ -3455,6 +3460,8 @@ async function executeExternalStrategySignal(
         tif: signal.mode === 'DAY_TRADE' ? 'DAY' : 'GTC',
       });
       ibOrderId = String(result.parentOrderId);
+      ibTpOrderId = String(result.takeProfitOrderId);
+      ibSlOrderId = String(result.stopLossOrderId);
       if (signal.mode === 'SWING_TRADE') {
         upsertSwingMetrics({ date: getETDateString(), swing_orders_placed: 1 }).catch(() => {});
       }
@@ -3492,6 +3499,8 @@ async function executeExternalStrategySignal(
       position_size: sizing.dollarSize,
       entry_trigger_type: effectiveEntryPrice != null ? 'bracket_limit' : 'market',
       ib_order_id: ibOrderId,
+      ib_tp_order_id: ibTpOrderId ?? null,
+      ib_sl_order_id: ibSlOrderId ?? null,
       status: 'SUBMITTED',
       scanner_reason: `External strategy signal from ${signal.source_name}`,
       notes: signal.notes ? `External signal${splitLabel} | ${signal.notes}` : `External signal${splitLabel}`,
@@ -3741,13 +3750,14 @@ async function syncPositions(
         if (trade.mode === 'SWING_TRADE' && trade.entry_trigger_type === 'bracket_limit') {
           upsertSwingMetrics({ date: getETDateString(), swing_orders_filled: 1 }).catch(() => {});
         }
-        // BUY fills: avgCost is a good proxy for the execution price (IB recalculates after each buy).
-        // SELL fills: avgCost is the cost of the REMAINING long shares — NOT the sale price. Use
-        // entry_price instead, which was set to ibPos.mktPrice at order creation time and closely
-        // approximates the actual execution price for a market sell.
-        const fillPrice = trade.signal === 'SELL'
-          ? (trade.entry_price ?? ibPos.mktPrice)
-          : ibPos.avgCost;
+        // Priority for fill price:
+        // 1. IB orderStatus avgFillPrice — the actual execution price from IB (definitive)
+        // 2. entry_price — the limit/stop price we sent to IB (close approximation)
+        // 3. avgCost — LAST RESORT only; blended across ALL shares in the position,
+        //    so it's wrong when the account holds prior shares of the same ticker
+        const ibOrderId = trade.ib_order_id ? parseInt(trade.ib_order_id, 10) : NaN;
+        const ibFill = !Number.isNaN(ibOrderId) ? getOrderFillPrice(ibOrderId) : undefined;
+        const fillPrice = ibFill ?? trade.entry_price ?? ibPos.avgCost;
         const updates: Record<string, unknown> = {
           status: 'FILLED',
           fill_price: fillPrice,
@@ -3798,8 +3808,14 @@ async function syncPositions(
         });
       }
     } else if (trade.status === 'FILLED') {
-      // Position gone — closed
-      const closePrice = await getQuotePrice(trade.ticker);
+      // Position gone — closed by bracket TP/SL or manual action.
+      // Try to get actual exit fill price from IB orderStatus events first.
+      const tpId = trade.ib_tp_order_id ? parseInt(trade.ib_tp_order_id, 10) : NaN;
+      const slId = trade.ib_sl_order_id ? parseInt(trade.ib_sl_order_id, 10) : NaN;
+      const tpFill = !Number.isNaN(tpId) ? getOrderFillPrice(tpId) : undefined;
+      const slFill = !Number.isNaN(slId) ? getOrderFillPrice(slId) : undefined;
+      const ibExitFill = tpFill ?? slFill;
+      const closePrice = ibExitFill ?? (await getQuotePrice(trade.ticker));
       const fillPrice = trade.fill_price ?? trade.entry_price ?? 0;
       const qty = trade.quantity ?? 1;
       const isLong = trade.signal === 'BUY';

--- a/supabase/migrations/20260508000001_bracket_child_order_ids.sql
+++ b/supabase/migrations/20260508000001_bracket_child_order_ids.sql
@@ -1,0 +1,5 @@
+-- Add columns to store bracket child order IDs so we can look up actual IB fill
+-- prices for take-profit and stop-loss exits (not just entry fills).
+ALTER TABLE paper_trades
+  ADD COLUMN IF NOT EXISTS ib_tp_order_id text,
+  ADD COLUMN IF NOT EXISTS ib_sl_order_id text;


### PR DESCRIPTION
## Summary
- **Root cause**: When the account already holds shares of a ticker (e.g. long-term SPY/QQQ positions), `ibPos.avgCost` is the blended average across ALL shares — not today's fill price. This caused massive P&L errors (e.g. QQQ fill recorded as $680 when actual IB fill was $705, producing +$175 phantom profit).
- **Fix**: Listen to IB `orderStatus` events to capture actual `avgFillPrice` from IB, and use it as the primary source for fill prices. Falls back to `entry_price` (limit/stop price sent to IB) if orderStatus wasn't received.
- **Additionally**: Store bracket child order IDs (`ib_tp_order_id`, `ib_sl_order_id`) in `paper_trades` so exit fill prices from bracket stops/targets can also be resolved from IB.

## Test plan
- [x] Auto-trader builds and type-checks cleanly
- [x] Frontend builds cleanly
- [x] Auto-trader restarted and IB connection established
- [x] Migration applied to Supabase
- [ ] Verify next day trade fills show accurate IB fill prices in logs
- [ ] Verify P&L matches IBKR mobile after next trade cycle


Made with [Cursor](https://cursor.com)