### PR TITLE
fix: IB data integrity architecture — persistent fills, audit-mode sync, EOD reconciliation

### DIFF
--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -416,8 +416,11 @@ export function PaperTrading() {
   const totalCostBasis = longCostBasis + shortCostBasis;
   const totalMktValue  = longMktValue  + shortMktValue;
 
-  // Correct P&L: long gains (MV-CB) + short gains (CB-MV). This is the source of truth.
-  const totalUnrealizedPnl = pricedEquityPositions.reduce((sum, p) => sum + p.unrealizedPnl, 0);
+  // Use IB's own unrealized P&L (from reqPnL) when available — it includes all
+  // asset types (stocks + options) and matches what the IB mobile app shows.
+  // Fall back to equity-only calculation when IB data isn't available.
+  const equityUnrealizedPnl = pricedEquityPositions.reduce((sum, p) => sum + p.unrealizedPnl, 0);
+  const totalUnrealizedPnl = ibAccountPnl?.unrealizedPnL ?? equityUnrealizedPnl;
   const uniqueOrderTickers = new Set(ibOrders.map(o => o.ticker)).size;
 
   return (
@@ -530,7 +533,9 @@ export function PaperTrading() {
           icon={<TrendingUp className="w-4 h-4" />}
           label="Unrealized P&L"
           value={connected && totalMktValue > 0 ? fmtUsd(totalUnrealizedPnl, 0, true) : '—'}
-          subtitle={`Realized: ${fmtUsd(performance?.total_pnl ?? 0, 0, true)}`}
+          subtitle={ibAccountPnl?.realizedPnL != null
+            ? `Today Realized: ${fmtUsd(ibAccountPnl.realizedPnL, 0, true)}`
+            : `All-Time: ${fmtUsd(performance?.total_pnl ?? 0, 0, true)}`}
           color={totalUnrealizedPnl >= 0 ? 'green' : 'red'}
         />
         <StatCard

--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -7,6 +7,7 @@
  */
 
 import { IBApi, EventName, Contract, Order, OrderAction, OrderType, SecType, TimeInForce, OptionType } from '@stoqey/ib';
+import { insertIbFill, updateIbFillCommission, getTodayFillPrices } from './lib/supabase.js';
 
 // ── Configuration ────────────────────────────────────────
 
@@ -110,11 +111,48 @@ export function getDailyPnL(): AccountPnL {
 }
 
 /**
- * Get the actual IB fill price for an order. Returns undefined if no fill was
- * received (order not yet filled, or filled before we started listening).
+ * Get the actual IB fill price for an order from the in-memory cache.
+ * For a DB fallback when the cache misses, use getOrderFillPriceWithFallback().
  */
 export function getOrderFillPrice(orderId: number): number | undefined {
   return _orderFillPrices.get(orderId);
+}
+
+/**
+ * Get fill price with DB fallback. Use this in non-hot paths where an async
+ * call is acceptable (e.g. syncPositions closure logic).
+ */
+export async function getOrderFillPriceWithFallback(orderId: number): Promise<number | undefined> {
+  const cached = _orderFillPrices.get(orderId);
+  if (cached !== undefined) return cached;
+  const { getFillPriceByOrderId } = await import('./lib/supabase.js');
+  const dbPrice = await getFillPriceByOrderId(orderId);
+  if (dbPrice !== undefined) {
+    _orderFillPrices.set(orderId, dbPrice);
+  }
+  return dbPrice;
+}
+
+/**
+ * Hydrate the in-memory fill price cache from the ib_fills DB table.
+ * Called on startup to survive restarts.
+ */
+async function hydrateOrderFillPrices(): Promise<void> {
+  try {
+    const fills = await getTodayFillPrices();
+    let count = 0;
+    for (const [orderId, price] of fills) {
+      if (!_orderFillPrices.has(orderId)) {
+        _orderFillPrices.set(orderId, price);
+        count++;
+      }
+    }
+    if (count > 0) {
+      console.log(`[IB] Hydrated ${count} fill prices from DB`);
+    }
+  } catch (err) {
+    console.warn('[IB] Failed to hydrate fill prices from DB:', err instanceof Error ? err.message : err);
+  }
 }
 
 // ── Connect ──────────────────────────────────────────────
@@ -211,8 +249,56 @@ export function connect(): void {
     if (status === 'Filled' && avgFillPrice > 0) {
       _orderFillPrices.set(orderId, avgFillPrice);
       console.log(`[IB] Order ${orderId} filled @ $${avgFillPrice.toFixed(4)}`);
+      insertIbFill({
+        order_id: orderId,
+        ticker: '',  // orderStatus doesn't include contract info; execDetails will fill this
+        side: '',
+        quantity: filled,
+        fill_price: avgFillPrice,
+        filled_at: new Date().toISOString(),
+      }).catch(err => console.warn(`[IB] Failed to persist orderStatus fill: ${err instanceof Error ? err.message : err}`));
     }
   });
+
+  // execDetails gives us the definitive per-fill record with contract info
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (ib as any).on(EventName.execDetails, (_reqId: number, contract: any, execution: any) => {
+    const orderId = execution?.orderId ?? execution?.order?.orderId;
+    const price = execution?.price ?? execution?.avgPrice;
+    const qty = execution?.shares ?? execution?.cumQty ?? 0;
+    const execId = execution?.execId ?? null;
+    const side = execution?.side ?? '';
+    const ticker = contract?.symbol ?? '';
+
+    if (orderId && price > 0) {
+      _orderFillPrices.set(orderId, price);
+      console.log(`[IB] ExecDetails: order ${orderId} ${side} ${qty}x ${ticker} @ $${price.toFixed(4)} (execId=${execId})`);
+      insertIbFill({
+        order_id: orderId,
+        exec_id: execId,
+        ticker,
+        side,
+        quantity: qty,
+        fill_price: price,
+        filled_at: new Date().toISOString(),
+      }).catch(err => console.warn(`[IB] Failed to persist execDetails fill: ${err instanceof Error ? err.message : err}`));
+    }
+  });
+
+  // commissionReport arrives after execDetails — update the matching fill row
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (ib as any).on(EventName.commissionReport, (report: any) => {
+    const execId = report?.execId;
+    const commission = report?.commission;
+    if (execId && commission != null && commission < 1e6) {
+      console.log(`[IB] Commission: execId=${execId} commission=$${commission.toFixed(4)}`);
+      updateIbFillCommission(execId, commission)
+        .catch(err => console.warn(`[IB] Failed to update commission: ${err instanceof Error ? err.message : err}`));
+    }
+  });
+
+  // Hydrate fill price cache from DB on connect so we survive restarts
+  hydrateOrderFillPrices().catch(() => {});
 
   // Connect
   console.log(`[IB] Connecting to ${IB_HOST}:${IB_PORT} (clientId=${IB_CLIENT_ID})...`);

--- a/auto-trader/src/lib/reconcile-executions.ts
+++ b/auto-trader/src/lib/reconcile-executions.ts
@@ -1,0 +1,266 @@
+/**
+ * End-of-day reconciliation: calls IB's reqExecutions to get today's fills,
+ * compares against paper_trades, and corrects any fill_price / P&L discrepancies.
+ *
+ * Scheduled at 4:15 PM ET (after market close + EOD sweep).
+ */
+
+import { EventName } from '@stoqey/ib';
+import { getIBApi, isConnected, getNextOrderId, getDefaultAccount } from '../ib-connection.js';
+import { getSupabase, createAutoTradeEvent, type PaperTrade } from './supabase.js';
+import { recalculatePerformance } from './feedback.js';
+
+interface IBExecution {
+  orderId: number;
+  execId: string;
+  ticker: string;
+  side: string;
+  shares: number;
+  price: number;
+  time: string;
+}
+
+function log(msg: string): void {
+  console.log(`[Reconcile] ${msg}`);
+}
+
+export async function runEndOfDayReconciliation(): Promise<void> {
+  if (!isConnected()) {
+    log('Skipped — IB not connected');
+    return;
+  }
+
+  const ib = getIBApi();
+  if (!ib) {
+    log('Skipped — no IB API instance');
+    return;
+  }
+
+  const account = getDefaultAccount();
+  if (!account) {
+    log('Skipped — no account available');
+    return;
+  }
+
+  log('Starting end-of-day reconciliation...');
+
+  // Get today's date in ET for the IB filter
+  const etNow = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
+  const yyyy = etNow.getFullYear();
+  const mm = String(etNow.getMonth() + 1).padStart(2, '0');
+  const dd = String(etNow.getDate()).padStart(2, '0');
+  const todayFilterET = `${yyyy}${mm}${dd} 00:00:00`;
+
+  // 1. Request all of today's executions from IB
+  const executions = await requestExecutions(ib, account, todayFilterET);
+  log(`Received ${executions.length} executions from IB`);
+
+  if (executions.length === 0) {
+    log('No executions found — nothing to reconcile');
+    await logReconciliationSummary(0, 0, 0, 0);
+    return;
+  }
+
+  // 2. Get today's trades from paper_trades
+  const sb = getSupabase();
+  const todayStartET = new Date(etNow);
+  todayStartET.setHours(0, 0, 0, 0);
+  const todayStartUTC = new Date(todayStartET.toLocaleString('en-US', { timeZone: 'UTC' }));
+
+  const { data: todayTrades } = await sb
+    .from('paper_trades')
+    .select('*')
+    .or(`opened_at.gte.${todayStartUTC.toISOString()},closed_at.gte.${todayStartUTC.toISOString()},filled_at.gte.${todayStartUTC.toISOString()}`)
+    .not('status', 'in', '(CANCELLED,REJECTED)');
+
+  const trades = (todayTrades ?? []) as PaperTrade[];
+  log(`Found ${trades.length} paper_trades for today`);
+
+  // Build lookup: ib_order_id → trade
+  const tradeByOrderId = new Map<number, PaperTrade>();
+  const tradeByTpOrderId = new Map<number, PaperTrade>();
+  const tradeBySlOrderId = new Map<number, PaperTrade>();
+
+  for (const t of trades) {
+    if (t.ib_order_id) tradeByOrderId.set(parseInt(t.ib_order_id, 10), t);
+    if (t.ib_tp_order_id) tradeByTpOrderId.set(parseInt(t.ib_tp_order_id, 10), t);
+    if (t.ib_sl_order_id) tradeBySlOrderId.set(parseInt(t.ib_sl_order_id, 10), t);
+  }
+
+  // 3. Reconcile
+  let corrected = 0;
+  let orphaned = 0;
+  let matched = 0;
+  const correctionDetails: string[] = [];
+
+  for (const exec of executions) {
+    // Try to match by order ID — could be parent (entry), TP, or SL
+    let trade = tradeByOrderId.get(exec.orderId);
+    let matchType: 'entry' | 'tp' | 'sl' = 'entry';
+
+    if (!trade) {
+      trade = tradeByTpOrderId.get(exec.orderId);
+      matchType = 'tp';
+    }
+    if (!trade) {
+      trade = tradeBySlOrderId.get(exec.orderId);
+      matchType = 'sl';
+    }
+
+    if (!trade) {
+      orphaned++;
+      log(`Orphaned execution: order ${exec.orderId} ${exec.side} ${exec.shares}x ${exec.ticker} @ $${exec.price.toFixed(2)}`);
+      continue;
+    }
+
+    matched++;
+
+    if (matchType === 'entry') {
+      // Check entry fill price
+      const currentFill = trade.fill_price;
+      if (currentFill != null && Math.abs(currentFill - exec.price) > 0.005) {
+        const qty = trade.quantity ?? 1;
+        const isLong = trade.signal === 'BUY';
+
+        const updates: Record<string, unknown> = { fill_price: exec.price };
+
+        // If trade is closed, recalculate P&L with corrected fill price
+        if (trade.close_price != null && trade.close_price > 0) {
+          const pnl = isLong
+            ? (trade.close_price - exec.price) * qty
+            : (exec.price - trade.close_price) * qty;
+          updates.pnl = parseFloat(pnl.toFixed(2));
+          updates.pnl_percent = parseFloat(((pnl / (exec.price * qty)) * 100).toFixed(2));
+        }
+
+        await sb.from('paper_trades').update(updates).eq('id', trade.id);
+        corrected++;
+        correctionDetails.push(`${trade.ticker}: fill_price ${currentFill.toFixed(2)} → ${exec.price.toFixed(2)}`);
+        log(`Corrected ${trade.ticker} fill_price: $${currentFill.toFixed(2)} → $${exec.price.toFixed(2)}`);
+      }
+    } else {
+      // TP or SL fill — check close price
+      if (['STOPPED', 'TARGET_HIT', 'CLOSED'].includes(trade.status) && trade.close_price != null) {
+        if (Math.abs(trade.close_price - exec.price) > 0.005) {
+          const fillPrice = trade.fill_price ?? trade.entry_price ?? 0;
+          const qty = trade.quantity ?? 1;
+          const isLong = trade.signal === 'BUY';
+          const pnl = isLong
+            ? (exec.price - fillPrice) * qty
+            : (fillPrice - exec.price) * qty;
+
+          await sb.from('paper_trades').update({
+            close_price: exec.price,
+            pnl: parseFloat(pnl.toFixed(2)),
+            pnl_percent: fillPrice > 0 ? parseFloat(((pnl / (fillPrice * qty)) * 100).toFixed(2)) : null,
+          }).eq('id', trade.id);
+          corrected++;
+          correctionDetails.push(`${trade.ticker}: close_price ${trade.close_price.toFixed(2)} → ${exec.price.toFixed(2)}`);
+          log(`Corrected ${trade.ticker} close_price: $${trade.close_price.toFixed(2)} → $${exec.price.toFixed(2)}`);
+        }
+      }
+    }
+  }
+
+  // 4. Check for trades with IB orders but no matching execution (potential issues)
+  let flagged = 0;
+  for (const trade of trades) {
+    if (trade.status === 'FILLED' && trade.ib_order_id) {
+      const orderId = parseInt(trade.ib_order_id, 10);
+      const hasExec = executions.some(e => e.orderId === orderId);
+      if (!hasExec) {
+        // Not necessarily an error — trade may have been filled on a prior day
+        const filledAt = trade.filled_at ? new Date(trade.filled_at) : null;
+        const isFilledToday = filledAt && filledAt >= todayStartUTC;
+        if (isFilledToday) {
+          flagged++;
+          log(`[FLAG] ${trade.ticker}: FILLED today but no IB execution found (orderId=${orderId})`);
+        }
+      }
+    }
+  }
+
+  // 5. Recalculate global performance if corrections were made
+  if (corrected > 0) {
+    log(`Recalculating trade_performance after ${corrected} corrections...`);
+    await recalculatePerformance();
+  }
+
+  // 6. Log summary
+  await logReconciliationSummary(matched, corrected, orphaned, flagged, correctionDetails);
+  log(`Done: ${matched} matched, ${corrected} corrected, ${orphaned} orphaned, ${flagged} flagged`);
+}
+
+function requestExecutions(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ib: any,
+  account: string,
+  timeFilter: string
+): Promise<IBExecution[]> {
+  return new Promise((resolve) => {
+    const reqId = getNextOrderId();
+    const executions: IBExecution[] = [];
+    let resolved = false;
+
+    const timeout = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        resolve(executions);
+      }
+    }, 15_000);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const detailHandler = (rId: number, contract: any, execution: any) => {
+      if (rId !== reqId || resolved) return;
+      executions.push({
+        orderId: execution?.orderId ?? 0,
+        execId: execution?.execId ?? '',
+        ticker: contract?.symbol ?? '',
+        side: execution?.side ?? '',
+        shares: execution?.shares ?? execution?.cumQty ?? 0,
+        price: execution?.price ?? execution?.avgPrice ?? 0,
+        time: execution?.time ?? '',
+      });
+    };
+
+    const endHandler = (rId: number) => {
+      if (rId !== reqId || resolved) return;
+      resolved = true;
+      clearTimeout(timeout);
+      ib.off(EventName.execDetails, detailHandler);
+      ib.off(EventName.execDetailsEnd, endHandler);
+      resolve(executions);
+    };
+
+    ib.on(EventName.execDetails, detailHandler);
+    ib.on(EventName.execDetailsEnd, endHandler);
+
+    ib.reqExecutions(reqId, {
+      acctCode: account,
+      time: timeFilter,
+    });
+  });
+}
+
+async function logReconciliationSummary(
+  matched: number,
+  corrected: number,
+  orphaned: number,
+  flagged: number,
+  details?: string[]
+): Promise<void> {
+  try {
+    await createAutoTradeEvent({
+      ticker: 'SYSTEM',
+      action: 'RECONCILIATION',
+      status: corrected > 0 ? 'CORRECTED' : 'OK',
+      notes: [
+        `EOD reconciliation: ${matched} matched, ${corrected} corrected, ${orphaned} orphaned, ${flagged} flagged`,
+        ...(details ?? []),
+      ].join('\n'),
+      created_at: new Date().toISOString(),
+    });
+  } catch (err) {
+    log(`Failed to log reconciliation summary: ${err instanceof Error ? err.message : err}`);
+  }
+}

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -189,11 +189,14 @@ export async function saveConfigPartial(
   updates: Record<string, unknown>
 ): Promise<void> {
   const sb = getSupabase();
-  await sb.from('auto_trader_config').upsert({
+  const { error } = await sb.from('auto_trader_config').upsert({
     id: 'default',
     ...updates,
     updated_at: new Date().toISOString(),
   });
+  if (error) {
+    console.error(`[Supabase] saveConfigPartial failed: ${error.message}`);
+  }
 }
 
 // ── Paper Trades ─────────────────────────────────────────
@@ -246,6 +249,7 @@ export interface PaperTrade {
   // Long-term trailing stop tracking
   price_peak?: number | null;
   price_peak_date?: string | null;
+  missing_since?: string | null;
 }
 
 export type ExternalStrategySignalStatus =
@@ -839,13 +843,73 @@ export async function getAtRiskPositionEvents(): Promise<
   return (data ?? []) as { ticker: string; message: string; created_at: string; metadata: Record<string, unknown> }[];
 }
 
+// ── IB Fills (persistent fill price storage) ─────────────
+
+export interface IbFill {
+  order_id: number;
+  exec_id?: string | null;
+  ticker: string;
+  side: string;
+  quantity: number;
+  fill_price: number;
+  commission?: number | null;
+  filled_at: string;
+}
+
+export async function insertIbFill(fill: IbFill): Promise<void> {
+  const sb = getSupabase();
+  const { error } = await sb.from('ib_fills').insert(fill);
+  if (error) {
+    console.warn(`[Supabase] Failed to persist IB fill for order ${fill.order_id}: ${error.message}`);
+  }
+}
+
+export async function updateIbFillCommission(execId: string, commission: number): Promise<void> {
+  const sb = getSupabase();
+  const { error } = await sb.from('ib_fills').update({ commission }).eq('exec_id', execId);
+  if (error) {
+    console.warn(`[Supabase] Failed to update commission for exec ${execId}: ${error.message}`);
+  }
+}
+
+export async function getTodayFillPrices(): Promise<Map<number, number>> {
+  const sb = getSupabase();
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  const { data, error } = await sb
+    .from('ib_fills')
+    .select('order_id, fill_price')
+    .gte('filled_at', todayStart.toISOString());
+  if (error || !data) return new Map();
+  const map = new Map<number, number>();
+  for (const row of data) {
+    map.set(row.order_id, row.fill_price);
+  }
+  return map;
+}
+
+export async function getFillPriceByOrderId(orderId: number): Promise<number | undefined> {
+  const sb = getSupabase();
+  const { data } = await sb
+    .from('ib_fills')
+    .select('fill_price')
+    .eq('order_id', orderId)
+    .order('filled_at', { ascending: false })
+    .limit(1)
+    .single();
+  return data?.fill_price ?? undefined;
+}
+
 // ── Portfolio Snapshot ───────────────────────────────────
 
 export async function savePortfolioSnapshot(
   snapshot: Record<string, unknown>
 ): Promise<void> {
   const sb = getSupabase();
-  await sb.from('portfolio_snapshots').insert(snapshot);
+  const { error } = await sb.from('portfolio_snapshots').insert(snapshot);
+  if (error) {
+    console.error(`[Supabase] savePortfolioSnapshot failed: ${error.message}`);
+  }
 }
 
 // ── Performance ──────────────────────────────────────────
@@ -913,19 +977,22 @@ export async function writeScanEvaluations(
         Object.entries(evals).map(([ticker, ev]) => [ticker, { ...ev, evaluated_at }])
       ),
     };
-    await sb
+    const { error } = await sb
       .from('trade_scans')
       .update({ auto_evaluations: merged })
       .eq('id', scanId);
-  } catch {
-    // Non-critical — don't let UI sync failure impact trading
+    if (error) {
+      console.error(`[Supabase] writeScanEvaluations update failed for ${scanId}: ${error.message}`);
+    }
+  } catch (err) {
+    console.error(`[Supabase] writeScanEvaluations threw for ${scanId}:`, err instanceof Error ? err.message : err);
   }
 }
 
 export async function upsertHeartbeat(payload: HeartbeatPayload): Promise<void> {
   try {
     const sb = getSupabase();
-    await sb.from('system_heartbeats').upsert({
+    const { error } = await sb.from('system_heartbeats').upsert({
       id: 'auto-trader',
       last_seen_at: new Date().toISOString(),
       status: payload.status,
@@ -936,7 +1003,10 @@ export async function upsertHeartbeat(payload: HeartbeatPayload): Promise<void> 
       run_count: payload.runCount,
       updated_at: new Date().toISOString(),
     }, { onConflict: 'id' });
-  } catch {
-    // Intentionally silent — heartbeat failure must not impact trading
+    if (error) {
+      console.error(`[Supabase] upsertHeartbeat failed: ${error.message}`);
+    }
+  } catch (err) {
+    console.error(`[Supabase] upsertHeartbeat threw:`, err instanceof Error ? err.message : err);
   }
 }

--- a/auto-trader/src/lib/tradePerformanceLog.ts
+++ b/auto-trader/src/lib/tradePerformanceLog.ts
@@ -149,7 +149,7 @@ function parseTag(trade: PaperTrade): string | null {
 
 export interface LogContext {
   source: 'app' | 'scheduler';
-  trigger: 'EOD_CLOSE' | 'IB_POSITION_GONE' | 'EXPIRED_DAY_ORDER' | 'EXPIRED_SWING_BRACKET';
+  trigger: 'EOD_CLOSE' | 'IB_POSITION_GONE' | 'IB_FILL_CONFIRMED' | 'IB_POSITION_GONE_FALLBACK' | 'EXPIRED_DAY_ORDER' | 'EXPIRED_SWING_BRACKET';
 }
 
 /** Log a closed trade to trade_performance_log. Idempotent. */

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -22,6 +22,7 @@ import {
   placeMarketOrder,
   cancelOrder,
   getOrderFillPrice,
+  getOrderFillPriceWithFallback,
   type PositionData,
 } from './ib-connection.js';
 import {
@@ -75,6 +76,7 @@ import { runOptionsScan, autoTradeOption, getOptionsAutoTradeConfig } from './li
 import { runEarningsScan, closeExpiredEarningsPositions } from './lib/earnings-scanner.js';
 import { runWatchlistScreener } from './lib/watchlist-screener.js';
 import { runOptionsManageCycle } from './lib/options-manager.js';
+import { runEndOfDayReconciliation } from './lib/reconcile-executions.js';
 import { runDipWatcher } from './lib/dip-watcher.js';
 import { checkSpxLevelSetups } from './lib/spx-level-scanner.js';
 import { isInsideOrb } from './lib/orb.js';
@@ -312,6 +314,17 @@ export function startScheduler(): void {
       await closeAllDayTrades(config);
     }
   }, { timezone: 'America/New_York' });
+
+  // EOD reconciliation — 4:15 PM ET: compare today's IB executions against paper_trades,
+  // correct any fill_price / P&L discrepancies, and recalculate global performance.
+  cron.schedule('15 16 * * 1-5', async () => {
+    try {
+      await runEndOfDayReconciliation();
+    } catch (err) {
+      console.error('[EOD Reconcile] Failed:', err instanceof Error ? err.message : err);
+    }
+  }, { timezone: 'America/New_York' });
+  log('EOD reconciliation: 4:15 PM ET');
 
   // Earnings IV-crush scanner — 2:30 PM ET, enter calendar spreads for tonight's AMC
   // and tomorrow morning's BMO earnings announcements.
@@ -3746,6 +3759,11 @@ async function syncPositions(
     );
 
     if (ibPos && ibPos.position !== 0) {
+      // Position exists — clear missing_since if it was set (position reappeared)
+      if (trade.missing_since) {
+        await updatePaperTrade(trade.id, { missing_since: null });
+        log(`${trade.ticker}: Position reappeared — cleared missing_since`);
+      }
       if (trade.status === 'SUBMITTED' || trade.status === 'PENDING') {
         if (trade.mode === 'SWING_TRADE' && trade.entry_trigger_type === 'bracket_limit') {
           upsertSwingMetrics({ date: getETDateString(), swing_orders_filled: 1 }).catch(() => {});
@@ -3756,7 +3774,9 @@ async function syncPositions(
         // 3. avgCost — LAST RESORT only; blended across ALL shares in the position,
         //    so it's wrong when the account holds prior shares of the same ticker
         const ibOrderId = trade.ib_order_id ? parseInt(trade.ib_order_id, 10) : NaN;
-        const ibFill = !Number.isNaN(ibOrderId) ? getOrderFillPrice(ibOrderId) : undefined;
+        const ibFill = !Number.isNaN(ibOrderId)
+          ? (getOrderFillPrice(ibOrderId) ?? await getOrderFillPriceWithFallback(ibOrderId))
+          : undefined;
         const fillPrice = ibFill ?? trade.entry_price ?? ibPos.avgCost;
         const updates: Record<string, unknown> = {
           status: 'FILLED',
@@ -3809,13 +3829,40 @@ async function syncPositions(
       }
     } else if (trade.status === 'FILLED') {
       // Position gone — closed by bracket TP/SL or manual action.
-      // Try to get actual exit fill price from IB orderStatus events first.
+      // 2-cycle guard: don't auto-close on first detection. Set missing_since,
+      // wait 30 min (2 sync cycles) before confirming closure.
+      const MISSING_GUARD_MS = 30 * 60 * 1000; // 30 minutes
+
+      // Try to get actual exit fill price from IB fills (cache + DB fallback)
       const tpId = trade.ib_tp_order_id ? parseInt(trade.ib_tp_order_id, 10) : NaN;
       const slId = trade.ib_sl_order_id ? parseInt(trade.ib_sl_order_id, 10) : NaN;
-      const tpFill = !Number.isNaN(tpId) ? getOrderFillPrice(tpId) : undefined;
-      const slFill = !Number.isNaN(slId) ? getOrderFillPrice(slId) : undefined;
+      const tpFill = !Number.isNaN(tpId) ? await getOrderFillPriceWithFallback(tpId) : undefined;
+      const slFill = !Number.isNaN(slId) ? await getOrderFillPriceWithFallback(slId) : undefined;
       const ibExitFill = tpFill ?? slFill;
+
+      // If we have a confirmed IB exit fill, close immediately (no guard needed)
+      const hasConfirmedFill = ibExitFill !== undefined;
+
+      if (!hasConfirmedFill && !trade.missing_since) {
+        // First detection — mark as missing, don't close yet
+        await updatePaperTrade(trade.id, { missing_since: new Date().toISOString() });
+        log(`${trade.ticker}: Position missing — marking missing_since (will confirm in ~30 min)`);
+        continue;
+      }
+
+      if (!hasConfirmedFill && trade.missing_since) {
+        const missingFor = Date.now() - new Date(trade.missing_since).getTime();
+        if (missingFor < MISSING_GUARD_MS) {
+          log(`${trade.ticker}: Position still missing (${Math.round(missingFor / 60000)} min) — waiting for guard period`);
+          continue;
+        }
+        log(`${trade.ticker}: Position missing for ${Math.round(missingFor / 60000)} min — proceeding with closure (fallback)`);
+      }
+
       const closePrice = ibExitFill ?? (await getQuotePrice(trade.ticker));
+      if (!hasConfirmedFill) {
+        log(`[WARN] ${trade.ticker}: Closing with fallback quote price (no IB fill found) — close_price=${closePrice}`);
+      }
       const fillPrice = trade.fill_price ?? trade.entry_price ?? 0;
       const qty = trade.quantity ?? 1;
       const isLong = trade.signal === 'BUY';
@@ -3857,8 +3904,9 @@ async function syncPositions(
         pnl: pnlVal,
         pnl_percent: pnlPct,
         r_multiple: rMultiple,
+        missing_since: null,
       });
-      log(`${trade.ticker}: Closed (${closeReason}) — P&L $${pnl.toFixed(2)}`);
+      log(`${trade.ticker}: Closed (${closeReason}) — P&L $${pnl.toFixed(2)}${hasConfirmedFill ? '' : ' [fallback price]'}`);
       const closedTrade = {
         ...trade,
         status,
@@ -3883,7 +3931,7 @@ async function syncPositions(
       }
       logClosedTradePerformance(closedTrade as import('./lib/supabase.js').PaperTrade, {
         source: 'scheduler',
-        trigger: 'IB_POSITION_GONE',
+        trigger: hasConfirmedFill ? 'IB_FILL_CONFIRMED' : 'IB_POSITION_GONE_FALLBACK',
       }).catch(err => log(`Trade perf log failed for ${trade.ticker}: ${err instanceof Error ? err.message : 'unknown'}`));
     } else if (trade.status === 'SUBMITTED') {
       const tradeAge = Date.now() - new Date(trade.created_at).getTime();

--- a/supabase/migrations/20260509000001_ib_fills_table.sql
+++ b/supabase/migrations/20260509000001_ib_fills_table.sql
@@ -1,0 +1,30 @@
+-- Persistent storage for IB fill events. Replaces the volatile in-memory Map
+-- that was lost on every auto-trader restart. Each fill from orderStatus or
+-- execDetails is recorded here so fill prices survive restarts and can be
+-- audited against IB's execution ledger.
+
+CREATE TABLE ib_fills (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  order_id integer NOT NULL,
+  exec_id text,
+  ticker text NOT NULL,
+  side text NOT NULL,
+  quantity numeric NOT NULL,
+  fill_price numeric NOT NULL,
+  commission numeric,
+  filled_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE ib_fills ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "read_ib_fills" ON ib_fills FOR SELECT USING (true);
+CREATE POLICY "insert_ib_fills" ON ib_fills FOR INSERT WITH CHECK (true);
+CREATE POLICY "update_ib_fills" ON ib_fills FOR UPDATE USING (true);
+
+CREATE INDEX idx_ib_fills_order_id ON ib_fills(order_id);
+CREATE INDEX idx_ib_fills_ticker_filled ON ib_fills(ticker, filled_at);
+
+-- Also add missing_since column to paper_trades for the 2-cycle close guard.
+-- When syncPositions detects a position is gone, it records the timestamp here
+-- instead of immediately closing. Only closes after 2 consecutive cycles (~30 min).
+ALTER TABLE paper_trades ADD COLUMN IF NOT EXISTS missing_since timestamptz;


### PR DESCRIPTION
## Summary

- **Persistent fill storage**: New `ib_fills` Supabase table replaces the volatile in-memory `Map` that was lost on every auto-trader restart. Every fill from `orderStatus`, `execDetails`, and `commissionReport` events is now durably stored.
- **Audit-mode syncPositions**: Position disappearance no longer triggers immediate auto-close. A `missing_since` timestamp is set on first detection, and closure only happens after 2 consecutive sync cycles (~30 min) or when an IB fill is confirmed. This prevents incorrect closures of long-term positions.
- **EOD reconciliation**: New 4:15 PM ET cron job calls IB's `reqExecutions` to get all of today's fills, compares against `paper_trades`, corrects any `fill_price`/P&L discrepancies, and recalculates global performance.
- **Error propagation**: Fixed silent error swallowing in `saveConfigPartial`, `savePortfolioSnapshot`, `writeScanEvaluations`, and `upsertHeartbeat` — all DB write failures are now logged.

## Test plan

- [ ] Verify `ib_fills` table created in Supabase with correct RLS policies
- [ ] Verify auto-trader builds and starts successfully
- [ ] Place a test trade and confirm fill is persisted to `ib_fills` table
- [ ] Restart auto-trader and verify fill prices are hydrated from DB
- [ ] Verify syncPositions logs `missing_since` instead of immediately closing
- [ ] Verify EOD reconciliation runs at 4:15 PM ET (check logs)


Made with [Cursor](https://cursor.com)