### PR TITLE
fix: type-safe auto_trade_events action/source values

### DIFF
--- a/.cursor/rules/auto-trader-conventions.mdc
+++ b/.cursor/rules/auto-trader-conventions.mdc
@@ -1,6 +1,6 @@
 ---
 description: Auto-trader system conventions — IB integration, paper trades, and trading logic
-globs: "{app/src/lib/autoTrader.ts,app/src/lib/paperTradesApi.ts,app/src/lib/ibClient.ts,app/src/hooks/useAutoTradeScheduler.ts,app/src/components/PaperTrading.tsx,auto-trader/**}"
+globs: "{app/src/lib/autoTrader.ts,app/src/lib/paperTradesApi.ts,app/src/lib/ibClient.ts,app/src/hooks/useAutoTradeScheduler.ts,app/src/components/PaperTrading/**,auto-trader/**}"
 alwaysApply: false
 ---
 
@@ -23,9 +23,26 @@ Browser (React) → auto-trader service (localhost:3001) → IB Gateway (TWS API
 - `DAY_TRADE` — Scanner signals, bracket orders, auto-close EOD
 - `SWING_TRADE` — Scanner signals, bracket orders, GTC
 
-## Event Sources
+## Event Sources & Actions (auto_trade_events)
 
-`auto_trade_events.source` must be one of: `scanner`, `suggested_finds`, `manual`, `system`, `dip_buy`, `profit_take`, `spx_level_scanner`
+**When adding a new `action` or `source` value, you MUST grep the entire codebase and update all consumers.** This is the #1 source of UI bugs — a new value on the write side that no read-side query knows about.
+
+Producers (auto-trader) write events → Consumers (frontend) query them. Both must agree.
+
+### `action` values
+`executed`, `closed`, `skipped`, `failed`
+
+- Frontend type: `AutoTradeEventRecord.action` in `app/src/lib/paperTradesApi.ts`
+- Frontend query: `getTodaysExecutedEvents()` filters on action — update it
+- Parent dedup: `PaperTrading/index.tsx` `dedupedToday` — key includes action
+
+### `source` values
+`scanner`, `suggested_finds`, `manual`, `system`, `dip_buy`, `profit_take`, `loss_cut`, `lt_auto_sell`, `swing_expiry`, `capital_pressure`, `external_signal`, `spx_level_scanner`
+
+- Frontend type: `AutoTradeEventRecord.source` in `app/src/lib/paperTradesApi.ts`
+- Display labels: `TodayActivityTab.tsx` `sourceLabel` chain
+- Sell inference: `TodayActivityTab.tsx` `SELL_SOURCES` set
+- P&L aggregation: `TodayActivityTab.tsx` `eventBasedPnl` `AUTO_CLOSE` set
 
 ## SPX Key-Level Breakout-Retest Strategy
 

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -576,13 +576,17 @@ export async function getRecentLearnings(limit = 20): Promise<TradeLearning[]> {
 
 // ── Auto Trade Events ────────────────────────────────────
 
+/**
+ * Canonical action/source/mode values — must stay in sync with
+ * AutoTradeAction / AutoTradeSource / AutoTradeMode in auto-trader/src/lib/supabase.ts
+ */
 export interface AutoTradeEventRecord {
   id: string;
   ticker: string;
   event_type: 'info' | 'success' | 'warning' | 'error';
-  action: 'executed' | 'skipped' | 'failed' | 'closed' | null;
-  source: 'scanner' | 'suggested_finds' | 'manual' | 'system' | 'dip_buy' | 'profit_take' | 'loss_cut' | 'lt_auto_sell' | 'swing_expiry' | 'capital_pressure' | 'external_signal' | null;
-  mode: 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL' | null;
+  action: 'executed' | 'skipped' | 'failed' | 'closed' | 'proceeding' | 'health_check' | 'RECONCILIATION' | 'scan_complete' | null;
+  source: 'scanner' | 'suggested_finds' | 'manual' | 'system' | 'dip_buy' | 'profit_take' | 'loss_cut' | 'lt_auto_sell' | 'swing_expiry' | 'capital_pressure' | 'external_signal' | 'spx_level_scanner' | 'earnings_scanner' | 'watchlist_screener' | 'compounder_health' | null;
+  mode: 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL' | 'EARNINGS_CALENDAR' | null;
   message: string;
   strategy_source: string | null;
   strategy_source_url: string | null;

--- a/auto-trader/src/lib/reconcile-executions.ts
+++ b/auto-trader/src/lib/reconcile-executions.ts
@@ -253,12 +253,13 @@ async function logReconciliationSummary(
     await createAutoTradeEvent({
       ticker: 'SYSTEM',
       action: 'RECONCILIATION',
-      status: corrected > 0 ? 'CORRECTED' : 'OK',
-      notes: [
-        `EOD reconciliation: ${matched} matched, ${corrected} corrected, ${orphaned} orphaned, ${flagged} flagged`,
-        ...(details ?? []),
-      ].join('\n'),
-      created_at: new Date().toISOString(),
+      source: 'system',
+      message: `EOD reconciliation: ${matched} matched, ${corrected} corrected, ${orphaned} orphaned, ${flagged} flagged`,
+      metadata: {
+        status: corrected > 0 ? 'CORRECTED' : 'OK',
+        matched, corrected, orphaned, flagged,
+        notes: (details ?? []).join('\n') || undefined,
+      },
     });
   } catch (err) {
     log(`Failed to log reconciliation summary: ${err instanceof Error ? err.message : err}`);

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -758,8 +758,33 @@ export async function getRecentClosedStrategyOutcomes(params: {
 
 // ── Auto Trade Events ────────────────────────────────────
 
+export type AutoTradeAction = 'executed' | 'closed' | 'skipped' | 'failed' | 'proceeding' | 'health_check' | 'RECONCILIATION' | 'scan_complete';
+export type AutoTradeSource = 'scanner' | 'suggested_finds' | 'manual' | 'system' | 'dip_buy' | 'profit_take' | 'loss_cut' | 'lt_auto_sell' | 'swing_expiry' | 'capital_pressure' | 'external_signal' | 'spx_level_scanner' | 'earnings_scanner' | 'watchlist_screener' | 'compounder_health';
+export type AutoTradeMode = 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL' | 'EARNINGS_CALENDAR';
+
+export interface AutoTradeEventInput {
+  ticker: string;
+  event_type?: string;
+  message: string;
+  action?: AutoTradeAction;
+  source?: AutoTradeSource;
+  mode?: AutoTradeMode;
+  scanner_signal?: string | null;
+  scanner_confidence?: number | null;
+  fa_recommendation?: string | null;
+  fa_confidence?: number | null;
+  skip_reason?: string | null;
+  strategy_source?: string | null;
+  strategy_source_url?: string | null;
+  strategy_video_id?: string | null;
+  strategy_video_heading?: string | null;
+  metadata?: Record<string, unknown>;
+  candle_patterns?: string[];
+  [key: string]: unknown;
+}
+
 export async function createAutoTradeEvent(
-  event: Record<string, unknown>
+  event: AutoTradeEventInput
 ): Promise<void> {
   try {
     const sb = getSupabase();

--- a/auto-trader/src/lib/watchlist-screener.ts
+++ b/auto-trader/src/lib/watchlist-screener.ts
@@ -227,6 +227,8 @@ export async function runWatchlistScreener(): Promise<void> {
   console.log(`[Watchlist Screener] Done. ${top.length} added, ${skipped.length} skipped.`);
 
   await createAutoTradeEvent({
+    ticker: 'SYSTEM',
+    message: `Watchlist scan complete: ${top.length} added, ${skipped.length} skipped`,
     action: 'scan_complete',
     source: 'watchlist_screener',
     metadata: {

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -44,6 +44,7 @@ import {
   updatePaperTrade,
   upsertSwingMetrics,
   createAutoTradeEvent,
+  type AutoTradeEventInput,
   getRecentDipBuyEvents,
   getPastTrimEvents,
   getPastLossCutEvents,
@@ -782,9 +783,11 @@ export async function reconcileIBShorts(): Promise<{ closed: string[]; errors: s
       closed.push(pos.symbol);
       await createAutoTradeEvent({
         ticker: pos.symbol,
-        level: 'warn',
+        event_type: 'warning',
+        action: 'executed',
+        source: 'system',
         message: `[IBReconcile] Orphaned short covered: BUY ${qty} shares (avg cost ${pos.avgCost})`,
-        metadata: { action: 'ib_short_reconcile', qty, avg_cost: pos.avgCost },
+        metadata: { reconcile_type: 'ib_short_reconcile', qty, avg_cost: pos.avgCost },
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'unknown';
@@ -1887,7 +1890,7 @@ function persistEvent(
   ticker: string,
   eventType: string,
   message: string,
-  extra?: Record<string, unknown>
+  extra?: Omit<AutoTradeEventInput, 'ticker' | 'message'>
 ): void {
   createAutoTradeEvent({ ticker, event_type: eventType, message, ...extra });
 }


### PR DESCRIPTION
## Summary
- Adds TypeScript type enforcement for `auto_trade_events` action/source/mode values across both the auto-trader (producer) and frontend (consumer)
- `createAutoTradeEvent` now accepts `AutoTradeEventInput` instead of `Record<string, unknown>` — TypeScript will error at compile time if a new action/source value is used without being added to the union type
- The same unions are mirrored in the frontend `AutoTradeEventRecord` — adding a value on one side without the other is now a conscious decision, not an accident

## What this prevents
This is the class of bug that caused today's missing lt_auto_sell events (#199). Someone added `action: 'closed'` on the write side, but the read side only queried `'executed' | 'failed'`. With typed events, adding a new action value requires updating the type union first, which surfaces all the places that need updating.

## Files changed
- `auto-trader/src/lib/supabase.ts` — canonical type definitions (AutoTradeAction, AutoTradeSource, AutoTradeMode, AutoTradeEventInput)
- `auto-trader/src/scheduler.ts` — typed persistEvent(), import types
- `auto-trader/src/lib/reconcile-executions.ts` — conform to typed interface
- `auto-trader/src/lib/watchlist-screener.ts` — conform to typed interface
- `app/src/lib/paperTradesApi.ts` — mirror complete unions in AutoTradeEventRecord
- `.cursor/rules/auto-trader-conventions.mdc` — document canonical values and consumer locations

## Test plan
- [x] auto-trader builds clean (`npm run build`)
- [x] app builds clean (`npm run build`)
- [x] auto-trader restarted and running

Made with [Cursor](https://cursor.com)