### PR TITLE
feat: options wheel improvements — fundamental gate, strike sniper, consistency fixes

### DIFF
--- a/app/src/components/PaperTrading/tabs/OptionsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/OptionsTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { RefreshCw, Plus, X, AlertTriangle, CheckCircle, Activity, Pencil, Check, TrendingUp, DollarSign } from 'lucide-react';
+import { RefreshCw, Plus, X, AlertTriangle, CheckCircle, Activity, Pencil, Check, TrendingUp, DollarSign, Crosshair, Search, Loader2 } from 'lucide-react';
 import { cn } from '../../../lib/utils';
 import { fmtUsd } from '../utils';
 import {
@@ -461,7 +461,7 @@ export function OptionsTab() {
   const [prices, setPrices] = useState<Map<string, TickerQuote>>(new Map());
   const [openPrices, setOpenPrices] = useState<Map<string, TickerQuote>>(new Map());
   const [maxAllocation, setMaxAllocation] = useState<number>(500_000);
-  const [activeSection, setActiveSection] = useState<'positions' | 'history' | 'watchlist' | 'log'>('positions');
+  const [activeSection, setActiveSection] = useState<'positions' | 'history' | 'watchlist' | 'log' | 'sniper'>('positions');
   const [tierFilter, setTierFilter]     = useState<'ALL' | 'STABLE' | 'GROWTH' | 'HIGH_VOL'>('ALL');
   const [sectorFilter, setSectorFilter] = useState<string>('ALL');
 
@@ -620,10 +620,51 @@ export function OptionsTab() {
     [[], []]
   );
 
+  // Strike Sniper state
+  const [sniperTicker, setSniperTicker] = useState('');
+  const [sniperTarget, setSniperTarget] = useState('');
+  const [sniperLoading, setSniperLoading] = useState(false);
+  const [sniperResults, setSniperResults] = useState<{
+    symbol: string;
+    currentPrice: number | null;
+    targetStrike: number;
+    fundamental: { grade: string; score: number };
+    contracts: Array<{
+      expiry: string;
+      strike: number;
+      premium: number;
+      delta: number;
+      annualizedROI: number;
+      dte: number;
+      collateral: number;
+    }>;
+  } | null>(null);
+  const [sniperError, setSniperError] = useState<string | null>(null);
+
+  async function handleSniperSearch() {
+    const ticker = sniperTicker.trim().toUpperCase();
+    const target = parseFloat(sniperTarget);
+    if (!ticker || !Number.isFinite(target) || target <= 0) return;
+    setSniperLoading(true);
+    setSniperError(null);
+    setSniperResults(null);
+    try {
+      const res = await fetch(`http://localhost:3001/api/options/strike-sniper?symbol=${ticker}&targetStrike=${target}`);
+      if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error ?? 'Request failed');
+      const data = await res.json();
+      setSniperResults(data);
+    } catch (err) {
+      setSniperError(err instanceof Error ? err.message : 'Failed to fetch');
+    } finally {
+      setSniperLoading(false);
+    }
+  }
+
   const sections = [
     { id: 'positions' as const, label: 'Open', count: openPositions.length },
     { id: 'history' as const, label: 'History', count: closedPositions.length },
     { id: 'watchlist' as const, label: 'Watchlist', count: watchlist.filter(w => w.active).length },
+    { id: 'sniper' as const, label: 'Sniper', count: 0 },
     { id: 'log' as const, label: 'Log', count: activityLog.length },
   ];
 
@@ -1055,6 +1096,136 @@ export function OptionsTab() {
             );
           })()}
 
+        </div>
+      )}
+
+      {/* Strike Sniper */}
+      {activeSection === 'sniper' && (
+        <div className="space-y-4">
+          <div className="rounded-xl border border-violet-200 bg-violet-50/60 px-4 py-3 space-y-2">
+            <div className="flex items-center gap-2">
+              <Crosshair className="w-4 h-4 text-violet-700" />
+              <span className="text-xs font-semibold text-violet-800">Strike Sniper</span>
+            </div>
+            <p className="text-[10px] text-violet-700 leading-relaxed">
+              Enter a stock and your target ownership price. The sniper finds the best put contract across all expirations, ranked by annualized return.
+            </p>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                placeholder="Ticker"
+                value={sniperTicker}
+                onChange={e => setSniperTicker(e.target.value.toUpperCase())}
+                onKeyDown={e => e.key === 'Enter' && handleSniperSearch()}
+                className="w-24 text-sm px-3 py-2 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--background))] focus:outline-none focus:ring-2 focus:ring-violet-500"
+              />
+              <input
+                type="number"
+                placeholder="Target price"
+                value={sniperTarget}
+                onChange={e => setSniperTarget(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && handleSniperSearch()}
+                className="w-32 text-sm px-3 py-2 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--background))] focus:outline-none focus:ring-2 focus:ring-violet-500"
+              />
+              <button
+                onClick={handleSniperSearch}
+                disabled={sniperLoading || !sniperTicker.trim() || !sniperTarget}
+                className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-violet-600 text-white text-sm font-semibold hover:bg-violet-700 disabled:opacity-50 transition-colors"
+              >
+                {sniperLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Search className="w-4 h-4" />}
+                Find
+              </button>
+            </div>
+          </div>
+
+          {sniperError && (
+            <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3">
+              <p className="text-xs text-red-700">{sniperError}</p>
+            </div>
+          )}
+
+          {sniperResults && (
+            <div className="space-y-3">
+              <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-4 py-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-bold text-[hsl(var(--foreground))]">{sniperResults.symbol}</span>
+                    {sniperResults.currentPrice != null && (
+                      <span className="text-xs text-[hsl(var(--muted-foreground))]">
+                        Current: <span className="font-semibold">${sniperResults.currentPrice.toFixed(2)}</span>
+                      </span>
+                    )}
+                    <span className="text-xs text-[hsl(var(--muted-foreground))]">
+                      Target: <span className="font-semibold text-violet-700">${sniperResults.targetStrike}</span>
+                    </span>
+                  </div>
+                  <span className={cn(
+                    'text-[10px] px-2 py-0.5 rounded-full font-bold',
+                    sniperResults.fundamental.grade === 'A' && 'bg-emerald-100 text-emerald-700',
+                    sniperResults.fundamental.grade === 'B' && 'bg-blue-100 text-blue-700',
+                    sniperResults.fundamental.grade === 'C' && 'bg-amber-100 text-amber-700',
+                    (sniperResults.fundamental.grade === 'D' || sniperResults.fundamental.grade === 'F') && 'bg-red-100 text-red-700',
+                  )}>
+                    Grade: {sniperResults.fundamental.grade} ({sniperResults.fundamental.score})
+                  </span>
+                </div>
+              </div>
+
+              {sniperResults.contracts.length === 0 ? (
+                <div className="text-center py-8 text-sm text-[hsl(var(--muted-foreground))]">
+                  No contracts found meeting the minimum return threshold. Try a different target price.
+                </div>
+              ) : (
+                <div className="rounded-xl border border-[hsl(var(--border))] overflow-hidden">
+                  <table className="w-full text-xs">
+                    <thead>
+                      <tr className="bg-[hsl(var(--muted))]/50 text-[hsl(var(--muted-foreground))]">
+                        <th className="text-left px-3 py-2 font-semibold">Expiry</th>
+                        <th className="text-right px-3 py-2 font-semibold">DTE</th>
+                        <th className="text-right px-3 py-2 font-semibold">Strike</th>
+                        <th className="text-right px-3 py-2 font-semibold">Premium</th>
+                        <th className="text-right px-3 py-2 font-semibold">Delta</th>
+                        <th className="text-right px-3 py-2 font-semibold">Ann. ROI</th>
+                        <th className="text-right px-3 py-2 font-semibold">Collateral</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sniperResults.contracts.map((c, i) => {
+                        const expiryFmt = c.expiry.length === 8
+                          ? `${c.expiry.slice(0, 4)}-${c.expiry.slice(4, 6)}-${c.expiry.slice(6, 8)}`
+                          : c.expiry;
+                        return (
+                          <tr
+                            key={i}
+                            className={cn(
+                              'border-t border-[hsl(var(--border))]',
+                              i === 0 && 'bg-emerald-50/60',
+                            )}
+                          >
+                            <td className="px-3 py-2 font-medium text-[hsl(var(--foreground))]">
+                              {new Date(expiryFmt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                              {i === 0 && <span className="ml-1.5 text-[9px] font-bold text-emerald-700 bg-emerald-100 px-1 py-0.5 rounded">BEST</span>}
+                            </td>
+                            <td className="text-right px-3 py-2 tabular-nums">{c.dte}d</td>
+                            <td className="text-right px-3 py-2 font-semibold tabular-nums">${c.strike}</td>
+                            <td className="text-right px-3 py-2 text-emerald-700 font-semibold tabular-nums">${c.premium.toFixed(2)}</td>
+                            <td className="text-right px-3 py-2 tabular-nums">{Math.abs(c.delta).toFixed(2)}</td>
+                            <td className={cn(
+                              'text-right px-3 py-2 font-bold tabular-nums',
+                              c.annualizedROI >= 20 ? 'text-emerald-700' : c.annualizedROI >= 10 ? 'text-blue-700' : 'text-[hsl(var(--foreground))]'
+                            )}>
+                              {c.annualizedROI.toFixed(1)}%
+                            </td>
+                            <td className="text-right px-3 py-2 tabular-nums text-[hsl(var(--muted-foreground))]">{fmtUsd(c.collateral, 0)}</td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/auto-trader/src/index.ts
+++ b/auto-trader/src/index.ts
@@ -21,6 +21,7 @@ import schedulerRoutes from './routes/scheduler.js';
 import strategyRoutes from './routes/strategies.js';
 import performanceLogRoutes from './routes/performance-log.js';
 import paperTradingRoutes from './routes/paper-trading.js';
+import optionsRoutes from './routes/options.js';
 import { startScheduler, stopScheduler } from './scheduler.js';
 
 const PORT = parseInt(process.env.PORT ?? '3001', 10);
@@ -58,6 +59,7 @@ app.use('/api', schedulerRoutes);
 app.use('/api', strategyRoutes);
 app.use('/api', performanceLogRoutes);
 app.use('/api', paperTradingRoutes);
+app.use('/api', optionsRoutes);
 
 // ── Compatibility endpoints (match old CPGW paths) ──────
 

--- a/auto-trader/src/lib/fundamental-grader.ts
+++ b/auto-trader/src/lib/fundamental-grader.ts
@@ -1,0 +1,156 @@
+/**
+ * Fundamental quality grader for options wheel candidates.
+ * Uses Finnhub /stock/metric?metric=all to score stocks A-F.
+ * Results are cached in memory with 24h TTL.
+ */
+
+const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+
+export type FundamentalGrade = 'A' | 'B' | 'C' | 'D' | 'F';
+
+export interface FundamentalResult {
+  grade: FundamentalGrade;
+  score: number;
+  breakdown: Record<string, { raw: number | null; points: number }>;
+}
+
+interface CacheEntry {
+  result: FundamentalResult;
+  ts: number;
+}
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const cache = new Map<string, CacheEntry>();
+
+interface FinnhubMetricAll {
+  metric?: Record<string, number | null>;
+}
+
+function gradeFromScore(score: number): FundamentalGrade {
+  if (score >= 80) return 'A';
+  if (score >= 65) return 'B';
+  if (score >= 50) return 'C';
+  if (score >= 35) return 'D';
+  return 'F';
+}
+
+/**
+ * Score a single metric on a 0-20 scale (6 metrics × ~16.7 each = 100 max).
+ * Each metric maps raw value to a 0–16.7 point score using piecewise linear bands.
+ */
+function scorePE(pe: number | null): number {
+  if (pe == null || pe <= 0) return 5; // no data or negative earnings → neutral
+  if (pe <= 12) return 16.7;
+  if (pe <= 18) return 14;
+  if (pe <= 25) return 11;
+  if (pe <= 35) return 7;
+  if (pe <= 50) return 4;
+  return 1;
+}
+
+function scoreDebtEquity(de: number | null): number {
+  if (de == null) return 8; // no data → neutral
+  if (de < 0) return 3;    // negative equity
+  if (de <= 0.3) return 16.7;
+  if (de <= 0.7) return 14;
+  if (de <= 1.2) return 11;
+  if (de <= 2.0) return 7;
+  if (de <= 3.0) return 4;
+  return 1;
+}
+
+function scoreROE(roe: number | null): number {
+  if (roe == null) return 5;
+  if (roe >= 25) return 16.7;
+  if (roe >= 18) return 14;
+  if (roe >= 12) return 11;
+  if (roe >= 6) return 7;
+  if (roe >= 0) return 4;
+  return 1;
+}
+
+function scoreRevenueGrowth(growth: number | null): number {
+  if (growth == null) return 5;
+  if (growth >= 20) return 16.7;
+  if (growth >= 12) return 14;
+  if (growth >= 5) return 11;
+  if (growth >= 0) return 7;
+  if (growth >= -5) return 4;
+  return 1;
+}
+
+function scoreCurrentRatio(cr: number | null): number {
+  if (cr == null) return 8;
+  if (cr >= 2.0) return 16.7;
+  if (cr >= 1.5) return 14;
+  if (cr >= 1.2) return 11;
+  if (cr >= 1.0) return 7;
+  if (cr >= 0.7) return 4;
+  return 1;
+}
+
+function scoreGrossMargin(gm: number | null): number {
+  if (gm == null) return 5;
+  if (gm >= 60) return 16.7;
+  if (gm >= 45) return 14;
+  if (gm >= 30) return 11;
+  if (gm >= 20) return 7;
+  if (gm >= 10) return 4;
+  return 1;
+}
+
+export async function getFundamentalGrade(ticker: string, isIndexEtf = false): Promise<FundamentalResult> {
+  if (isIndexEtf) {
+    return { grade: 'B', score: 65, breakdown: {} };
+  }
+
+  const cached = cache.get(ticker);
+  if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+    return cached.result;
+  }
+
+  let metrics: Record<string, number | null> = {};
+  try {
+    const wait = 900 - (Date.now() - lastCall);
+    if (wait > 0) await new Promise(r => setTimeout(r, wait));
+    lastCall = Date.now();
+
+    const res = await fetch(`https://finnhub.io/api/v1/stock/metric?symbol=${ticker}&metric=all&token=${FINNHUB_KEY}`);
+    if (res.ok) {
+      const data: FinnhubMetricAll = await res.json();
+      metrics = data.metric ?? {};
+    }
+  } catch {
+    // API failure → return neutral C grade
+    return { grade: 'C', score: 50, breakdown: {} };
+  }
+
+  const pe = metrics.peBasicExclExtraTTM ?? metrics.peTTM ?? null;
+  const de = metrics.totalDebtToEquityQuarterly ?? metrics.totalDebtToEquityAnnual ?? null;
+  const roe = metrics.roeTTM ?? metrics.roeRfy ?? null;
+  const revGrowth = metrics.revenueGrowthQuarterlyYoy ?? metrics.revenueGrowthTTMYoy ?? null;
+  const cr = metrics.currentRatioQuarterly ?? metrics.currentRatioAnnual ?? null;
+  const gm = metrics.grossMarginTTM ?? metrics.grossMarginAnnual ?? null;
+
+  const breakdown: Record<string, { raw: number | null; points: number }> = {
+    pe: { raw: pe, points: scorePE(pe) },
+    debtEquity: { raw: de, points: scoreDebtEquity(de) },
+    roe: { raw: roe, points: scoreROE(roe) },
+    revenueGrowth: { raw: revGrowth, points: scoreRevenueGrowth(revGrowth) },
+    currentRatio: { raw: cr, points: scoreCurrentRatio(cr) },
+    grossMargin: { raw: gm, points: scoreGrossMargin(gm) },
+  };
+
+  const score = Math.round(Object.values(breakdown).reduce((s, v) => s + v.points, 0));
+  const grade = gradeFromScore(score);
+  const result: FundamentalResult = { grade, score, breakdown };
+
+  cache.set(ticker, { result, ts: Date.now() });
+  return result;
+}
+
+let lastCall = 0;
+
+export function clearFundamentalCache(): void {
+  cache.clear();
+}

--- a/auto-trader/src/lib/options-chain.ts
+++ b/auto-trader/src/lib/options-chain.ts
@@ -435,6 +435,43 @@ async function findBestPutStrike(
   return null;
 }
 
+/**
+ * Find the best OTM call strike for covered call writing, using delta targeting.
+ * Mirrors findBestPutStrike logic but for the call side.
+ */
+async function findBestCallStrike(
+  symbol: string,
+  strikes: number[],
+  expiry: string,
+  underlyingPrice: number,
+  deltaTarget = 0.20,
+): Promise<OptionGreeks | null> {
+  const deltaLow = Math.max(0.10, deltaTarget - 0.07);
+  const deltaHigh = deltaTarget + 0.07;
+
+  const targetPct = deltaTarget < 0.18 ? 0.08 : 0.06;
+  const targetStrike = underlyingPrice * (1 + targetPct);
+
+  const candidates = strikes
+    .filter(s => s > underlyingPrice * 1.02)
+    .sort((a, b) => Math.abs(a - targetStrike) - Math.abs(b - targetStrike))
+    .slice(0, 6);
+
+  for (const strike of candidates) {
+    const greeks = await getOptionGreeksForContract(symbol, strike, expiry, 'C', underlyingPrice);
+    if (!greeks) continue;
+    const absDelta = Math.abs(greeks.delta);
+    if (absDelta >= deltaLow && absDelta <= deltaHigh) return greeks;
+  }
+
+  for (const strike of candidates) {
+    const greeks = await getOptionGreeksForContract(symbol, strike, expiry, 'C', underlyingPrice);
+    if (greeks) return greeks;
+  }
+
+  return null;
+}
+
 // ── Main Export ──────────────────────────────────────────
 
 /**
@@ -477,12 +514,8 @@ export async function getOptionsChain(
   // If Greeks failed (e.g. market data not subscribed), fall back to synthetic.
   if (!bestPut) return syntheticFallback();
 
-  // Step 5: Optionally find best covered call (just above current price)
-  const callStrike = params.strikes.find(s => s > underlyingPrice * 1.05) ?? null;
-  let bestCall: OptionGreeks | null = null;
-  if (callStrike) {
-    bestCall = await getOptionGreeksForContract(symbol, callStrike, expiry, 'C', underlyingPrice);
-  }
+  // Step 5: Find best covered call via delta targeting (mirrors put logic)
+  const bestCall = await findBestCallStrike(symbol, params.strikes, expiry, underlyingPrice);
 
   const currentIV = bestPut?.impliedVol ?? bestCall?.impliedVol ?? 0;
 
@@ -507,4 +540,72 @@ export async function getBestPutOpportunity(
 ): Promise<OptionGreeks | null> {
   const chain = await getOptionsChain(symbol, underlyingPrice, storedIvRank);
   return chain?.bestPut ?? null;
+}
+
+// ── Strike Sniper ─────────────────────────────────────────
+
+export interface StrikeSniperResult {
+  expiry: string;
+  strike: number;
+  premium: number;
+  delta: number;
+  annualizedROI: number;
+  dte: number;
+  collateral: number;
+}
+
+/**
+ * Given a user-specified target strike price, find the best put contract
+ * across multiple expirations, ranked by annualized ROI.
+ */
+export async function findBestContractForStrike(
+  symbol: string,
+  targetStrike: number,
+  minAnnualizedReturn = 8,
+  underlyingPrice?: number,
+): Promise<StrikeSniperResult[]> {
+  const results: StrikeSniperResult[] = [];
+
+  const contractInfo = await searchContract(symbol);
+  if (!contractInfo) return results;
+
+  const spotPrice = underlyingPrice ?? targetStrike;
+
+  const params = await getOptionChainParams(contractInfo.conId, symbol);
+  if (!params || params.expirations.length === 0) return results;
+
+  // Find the strike closest to the user's target
+  const closestStrike = params.strikes.reduce((best, s) =>
+    Math.abs(s - targetStrike) < Math.abs(best - targetStrike) ? s : best,
+    params.strikes[0],
+  );
+
+  // Try each expiration in the 14–90 DTE window
+  const eligibleExpiries = params.expirations
+    .map(e => ({ e, dte: daysToExpiry(e) }))
+    .filter(x => x.dte >= 14 && x.dte <= 90)
+    .sort((a, b) => a.dte - b.dte);
+
+  for (const { e: expiry, dte } of eligibleExpiries) {
+    const greeks = await getOptionGreeksForContract(symbol, closestStrike, expiry, 'P', spotPrice);
+    if (!greeks || greeks.mid <= 0) continue;
+
+    const premium = greeks.mid;
+    const collateral = closestStrike * 100;
+    const annualizedROI = (premium / closestStrike) * (365 / dte) * 100;
+
+    if (annualizedROI < minAnnualizedReturn) continue;
+
+    results.push({
+      expiry,
+      strike: closestStrike,
+      premium,
+      delta: greeks.delta,
+      annualizedROI: Math.round(annualizedROI * 100) / 100,
+      dte,
+      collateral,
+    });
+  }
+
+  return results.sort((a, b) => b.annualizedROI - a.annualizedROI);
 }

--- a/auto-trader/src/lib/options-manager.ts
+++ b/auto-trader/src/lib/options-manager.ts
@@ -318,6 +318,8 @@ export interface ManageCycleResult {
   assignmentAlerts: string[];
   expiredPositions: string[];
   stopLossAlerts: string[];
+  stopLossMultiplier: number;
+  profitClosePct: number;
 }
 
 export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
@@ -328,12 +330,16 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
     assignmentAlerts: [],
     expiredPositions: [],
     stopLossAlerts: [],
+    stopLossMultiplier: 3,
+    profitClosePct: 50,
   };
 
   // Load auto-tuned wheel parameters from DB
   const wheelConfig = await getOptionsAutoTradeConfig();
   const profitClosePct = wheelConfig.profitClosePct;
   const stopLossMultiplier = wheelConfig.stopLossMultiplier;
+  result.stopLossMultiplier = stopLossMultiplier;
+  result.profitClosePct = profitClosePct;
 
   // ── Check SUBMITTED orders for IB fills ──────────────────
   if (isConnected()) {
@@ -717,8 +723,8 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
     const pnl = (premiumCollected - currentCallPremium) * 100;
     await sb.from('paper_trades').update({ pnl }).eq('id', pos.id);
 
-    // Check B: 50% profit — buy back cheap, free up the shares
-    if (profitCapturePct >= 50) {
+    // Check B: Profit capture threshold — auto close when target % reached (same as puts)
+    if (profitCapturePct >= profitClosePct) {
       await sb.from('paper_trades').update({
         status: 'CLOSED',
         close_price: currentCallPremium,
@@ -729,8 +735,8 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
       }).eq('id', pos.id);
       result.closed50Pct.push(pos.ticker);
       persistEvent(pos.ticker, 'success',
-        `💰 ${pos.ticker} $${pos.option_strike} covered call closed at ${profitCapturePct.toFixed(0)}% profit — captured $${pnl.toFixed(0)}`,
-        { action: 'closed', source: 'options', metadata: { reason: '50pct_profit', pnl } }
+        `💰 ${pos.ticker} $${pos.option_strike} covered call closed at ${profitCapturePct.toFixed(0)}% profit (target ${profitClosePct}%) — captured $${pnl.toFixed(0)}`,
+        { action: 'closed', source: 'options', metadata: { reason: '50pct_profit', pnl, profitCapturePct, profitClosePct } }
       );
       continue;
     }

--- a/auto-trader/src/lib/options-scanner.ts
+++ b/auto-trader/src/lib/options-scanner.ts
@@ -15,6 +15,7 @@
  *   3.5 Stock trend — must be above 50-day SMA and not down >20% in 3 months
  *   3.6 Beta filter — skip high-beta (>1.5) stocks
  *   4.  Earnings blackout — skip if earnings within 7 days
+ *   4.2 Fundamental quality — grade A-F from Finnhub metrics; skip D/F
  *   4.5 News sentiment — block on red-flag headlines or score < -0.3
  *   4.6 Sector concentration — max 2 open put positions per sector
  *   4.7 Bear mode sector filter — only defensive sectors in bear mode
@@ -36,6 +37,7 @@ import { getSupabase, createAutoTradeEvent } from './supabase.js';
 import { getOptionsChain, type OptionGreeks } from './options-chain.js';
 import { isConnected, placeOptionsOrder, getDefaultAccount } from '../ib-connection.js';
 import { fetchDailyBars, fetchQuote, sma as calcSma, estimateHistoricalVol } from './yahoo-finance.js';
+import { getFundamentalGrade } from './fundamental-grader.js';
 
 // ── Constants ────────────────────────────────────────────
 
@@ -673,6 +675,13 @@ async function checkStock(
   const daysToEarnings = earningsDate ? daysUntil(earningsDate) : 999;
   checks.earningsBlackout = daysToEarnings > EARNINGS_BLACKOUT_DAYS;
   if (daysToEarnings <= EARNINGS_BLACKOUT_DAYS) return { ticker, skipped: true, reason: `earnings_in_${daysToEarnings}d` };
+
+  // Check 4.2: Fundamental quality — grade A-F from Finnhub metrics; skip D/F
+  const fundamental = await getFundamentalGrade(ticker, isIndexEtf);
+  checks.fundamentalGrade = `${fundamental.grade}(${fundamental.score})`;
+  if (fundamental.grade === 'D' || fundamental.grade === 'F') {
+    return { ticker, skipped: true, reason: `weak_fundamentals:${fundamental.grade}(${fundamental.score})` };
+  }
 
   // Check 4.5: News sentiment — block on red-flag headlines or strongly negative sentiment
   const newsSentiment = await getNewsSentiment(ticker);

--- a/auto-trader/src/routes/options.ts
+++ b/auto-trader/src/routes/options.ts
@@ -1,0 +1,39 @@
+import { Router } from 'express';
+import { findBestContractForStrike } from '../lib/options-chain.js';
+import { fetchQuote } from '../lib/yahoo-finance.js';
+import { getFundamentalGrade } from '../lib/fundamental-grader.js';
+
+const router = Router();
+
+router.get('/options/strike-sniper', async (req, res) => {
+  try {
+    const symbol = String(req.query.symbol ?? '').toUpperCase().trim();
+    const targetStrike = Number(req.query.targetStrike);
+    const minReturn = Number(req.query.minReturn || 8);
+
+    if (!symbol) {
+      return res.status(400).json({ error: 'symbol is required' });
+    }
+    if (!Number.isFinite(targetStrike) || targetStrike <= 0) {
+      return res.status(400).json({ error: 'targetStrike must be a positive number' });
+    }
+
+    const quote = await fetchQuote(symbol);
+    const currentPrice = quote?.price ?? null;
+
+    const contracts = await findBestContractForStrike(symbol, targetStrike, minReturn, currentPrice ?? undefined);
+    const fundamental = await getFundamentalGrade(symbol);
+
+    res.json({
+      symbol,
+      currentPrice,
+      targetStrike,
+      fundamental: { grade: fundamental.grade, score: fundamental.score },
+      contracts,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err instanceof Error ? err.message : 'Strike sniper failed' });
+  }
+});
+
+export default router;

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -5428,7 +5428,7 @@ async function runSchedulerCycle(): Promise<void> {
     // 13. Options wheel — manage open positions (every cycle, 30-min intervals)
     try {
       const optsMgr = await runOptionsManageCycle();
-      if (optsMgr.closed50Pct.length > 0) log(`Options: closed at 50% profit — ${optsMgr.closed50Pct.join(', ')}`);
+      if (optsMgr.closed50Pct.length > 0) log(`Options: closed at ${optsMgr.profitClosePct}% profit — ${optsMgr.closed50Pct.join(', ')}`);
       if (optsMgr.rollAlerts.length > 0) log(`Options: roll/close alerts — ${optsMgr.rollAlerts.join(', ')}`);
       if (optsMgr.assignmentAlerts.length > 0) log(`Options: assignment risk — ${optsMgr.assignmentAlerts.join(', ')}`);
       if (optsMgr.stopLossAlerts.length > 0) {
@@ -5438,7 +5438,7 @@ async function runSchedulerCycle(): Promise<void> {
             `🛑 Options Stop-Loss Triggered: ${ticker}`,
             `An options position stop-loss was triggered for ${ticker}.
 
-The premium exceeded 3× the original collected — the position was closed automatically to protect capital.
+The premium exceeded ${optsMgr.stopLossMultiplier}× the original collected — the position was closed automatically to protect capital.
 
 Check the Options Wheel → History tab for details.`,
             ticker,


### PR DESCRIPTION
## Summary

- **Part A — Consistency fixes**: Covered call profit target uses configurable `profitClosePct` (was hardcoded 50%), new delta-targeted `findBestCallStrike` replaces naive >105% OTM selection, and stop-loss alert interpolates actual `stopLossMultiplier` from config
- **Part B — Fundamental quality gate**: New `fundamental-grader.ts` scores stocks A-F using 6 Finnhub metrics (P/E, D/E, ROE, revenue growth, current ratio, gross margin) with 24h cache. Gate 4.2 in the options scanner skips D/F stocks before fetching options chains. ETFs auto-grade B.
- **Part C — Strike sniper**: New feature to find the best put contract for a user-specified target price across all expirations (14-90 DTE), ranked by annualized ROI. Includes backend endpoint (`/api/options/strike-sniper`), core logic in `options-chain.ts`, and a new "Sniper" tab in the Options UI.

## Test plan

- [ ] Verify auto-trader builds and starts cleanly
- [ ] Verify frontend builds without errors
- [ ] Test strike sniper UI: enter a ticker and target price, confirm results table renders
- [ ] Verify options scanner logs show fundamental grade checks in scan output
- [ ] Confirm covered call profit close uses configured % (check events metadata)
- [ ] Confirm stop-loss alerts show the correct multiplier value


Made with [Cursor](https://cursor.com)