### PR TITLE
feat: module toggles + persistEvent reliability fix

### DIFF
--- a/app/src/components/PaperTrading/tabs/SettingsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/SettingsTab.tsx
@@ -121,6 +121,38 @@ export function SettingsTab({ config, onUpdate }: SettingsTabProps) {
     <div className="rounded-xl border border-[hsl(var(--border))] bg-white p-6 space-y-6">
       <h3 className="text-lg font-semibold text-[hsl(var(--foreground))]">Auto-Trading Settings</h3>
 
+      <div className="rounded-lg border border-[hsl(var(--border))] bg-slate-50 p-4 space-y-3">
+        <h4 className="text-sm font-semibold text-[hsl(var(--foreground))]">Module Toggles</h4>
+        <p className="text-xs text-[hsl(var(--muted-foreground))] -mt-1">Enable or disable individual trading modules</p>
+
+        <div className="flex items-center gap-3">
+          <SettingsToggle enabled={config.tradeSignalsEnabled}
+            onToggle={() => onUpdate({ tradeSignalsEnabled: !config.tradeSignalsEnabled })} />
+          <div>
+            <p className="text-sm font-medium text-[hsl(var(--foreground))]">Trade Signals</p>
+            <p className="text-xs text-[hsl(var(--muted-foreground))]">Day & swing trade scanner — AI + technical analysis for short-term trades</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <SettingsToggle enabled={config.suggestedFindsEnabled}
+            onToggle={() => onUpdate({ suggestedFindsEnabled: !config.suggestedFindsEnabled })} />
+          <div>
+            <p className="text-sm font-medium text-[hsl(var(--foreground))]">Suggested Finds</p>
+            <p className="text-xs text-[hsl(var(--muted-foreground))]">Quiet Compounders & Gold Mines — auto-buy long-term positions</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <SettingsToggle enabled={config.optionsWheelEnabled}
+            onToggle={() => onUpdate({ optionsWheelEnabled: !config.optionsWheelEnabled })} />
+          <div>
+            <p className="text-sm font-medium text-[hsl(var(--foreground))]">Options Wheel</p>
+            <p className="text-xs text-[hsl(var(--muted-foreground))]">Sell cash-secured puts & covered calls for premium income</p>
+          </div>
+        </div>
+      </div>
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <label className="block text-sm font-medium text-[hsl(var(--foreground))] mb-1.5">

--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -177,6 +177,11 @@ export interface AutoTraderConfig {
   ltMaxHoldDays: number;            // long-term max hold days (0 = disabled)
   ltTrailingStopPct: number;        // trailing stop: sell if price falls this % from peak (only after profit peak)
 
+  // ── Module Toggles ──
+  tradeSignalsEnabled: boolean;      // enable/disable day/swing trade scanner
+  suggestedFindsEnabled: boolean;    // enable/disable Suggested Finds auto-buy
+  optionsWheelEnabled: boolean;      // enable/disable options wheel scanner
+
   // ── Suggested Finds ──
   suggestedFindPositionSize: number; // flat $ per Suggested Find (0 = use dynamic sizing)
 }
@@ -249,6 +254,11 @@ const DEFAULT_CONFIG: AutoTraderConfig = {
   ltProfitTakePct: 15,
   ltMaxHoldDays: 0,
   ltTrailingStopPct: 10,
+
+  // Module Toggles
+  tradeSignalsEnabled: true,
+  suggestedFindsEnabled: true,
+  optionsWheelEnabled: true,
 
   // Suggested Finds
   suggestedFindPositionSize: 2000,
@@ -341,6 +351,11 @@ export async function loadAutoTraderConfig(): Promise<AutoTraderConfig> {
         ltMaxHoldDays: Number(data.lt_max_hold_days ?? DEFAULT_CONFIG.ltMaxHoldDays),
         ltTrailingStopPct: Number(data.lt_trailing_stop_pct ?? DEFAULT_CONFIG.ltTrailingStopPct),
         suggestedFindPositionSize: Number(data.suggested_find_position_size ?? DEFAULT_CONFIG.suggestedFindPositionSize),
+
+        // Module Toggles
+        tradeSignalsEnabled: data.trade_signals_enabled ?? DEFAULT_CONFIG.tradeSignalsEnabled,
+        suggestedFindsEnabled: data.suggested_finds_enabled ?? DEFAULT_CONFIG.suggestedFindsEnabled,
+        optionsWheelEnabled: data.options_wheel_enabled ?? DEFAULT_CONFIG.optionsWheelEnabled,
       };
       localStorage.setItem(CONFIG_KEY, JSON.stringify(config));
       return config;
@@ -425,6 +440,10 @@ export async function saveAutoTraderConfig(config: Partial<AutoTraderConfig>): P
         lt_max_hold_days: updated.ltMaxHoldDays,
         lt_trailing_stop_pct: updated.ltTrailingStopPct,
         suggested_find_position_size: updated.suggestedFindPositionSize,
+        // Module Toggles
+        trade_signals_enabled: updated.tradeSignalsEnabled,
+        suggested_finds_enabled: updated.suggestedFindsEnabled,
+        options_wheel_enabled: updated.optionsWheelEnabled,
         updated_at: new Date().toISOString(),
       });
   } catch (err) {

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -629,18 +629,58 @@ export async function getAutoTradeEvents(limit = 100): Promise<AutoTradeEventRec
 export async function getTodaysExecutedEvents(): Promise<AutoTradeEventRecord[]> {
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
+  const todayISO = todayStart.toISOString();
 
-  // Fetch executed trades, system close events, and auto-sell closes (lt_auto_sell, swing_expiry, capital_pressure)
-  const { data, error } = await supabase
-    .from('auto_trade_events')
-    .select('*')
-    .in('action', ['executed', 'failed', 'closed'])
-    .gte('created_at', todayStart.toISOString())
-    .order('created_at', { ascending: false });
+  const [eventsRes, tradesRes] = await Promise.all([
+    supabase
+      .from('auto_trade_events')
+      .select('*')
+      .in('action', ['executed', 'failed', 'closed'])
+      .gte('created_at', todayISO)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('paper_trades')
+      .select('id, ticker, mode, signal, scanner_confidence, fa_confidence, fa_recommendation, strategy_source, strategy_source_url, strategy_video_id, strategy_video_heading, quantity, fill_price, status, opened_at, filled_at, scanner_signal')
+      .in('status', ['FILLED', 'TARGET_HIT', 'STOPPED', 'CLOSED', 'PARTIAL'])
+      .gte('opened_at', todayISO)
+      .order('opened_at', { ascending: false }),
+  ]);
 
-  if (error) return [];
-  return ((data ?? []) as AutoTradeEventRecord[]).filter(
+  const events = ((eventsRes.data ?? []) as AutoTradeEventRecord[]).filter(
     e => e.action === 'executed' || e.action === 'closed' || e.source === 'system'
+  );
+
+  const eventTickers = new Set(
+    events.filter(e => e.action === 'executed').map(e => e.ticker.toUpperCase())
+  );
+
+  const fallbackTrades = (tradesRes.data ?? []).filter(
+    t => !eventTickers.has(t.ticker.toUpperCase())
+  );
+
+  const synthetic: AutoTradeEventRecord[] = fallbackTrades.map(t => ({
+    id: `synth-${t.id}`,
+    ticker: t.ticker,
+    event_type: 'success' as const,
+    action: 'executed' as const,
+    source: 'scanner' as const,
+    mode: t.mode as AutoTradeEventRecord['mode'],
+    message: `${t.signal} ${t.quantity ?? '?'} @ $${(t.fill_price ?? 0).toFixed(2)}`,
+    strategy_source: t.strategy_source ?? null,
+    strategy_source_url: t.strategy_source_url ?? null,
+    strategy_video_id: t.strategy_video_id ?? null,
+    strategy_video_heading: t.strategy_video_heading ?? null,
+    scanner_signal: t.scanner_signal ?? t.signal,
+    scanner_confidence: t.scanner_confidence ?? null,
+    fa_recommendation: t.fa_recommendation ?? null,
+    fa_confidence: t.fa_confidence ?? null,
+    skip_reason: null,
+    metadata: { synthetic: true },
+    created_at: t.filled_at ?? t.opened_at,
+  }));
+
+  return [...events, ...synthetic].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
   );
 }
 

--- a/auto-trader/src/lib/dip-watcher.ts
+++ b/auto-trader/src/lib/dip-watcher.ts
@@ -152,7 +152,7 @@ export async function runDipWatcher(): Promise<void> {
         aboveSma50: result.aboveSma50,
         trigger: result.trigger ?? 'dip_watcher',
       },
-    });
+    }).catch(() => {});
   }
 
   // If we found dip candidates, trigger a focused scan immediately

--- a/auto-trader/src/lib/options-manager.ts
+++ b/auto-trader/src/lib/options-manager.ts
@@ -15,7 +15,8 @@ import { getOptionsChain } from './options-chain.js';
 import { isConnected, requestOpenOrders, placeOptionsOrder, getDefaultAccount } from '../ib-connection.js';
 
 function persistEvent(ticker: string, eventType: string, message: string, extra?: Record<string, unknown>): void {
-  createAutoTradeEvent({ ticker, event_type: eventType, message, ...extra });
+  createAutoTradeEvent({ ticker, event_type: eventType, message, ...extra })
+    .catch(err => console.warn(`[Options persistEvent] ${ticker}/${eventType} failed:`, err instanceof Error ? err.message : err));
 }
 
 // ── Types ────────────────────────────────────────────────

--- a/auto-trader/src/lib/options-scanner.ts
+++ b/auto-trader/src/lib/options-scanner.ts
@@ -1120,7 +1120,7 @@ export async function autoTradeOption(ticket: OptionsTradeTicket): Promise<{ tra
       mode: 'OPTIONS_PUT',
       message: `Paper trade opened — IB offline. Sold ${ticket.contracts ?? 1}x $${ticket.strike}P exp ${ticket.expiry}, premium $${ticket.premium.toFixed(2)}/contract`,
       metadata: { strike: ticket.strike, expiry: ticket.expiry, premium: ticket.premium, contracts: ticket.contracts ?? 1, paper: true },
-    });
+    }).catch(() => {});
     return { tradeId, ibOrderId: null, isLive: false };
   }
 
@@ -1145,7 +1145,7 @@ export async function autoTradeOption(ticket: OptionsTradeTicket): Promise<{ tra
       mode: 'OPTIONS_PUT',
       message: `Live order placed #${orderId} — Sold ${ticket.contracts ?? 1}x $${ticket.strike}P exp ${ticket.expiry}, limit $${ticket.premium.toFixed(2)}/contract`,
       metadata: { ibOrderId: orderId, strike: ticket.strike, expiry: ticket.expiry, premium: ticket.premium, contracts: ticket.contracts ?? 1 },
-    });
+    }).catch(() => {});
     return { tradeId, ibOrderId: orderId, isLive: true };
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
@@ -1158,8 +1158,8 @@ export async function autoTradeOption(ticket: OptionsTradeTicket): Promise<{ tra
       source: 'scanner',
       mode: 'OPTIONS_PUT',
       message: `IB order failed — paper fallback. $${ticket.strike}P exp ${ticket.expiry}. Error: ${errMsg}`,
-      metadata: { strike: ticket.strike, expiry: ticket.expiry, premium: ticket.premium, error: errMsg },
-    });
+      metadata: { strike: ticket.strike, expiry: ticket.expiry, premium: ticket.premium, error: errMsg } as Record<string, unknown>,
+    }).catch(() => {});
     return { tradeId, ibOrderId: null, isLive: false };
   }
 }

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -80,6 +80,9 @@ export interface AutoTraderConfig {
   ltMaxHoldDays: number;           // long-term max hold days (0 = disabled)
   ltTrailingStopPct: number;       // trailing stop: sell if price falls this % from peak (only after being in profit)
   dayTradeMaxDailyLoss: number;    // stop new day-trade entries when session realized P&L < -$X (0 = disabled)
+  tradeSignalsEnabled: boolean;    // enable/disable day/swing trade scanner
+  suggestedFindsEnabled: boolean;  // enable/disable Suggested Finds auto-buy
+  optionsWheelEnabled: boolean;    // enable/disable options wheel scanner
 }
 
 const DEFAULT_CONFIG: AutoTraderConfig = {
@@ -116,6 +119,9 @@ const DEFAULT_CONFIG: AutoTraderConfig = {
   ltMaxHoldDays: 0,
   ltTrailingStopPct: 10,
   dayTradeMaxDailyLoss: 500,
+  tradeSignalsEnabled: true,
+  suggestedFindsEnabled: true,
+  optionsWheelEnabled: true,
 };
 
 export async function loadConfig(): Promise<AutoTraderConfig> {
@@ -182,6 +188,9 @@ export async function loadConfig(): Promise<AutoTraderConfig> {
     ltMaxHoldDays: Number(data.lt_max_hold_days ?? DEFAULT_CONFIG.ltMaxHoldDays),
     ltTrailingStopPct: Number(data.lt_trailing_stop_pct ?? DEFAULT_CONFIG.ltTrailingStopPct),
     dayTradeMaxDailyLoss: Number(data.day_trade_max_daily_loss ?? DEFAULT_CONFIG.dayTradeMaxDailyLoss),
+    tradeSignalsEnabled: data.trade_signals_enabled ?? DEFAULT_CONFIG.tradeSignalsEnabled,
+    suggestedFindsEnabled: data.suggested_finds_enabled ?? DEFAULT_CONFIG.suggestedFindsEnabled,
+    optionsWheelEnabled: data.options_wheel_enabled ?? DEFAULT_CONFIG.optionsWheelEnabled,
   };
 }
 
@@ -786,14 +795,10 @@ export interface AutoTradeEventInput {
 export async function createAutoTradeEvent(
   event: AutoTradeEventInput
 ): Promise<void> {
-  try {
-    const sb = getSupabase();
-    const { error } = await sb.from('auto_trade_events').insert(event);
-    if (error) {
-      console.warn(`[Supabase] Failed to persist event for ${event.ticker}: ${error.message}`);
-    }
-  } catch (err) {
-    console.warn(`[Supabase] createAutoTradeEvent threw:`, err instanceof Error ? err.message : err);
+  const sb = getSupabase();
+  const { error } = await sb.from('auto_trade_events').insert(event);
+  if (error) {
+    throw new Error(`Failed to persist event for ${event.ticker}: ${error.message}`);
   }
 }
 

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -1886,13 +1886,28 @@ async function getEnrichedPositions(): Promise<EnrichedPosition[]> {
   });
 }
 
-function persistEvent(
+async function persistEvent(
   ticker: string,
   eventType: string,
   message: string,
   extra?: Omit<AutoTradeEventInput, 'ticker' | 'message'>
-): void {
-  createAutoTradeEvent({ ticker, event_type: eventType, message, ...extra });
+): Promise<void> {
+  const payload = { ticker, event_type: eventType, message, ...extra };
+  const delays = [1000, 2000];
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    try {
+      await createAutoTradeEvent(payload);
+      return;
+    } catch (err) {
+      const label = `${ticker}/${eventType}`;
+      if (attempt < delays.length) {
+        log(`[persistEvent] ${label} attempt ${attempt + 1} failed, retrying in ${delays[attempt]}ms: ${err instanceof Error ? err.message : err}`);
+        await new Promise(r => setTimeout(r, delays[attempt]));
+      } else {
+        log(`[persistEvent] ${label} FAILED after ${attempt + 1} attempts: ${err instanceof Error ? err.message : err}`);
+      }
+    }
+  }
 }
 
 // ── Edge Function Calls ──────────────────────────────────
@@ -5051,6 +5066,7 @@ async function runTradeExecutionOnly(): Promise<void> {
 
   const config = await loadConfig();
   if (!config.enabled || !config.accountId) return;
+  if (!config.tradeSignalsEnabled) return;
 
   _running = true;
   const startTime = Date.now();
@@ -5287,7 +5303,11 @@ async function runSchedulerCycle(): Promise<void> {
     // 5. Pre-generate Suggested Finds (daily, after market open only)
     // Moved AFTER the market hours gate — belt-and-suspenders to prevent pre-market order placement.
     // Runs after sync+reset so SF trades are tracked in _pendingDeployedDollar for this cycle.
-    await preGenerateSuggestedFinds(config, positions);
+    if (config.suggestedFindsEnabled) {
+      await preGenerateSuggestedFinds(config, positions);
+    } else {
+      log('Suggested Finds module disabled — skipping');
+    }
 
     // 6. Position management: dip buy, profit take, loss cut, swing expiry
     await checkStaleDayTrades(positions);              // flag/close day trades stuck FILLED from a prior day
@@ -5301,79 +5321,82 @@ async function runSchedulerCycle(): Promise<void> {
     // Load scanner ideas once per cycle (used by generic-video queue + scanner execution)
     let allIdeas: TradeIdea[] = [];
     let scannerIdeasLoaded = false;
-    try {
-      const data = await fetchTradeIdeas();
-      allIdeas = [...(data.dayTrades ?? []), ...(data.swingTrades ?? [])];
-      scannerIdeasLoaded = true;
-    } catch (err) {
-      const msg = `Scanner fetch failed: ${err instanceof Error ? err.message : 'unknown'}`;
-      log(msg);
-      summaryLog(msg);
-    }
 
-    // 7. Auto-queue daily ticker/trigger signals from tracked strategy videos
-    await autoQueueDailySignalsFromTrackedVideos();
-
-    // 8. Auto-queue generic strategy videos via scanner candidates (paper-trading execution)
-    const genericQueuedTickers = await autoQueueGenericSignalsFromTrackedVideos(allIdeas, config);
-
-    // 9. Process externally supplied strategy signals (date/time gated)
-    await processExternalStrategySignals(config, positions);
-
-    // 10. Execute scanner ideas not already routed through generic strategies
-    const newIdeas = allIdeas.filter(i =>
-      !_processedTickers.has(i.ticker) &&
-      !genericQueuedTickers.has(i.ticker)
-    );
-    // Collect gate results per scan row for UI status badges
-    const dayEvals: Record<string, { status: ScanEvaluationStatus; reason: string }> = {};
-    const swingEvals: Record<string, { status: ScanEvaluationStatus; reason: string }> = {};
-    const recordEval = (idea: TradeIdea, result: string) => {
-      const ev = scanResultToEval(result);
-      if (idea.mode === 'DAY_TRADE') dayEvals[idea.ticker] = ev;
-      else swingEvals[idea.ticker] = ev;
-    };
-
-    if (newIdeas.length > 0) {
-      const activeCount = await countActivePositions();
-      const slots = config.maxPositions - activeCount;
-
-      if (slots > 0) {
-        const qualified = newIdeas
-          .filter(i => i.confidence >= config.minScannerConfidence)
-          .sort((a, b) => b.confidence - a.confidence)
-          .slice(0, slots);
-
-        for (const idea of qualified) {
-          const result = await executeScannerTrade(idea, config, positions);
-          log(`  ${idea.ticker}: ${result}`);
-          recordEval(idea, result);
-          // Don't mark time-dependent skips as processed — conditions change throughout the day.
-          if (!isRetryableSkip(result)) {
-            _processedTickers.add(idea.ticker);
-          }
-          await new Promise(r => setTimeout(r, 2000));
-        }
-      } else {
-        log(`Max positions reached (${config.maxPositions}) — skipping scanner ideas`);
-        // Mark all unprocessed ideas as blocked due to max positions
-        for (const idea of newIdeas) recordEval(idea, 'skipped:max_positions');
+    if (!config.tradeSignalsEnabled) {
+      log('Trade Signals module disabled — skipping scanner + video signals');
+    } else {
+      try {
+        const data = await fetchTradeIdeas();
+        allIdeas = [...(data.dayTrades ?? []), ...(data.swingTrades ?? [])];
+        scannerIdeasLoaded = true;
+      } catch (err) {
+        const msg = `Scanner fetch failed: ${err instanceof Error ? err.message : 'unknown'}`;
+        log(msg);
+        summaryLog(msg);
       }
-    } else if (scannerIdeasLoaded) {
-      const msg = allIdeas.length === 0 ? 'No scanner ideas' : `Scanner: ${allIdeas.length} ideas (all filtered or already processed)`;
-      log(msg);
-      summaryLog(msg);
-    }
 
-    // Write evaluation results to DB so the UI can show Armed/Watching/Blocked badges
-    if (Object.keys(dayEvals).length > 0)   writeScanEvaluations('day_trades', dayEvals).catch(() => {});
-    if (Object.keys(swingEvals).length > 0)  writeScanEvaluations('swing_trades', swingEvals).catch(() => {});
+      // 7. Auto-queue daily ticker/trigger signals from tracked strategy videos
+      await autoQueueDailySignalsFromTrackedVideos();
+
+      // 8. Auto-queue generic strategy videos via scanner candidates (paper-trading execution)
+      const genericQueuedTickers = await autoQueueGenericSignalsFromTrackedVideos(allIdeas, config);
+
+      // 9. Process externally supplied strategy signals (date/time gated)
+      await processExternalStrategySignals(config, positions);
+
+      // 10. Execute scanner ideas not already routed through generic strategies
+      const newIdeas = allIdeas.filter(i =>
+        !_processedTickers.has(i.ticker) &&
+        !genericQueuedTickers.has(i.ticker)
+      );
+      // Collect gate results per scan row for UI status badges
+      const dayEvals: Record<string, { status: ScanEvaluationStatus; reason: string }> = {};
+      const swingEvals: Record<string, { status: ScanEvaluationStatus; reason: string }> = {};
+      const recordEval = (idea: TradeIdea, result: string) => {
+        const ev = scanResultToEval(result);
+        if (idea.mode === 'DAY_TRADE') dayEvals[idea.ticker] = ev;
+        else swingEvals[idea.ticker] = ev;
+      };
+
+      if (newIdeas.length > 0) {
+        const activeCount = await countActivePositions();
+        const slots = config.maxPositions - activeCount;
+
+        if (slots > 0) {
+          const qualified = newIdeas
+            .filter(i => i.confidence >= config.minScannerConfidence)
+            .sort((a, b) => b.confidence - a.confidence)
+            .slice(0, slots);
+
+          for (const idea of qualified) {
+            const result = await executeScannerTrade(idea, config, positions);
+            log(`  ${idea.ticker}: ${result}`);
+            recordEval(idea, result);
+            if (!isRetryableSkip(result)) {
+              _processedTickers.add(idea.ticker);
+            }
+            await new Promise(r => setTimeout(r, 2000));
+          }
+        } else {
+          log(`Max positions reached (${config.maxPositions}) — skipping scanner ideas`);
+          for (const idea of newIdeas) recordEval(idea, 'skipped:max_positions');
+        }
+      } else if (scannerIdeasLoaded) {
+        const msg = allIdeas.length === 0 ? 'No scanner ideas' : `Scanner: ${allIdeas.length} ideas (all filtered or already processed)`;
+        log(msg);
+        summaryLog(msg);
+      }
+
+      // Write evaluation results to DB so the UI can show Armed/Watching/Blocked badges
+      if (Object.keys(dayEvals).length > 0)   writeScanEvaluations('day_trades', dayEvals).catch(() => {});
+      if (Object.keys(swingEvals).length > 0)  writeScanEvaluations('swing_trades', swingEvals).catch(() => {});
+    }
 
     // 11. SPX key-level breakout-retest scanner (Somesh's strategy)
     // Watches $50 SPX levels for the break → 2 independent candles → retest pattern.
     // Generates a SPY DAY_TRADE order when a clean retest is confirmed.
     // Runs every cycle during market hours; state machine persists in memory across cycles.
-    try {
+    if (config.tradeSignalsEnabled) try {
       const spxSetups = await checkSpxLevelSetups();
       for (const setup of spxSetups) {
         // Confidence: 9 base. Bump to 9.5 when QQQ confluence is detected
@@ -5426,6 +5449,9 @@ async function runSchedulerCycle(): Promise<void> {
     }
 
     // 13. Options wheel — manage open positions (every cycle, 30-min intervals)
+    if (!config.optionsWheelEnabled) {
+      log('Options Wheel module disabled — skipping management + scan');
+    } else {
     try {
       const optsMgr = await runOptionsManageCycle();
       if (optsMgr.closed50Pct.length > 0) log(`Options: closed at ${optsMgr.profitClosePct}% profit — ${optsMgr.closed50Pct.join(', ')}`);
@@ -5571,6 +5597,7 @@ No new options positions will be opened until next month. Existing positions con
       // day-trade contract lookups. Prevents no_contract failures after heavy scans.
       await new Promise(r => setTimeout(r, 5_000));
     }
+    } // end optionsWheelEnabled
 
     // 15. Daily rehydration (after 4:15 PM ET)
     await runDailyRehydration(config);

--- a/supabase/migrations/20260513000001_module_toggles.sql
+++ b/supabase/migrations/20260513000001_module_toggles.sql
@@ -1,0 +1,7 @@
+-- Add per-module enable/disable toggles to auto_trader_config.
+-- All default to true (enabled) to preserve existing behavior.
+
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS trade_signals_enabled   boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS suggested_finds_enabled  boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS options_wheel_enabled    boolean NOT NULL DEFAULT true;


### PR DESCRIPTION
## Summary
- Add per-module enable/disable toggles (Trade Signals, Suggested Finds, Options Wheel) in Settings UI
- Fix persistEvent fire-and-forget: awaited with 2x retry + exponential backoff, log failures
- Today's Activity falls back to paper_trades when auto_trade_events entries are missing
- DB migration adds three boolean columns to auto_trader_config (all default true)

## Test plan
- [ ] Verify module toggles appear in Settings tab
- [ ] Toggle each module off, confirm scheduler logs "module disabled — skipping"
- [ ] Verify Today's Activity shows trades even when auto_trade_events is missing


Made with [Cursor](https://cursor.com)