### PR TITLE
fix: hide auto-buy/AUTO indicators when module is disabled

### DIFF
--- a/app/src/components/SuggestedFinds.tsx
+++ b/app/src/components/SuggestedFinds.tsx
@@ -268,7 +268,7 @@ export function SuggestedFinds({ existingTickers }: SuggestedFindsProps) {
       />
 
       {/* Auto-trading indicator */}
-      {isAuthed && getAutoTraderConfig().enabled && (
+      {isAuthed && getAutoTraderConfig().enabled && getAutoTraderConfig().suggestedFindsEnabled && (
         <div className={cn(
           'flex items-center gap-2 px-3 py-2 rounded-lg text-sm',
           isAutoTrading

--- a/app/src/components/TradeIdeas.tsx
+++ b/app/src/components/TradeIdeas.tsx
@@ -276,7 +276,7 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
             </span>
           )}
           {loading && <Spinner size="xs" className="text-amber-500" />}
-          {getAutoTraderConfig().enabled && (
+          {getAutoTraderConfig().enabled && getAutoTraderConfig().tradeSignalsEnabled && (
             <span className="flex items-center gap-1 text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200 px-1.5 py-0.5 rounded-full">
               <Bot className="w-3 h-3" />
               AUTO


### PR DESCRIPTION
## Summary
- Suggested Finds banner now checks `suggestedFindsEnabled` before showing "Auto-buying..."
- Trade Signals AUTO badge now checks `tradeSignalsEnabled` before rendering

Follow-up to #204.


Made with [Cursor](https://cursor.com)