### PR TITLE
fix: gate frontend Suggested Finds and Trade Signals on module toggles

### DIFF
--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -661,6 +661,11 @@ export async function processTradeIdeas(
     return [];
   }
 
+  if (!cfg.tradeSignalsEnabled) {
+    logEvent('*', 'info', 'Trade Signals module disabled — skipping');
+    return [];
+  }
+
   if (!cfg.accountId) {
     logEvent('*', 'error', 'No IB account configured');
     return [];
@@ -2084,6 +2089,11 @@ export async function processSuggestedFinds(
 
   if (!cfg.enabled) {
     logEvent('*', 'warning', 'Auto-trading is disabled — skipping Suggested Finds');
+    return [];
+  }
+
+  if (!cfg.suggestedFindsEnabled) {
+    logEvent('*', 'info', 'Suggested Finds module disabled — skipping');
     return [];
   }
 


### PR DESCRIPTION
## Summary
- Frontend `processSuggestedFinds()` now checks `suggestedFindsEnabled` before processing
- Frontend `processTradeIdeas()` now checks `tradeSignalsEnabled` before processing
- Root cause: the frontend had its own execution paths that only checked the global `enabled` flag

This was causing "Processing 4 Suggested Finds" events even after disabling Suggested Finds in Settings.


Made with [Cursor](https://cursor.com)