### PR TITLE
fix: stop Suggested Finds page from triggering auto-buy when disabled

### DIFF
--- a/app/src/components/SuggestedFinds.tsx
+++ b/app/src/components/SuggestedFinds.tsx
@@ -92,7 +92,7 @@ export function SuggestedFinds({ existingTickers }: SuggestedFindsProps) {
   // ── Auto-buy Suggested Finds ──
   useEffect(() => {
     const config = getAutoTraderConfig();
-    if (!config.enabled || !isAuthed) return;
+    if (!config.enabled || !config.suggestedFindsEnabled || !isAuthed) return;
 
     // Combine compounders and gold mines
     const allStocks = [...displayedCompounders, ...displayedGoldMines];
@@ -136,7 +136,7 @@ export function SuggestedFinds({ existingTickers }: SuggestedFindsProps) {
     if (!selectedGoldMineCategory || isGoldMineCategoryLoading) return;
     if (displayedGoldMines.length === 0) return;
     const config = getAutoTraderConfig();
-    if (!config.enabled || !isAuthed) return;
+    if (!config.enabled || !config.suggestedFindsEnabled || !isAuthed) return;
     // Only offer if we haven't already for this category
     if (catAutoTradedRef.current.has(selectedGoldMineCategory)) return;
     setCatAutoTradeOffer('offered');


### PR DESCRIPTION
## Summary
- The SuggestedFinds.tsx component had two useEffect hooks that called `processSuggestedFinds()` every time the page loaded/refreshed
- These only checked the global `enabled` flag, not `suggestedFindsEnabled`
- Now both hooks bail out early when `suggestedFindsEnabled` is false

Root cause of "Processing 3 Suggested Finds" events appearing after disabling the module.


Made with [Cursor](https://cursor.com)