### PR TITLE
fix: prevent schema drift from silently dropping trade events

### DIFF
--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -611,6 +611,7 @@ export function PaperTrading() {
               trades={allTrades}
               todaySignalsForExecute={todaySignalsForExecute}
               onExecuteSignal={refreshAfterAction}
+              ibRealizedPnl={ibAccountPnl?.realizedPnL ?? null}
             />
           )}
           {tab === 'smart' && (

--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -203,7 +203,7 @@ export interface TodayActivityTabProps {
   ibRealizedPnl?: number | null;
 }
 
-export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], onExecuteSignal }: TodayActivityTabProps) {
+export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], onExecuteSignal, ibRealizedPnl }: TodayActivityTabProps) {
   const [executingId, setExecutingId] = useState<string | null>(null);
   const [executingAll, setExecutingAll] = useState(false);
   const [scannerTickers, setScannerTickers] = useState<Set<string>>(new Set());
@@ -423,13 +423,19 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
     return sum;
   })();
 
-  const todayPnl = eventBasedPnl;
+  const todayPnl = ibRealizedPnl ?? eventBasedPnl;
+  const pnlSource = ibRealizedPnl != null ? 'ib' : 'events';
 
   return (
     <div className="space-y-3">
       {todayPnl !== 0 && (
         <div className="flex items-center justify-between rounded-lg bg-[hsl(var(--secondary))] px-4 py-2.5">
-          <span className="text-sm font-medium text-[hsl(var(--muted-foreground))]">Today&apos;s Realized P&L</span>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-[hsl(var(--muted-foreground))]">Today&apos;s Realized P&L</span>
+            {pnlSource === 'ib' && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 font-semibold">IB</span>
+            )}
+          </div>
           <span className={cn('text-sm font-bold tabular-nums', todayPnl > 0 ? 'text-emerald-600' : todayPnl < 0 ? 'text-red-600' : '')}>
             {fmtUsd(todayPnl, 2, true)}
           </span>

--- a/auto-trader/src/lib/reconcile-executions.ts
+++ b/auto-trader/src/lib/reconcile-executions.ts
@@ -252,6 +252,7 @@ async function logReconciliationSummary(
   try {
     await createAutoTradeEvent({
       ticker: 'SYSTEM',
+      event_type: 'info',
       action: 'RECONCILIATION',
       source: 'system',
       message: `EOD reconciliation: ${matched} matched, ${corrected} corrected, ${orphaned} orphaned, ${flagged} flagged`,

--- a/auto-trader/src/lib/watchlist-screener.ts
+++ b/auto-trader/src/lib/watchlist-screener.ts
@@ -228,6 +228,7 @@ export async function runWatchlistScreener(): Promise<void> {
 
   await createAutoTradeEvent({
     ticker: 'SYSTEM',
+    event_type: 'info',
     message: `Watchlist scan complete: ${top.length} added, ${skipped.length} skipped`,
     action: 'scan_complete',
     source: 'watchlist_screener',

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -1889,13 +1889,24 @@ async function getEnrichedPositions(): Promise<EnrichedPosition[]> {
   });
 }
 
+const VALID_EVENT_TYPES = new Set(['info', 'success', 'warning', 'error']);
+
+function isPermanentDbError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes('violates check constraint')
+    || msg.includes('Could not find the')
+    || msg.includes('not-null constraint')
+    || msg.includes('duplicate key');
+}
+
 async function persistEvent(
   ticker: string,
   eventType: string,
   message: string,
   extra?: Omit<AutoTradeEventInput, 'ticker' | 'message'>
 ): Promise<void> {
-  const payload = { ticker, event_type: eventType, message, ...extra };
+  const safeType = VALID_EVENT_TYPES.has(eventType) ? eventType : 'info';
+  const payload = { ticker, event_type: safeType, message, ...extra };
   const delays = [1000, 2000];
   for (let attempt = 0; attempt <= delays.length; attempt++) {
     try {
@@ -1903,6 +1914,10 @@ async function persistEvent(
       return;
     } catch (err) {
       const label = `${ticker}/${eventType}`;
+      if (isPermanentDbError(err)) {
+        log(`[persistEvent] ${label} PERMANENT failure (no retry): ${err instanceof Error ? err.message : err}`);
+        return;
+      }
       if (attempt < delays.length) {
         log(`[persistEvent] ${label} attempt ${attempt + 1} failed, retrying in ${delays[attempt]}ms: ${err instanceof Error ? err.message : err}`);
         await new Promise(r => setTimeout(r, delays[attempt]));
@@ -2846,7 +2861,7 @@ async function executeScannerTrade(
       action: 'executed', source: 'scanner', mode,
       scanner_signal: signal, scanner_confidence: Math.round(effectiveScannerConf),
       fa_recommendation: faRec, fa_confidence: faConf != null ? Math.round(faConf) : null,
-      ...(candlePatternLog.length > 0 && { candle_patterns: candlePatternLog }),
+      ...(candlePatternLog.length > 0 && { metadata: { candle_patterns: candlePatternLog } }),
     });
     return 'executed';
   } catch (err) {


### PR DESCRIPTION
## Summary
- **Root cause**: `persistEvent` spread `candle_patterns` as a top-level column on `auto_trade_events`, but no migration existed. Supabase rejected every insert for trades with candle pattern confirmations (AAPL, GOOGL, NVTS, SMH, AAOI), making them invisible in Today's Activity while IB executed them normally.
- Moved `candle_patterns` into `metadata` JSONB; normalized invalid `event_type` values; added permanent DB error classification to skip pointless retries; fixed missing `event_type` in reconciliation + watchlist events
- Wired up IB realized P&L (built May 8, never connected) to Today's Activity with an "IB" badge

## Test plan
- [x] `npx tsc --noEmit` passes for both app and auto-trader
- [x] `npm run build` passes for both
- [x] Auto-trader restarted and running cleanly (no persistEvent errors in logs)
- [ ] Tomorrow's trading session: verify all executed trades appear in Today's Activity
- [ ] Verify IB P&L badge shows correct realized P&L on Today's Activity tab

Made with [Cursor](https://cursor.com)