### PR TITLE
docs: add trading invariants and AI guardrails

### DIFF
--- a/.cursor/rules/ai-guardrails.mdc
+++ b/.cursor/rules/ai-guardrails.mdc
@@ -1,0 +1,89 @@
+---
+description: Guardrails for AI agents working on financial/trading code
+globs: auto-trader/**
+alwaysApply: false
+---
+
+# AI Guardrails for Trading Code
+
+This system trades real money. Every change has financial consequences.
+Follow these rules to prevent the recurring pattern of confident-but-wrong changes.
+
+## 1. Classify Your Change Before Making It
+
+Before editing any auto-trader code, determine what kind of change you're making:
+
+| Type | Examples | Required |
+|------|----------|----------|
+| **Bug fix** | Null check, typo, wrong variable | Just fix it |
+| **Behavior change** | Different execution timing, new gates, changed attribution | ASK THE USER first |
+| **Product decision** | Who sees what, when trades execute, what gets logged | ASK THE USER first |
+| **Safety-critical** | Order placement, position closing, reconciliation | Read `auto-trader-invariants.mdc` first, ASK if any doubt |
+
+**If you're not sure whether something is a behavior change, it is.** Ask.
+
+## 2. Check Existing Rules Before Deciding
+
+Before making any design decision in the auto-trader:
+
+1. Read `auto-trader-invariants.mdc` — hard rules that cannot be violated
+2. Read `influencer-signals.mdc` — rules specific to influencer/strategy signals
+3. Read `auto-trader-conventions.mdc` — architecture and event system conventions
+4. Read `quality-checklist.mdc` — formatting, data sources, edge cases
+5. Check `docs/cursor/` for any relevant design docs or ADRs
+
+**If a rule file answers your question, follow it. Don't re-derive the answer.**
+
+## 3. Never Silently Change User-Visible Behavior
+
+If your change affects what the user sees in:
+- Activity log (event attribution, source labels, status)
+- Strategy Tracker (influencer names, win rates, P&L)
+- Trade notifications (what gets executed, when)
+- Portfolio display (positions, P&L calculations)
+
+Then you MUST tell the user what will change and get confirmation.
+A confident commit message is not a substitute for user approval.
+
+## 4. The "Mark CLOSED Anyway" Anti-Pattern
+
+Never write code that marks a position as closed/completed/done when the underlying
+action (IB order, API call, etc.) actually failed. This applies to:
+
+- `paper_trades.status` — only set to CLOSED after confirmed execution
+- `external_strategy_signals.status` — only set to EXECUTED after confirmed placement
+- Any state transition that implies "done" — verify the action succeeded first
+
+If the action fails, leave the state unchanged and log the failure.
+The next retry cycle will pick it up.
+
+## 5. Grep Before You Fix
+
+When fixing a bug, ALWAYS grep the entire codebase for the same pattern.
+The scheduler.ts file is 5,700+ lines — the same anti-pattern likely exists
+in multiple places. Fix ALL instances, not just the one the user reported.
+
+Specific patterns to audit:
+- `catch.*marking.*anyway` or `catch.*CLOSED` — state changes on failure
+- `alsoInScanner.*null` — attribution stripping
+- `placeMarketOrder` without market-hour checks
+- `status: 'CLOSED'` without fill confirmation
+
+## 6. Document Design Decisions
+
+When you make a non-obvious design choice, add it to `docs/cursor/` as a short ADR:
+
+```
+docs/cursor/YYYY-MM-DD-decision-name.md
+```
+
+Include: what was decided, why, what alternatives were considered.
+This prevents the next AI session from re-deriving (and getting wrong) the same decision.
+
+## 7. scheduler.ts Is a Monolith — Be Extra Careful
+
+At 5,700+ lines, changes have unpredictable blast radius. When editing:
+- Read at least 50 lines of context around your change
+- Check if the function you're editing is called from multiple places
+- Check if other functions have the same pattern you're fixing
+- Run `npx tsc --noEmit` after every substantive edit

--- a/.cursor/rules/auto-trader-invariants.mdc
+++ b/.cursor/rules/auto-trader-invariants.mdc
@@ -1,0 +1,77 @@
+---
+description: Hard invariants for the auto-trader — NEVER violate these, regardless of context
+globs: auto-trader/**
+alwaysApply: false
+---
+
+# Auto-Trader Invariants
+
+These are **hard rules** — product requirements that no single conversation may override.
+If a change would violate any of these, STOP and ask the user before proceeding.
+
+## 1. Position State Integrity
+
+- **Never mark a paper_trade as CLOSED unless the IB order was accepted.**
+  If `placeMarketOrder()` or `placeBracketOrder()` throws, the trade status MUST remain unchanged.
+  The next sweep or reconciliation will retry. "Marking CLOSED in DB anyway" is ALWAYS wrong.
+
+- **IB is the source of truth for position state, not paper_trades.**
+  If paper_trades says flat but IB says short, IB wins. Any reconciliation must check IB positions directly.
+
+- **Never null a field that was set at trade creation time.**
+  If `strategy_source`, `strategy_video_id`, `mode`, or `signal` was set when the trade was created,
+  no downstream code path may null it out. These are immutable attribution fields.
+
+## 2. Market Hours
+
+- **Never place MKT/DAY orders outside regular trading hours (9:30 AM – 4:00 PM ET).**
+  They will be rejected by IB. If a function detects an actionable condition after hours,
+  it must LOG AN ALERT and DEFER — not fire-and-forget a doomed order.
+
+- **Scanner trades must not execute before 9:35 AM ET** (first candle hasn't formed).
+  This gate exists in `executeScannerTrade()` — never remove it.
+
+- **External/influencer signals must not execute before 9:35 AM ET** either.
+  Same rationale: spreads are widest at open, fills are worst. Apply the same gate.
+
+## 3. Influencer Signal Attribution
+
+- **Always preserve influencer attribution.** `strategy_source`, `strategy_source_url`,
+  `strategy_video_id`, and `strategy_video_heading` must ALWAYS be set on both
+  `paper_trades` and `auto_trade_events` for influencer signals.
+  Scanner overlap (`alsoInScanner`) does NOT override attribution — record it in metadata only.
+
+- **Source must be `external_signal`** for all influencer/strategy video trades.
+  Never re-attribute them to `scanner` even if the ticker also appears in trade_scans.
+
+## 4. Safety & Notifications
+
+- **Orphaned positions must trigger a CRITICAL alert** in `auto_trade_events`
+  (event_type='error'). Silent failures that leave positions open are unacceptable.
+
+- **Autonomous trades not triggered by today's signals require elevated logging.**
+  If `reconcileIBShorts()` or any reconciliation function places orders that weren't
+  part of the normal signal flow, those MUST be logged as warnings with full context.
+
+## 5. EOD Pipeline Order
+
+```
+3:45 PM — softCloseDayTrades (losing + near-target)
+3:55 PM — closeAllDayTrades (hard backstop)
+4:05 PM — safety sweep (same function, catches 3:55–4:00 stragglers)
+4:10 PM — reconcileIBShorts (IB position-level check, alert-only after hours)
+4:15 PM — runEndOfDayReconciliation (fill price / P&L corrections)
+```
+
+Do not reorder these. Do not skip any. Each layer is a safety net for the one above.
+
+## How to Use This File
+
+**Before making ANY change to the auto-trader:**
+1. Read this file
+2. Check if your change would violate any invariant
+3. If yes → ask the user, do not proceed on your own judgment
+4. If adding new behavior → check if a new invariant should be added here
+
+**When reviewing AI-generated changes:**
+If a diff contradicts any rule above, the rule wins, not the diff.

--- a/.cursor/rules/influencer-signals.mdc
+++ b/.cursor/rules/influencer-signals.mdc
@@ -22,6 +22,20 @@ Signals from tracked strategy videos (Somesh / Kay Capitals, etc.) are identifie
 - ❌ Duplicate active trade (same ticker/direction/video already open)
 - ❌ Strategy marked X (consecutive losses threshold)
 
+## Attribution — NEVER strip
+
+- `strategy_source`, `strategy_source_url`, `strategy_video_id`, `strategy_video_heading`
+  must ALWAYS be preserved on both `paper_trades` AND `auto_trade_events`.
+- If the ticker also appears in `trade_scans` (scanner overlap), record that fact in
+  `metadata.also_in_scanner` — do NOT null out the attribution fields.
+- Source must be `external_signal`, never re-attributed to `scanner`.
+- This was broken on April 22 (commit 0af5475) and had to be reverted. Don't repeat it.
+
+## Execution timing
+
+- Influencer signals must NOT execute before 9:35 AM ET (same as scanner trades).
+  Spreads are widest at open; executing at 9:30 gets the worst fills.
+
 ## The reason
 
 Drawdown/allocation/sector checks exist to protect against our own AI-generated (scanner) trades going bad. Influencer signals come from a human expert with their own risk management — our system should not second-guess them. When the portfolio is in critical drawdown, blocking Somesh's signals just means we miss his recovery plays.

--- a/.cursor/rules/quality-checklist.mdc
+++ b/.cursor/rules/quality-checklist.mdc
@@ -82,3 +82,11 @@ If a table holds user-specific data, use `auth.uid() = user_id` instead of `true
 If it's a system/log table (single-user app), `USING (true)` is fine.
 
 Missing RLS = table is publicly readable and writable by anyone with the project URL.
+
+## 9. Auto-Trader Invariant Check
+
+Before committing any change to `auto-trader/`:
+1. Read `.cursor/rules/auto-trader-invariants.mdc`
+2. Verify your change does not violate any hard rule
+3. If changing user-visible behavior (activity log, trade execution, attribution), confirm with the user first
+4. If unsure whether your change is a behavior change, it is — ask before proceeding

--- a/docs/cursor/2026-05-14-eod-sweep-and-attribution-fixes.md
+++ b/docs/cursor/2026-05-14-eod-sweep-and-attribution-fixes.md
@@ -1,0 +1,42 @@
+# 2026-05-14: EOD Sweep State Desync & Influencer Attribution
+
+## What happened
+
+### Orphaned shorts overnight
+4 short positions (TLT, GD, MSFT, AVY) survived the EOD sweep and were held overnight.
+At 9:12 AM the next day, `reconcileIBShorts()` auto-covered them at market-open prices (~$16K).
+
+**Root cause:** `closeAllDayTrades()` marked paper_trades as CLOSED even when the IB cover
+order was rejected (`catch { log("marking CLOSED in DB anyway") }`). The DB thought positions
+were flat; IB still held the shorts. `reconcileIBShorts()` then tried to cover after market
+close with MKT/DAY orders that couldn't fill.
+
+### Influencer attribution stripped
+Somesh's trades showed as generic "Trade signal" in the activity log instead of showing
+the influencer source name.
+
+**Root cause:** Commit `0af5475` (April 22) added `alsoInScanner ? null : signal.source_name`
+which stripped attribution when the scanner independently found the same ticker. This was an
+intentional design decision at the time that turned out to be wrong — the whole point of
+tracking influencer signals is to measure their performance separately.
+
+## Decisions made
+
+1. **Never mark CLOSED if IB order fails.** Leave status unchanged; next sweep retries.
+2. **Always preserve influencer attribution.** Scanner overlap goes in metadata, not source override.
+3. **Market-hour gate on reconcileIBShorts.** Defer and alert after hours, schedule retry at 9:31 AM.
+4. **4:10 PM IB position check.** New cron job queries IB directly for orphaned positions.
+5. **9:35 AM gate should apply to influencer signals too.** Not yet implemented — noted as TODO.
+
+## New rules created
+
+- `.cursor/rules/auto-trader-invariants.mdc` — hard never-violate rules
+- `.cursor/rules/ai-guardrails.mdc` — process guardrails for AI editing trading code
+- Updated `.cursor/rules/influencer-signals.mdc` — added attribution and timing rules
+
+## Lesson learned
+
+The AI flip-flopped on design decisions across sessions because there was no persistent
+specification to check against. Tests and rule files are the only things that survive between
+AI sessions. Without them, each session re-derives intent from the code and sometimes gets
+it wrong. The new rule files encode these decisions so future sessions can't silently override them.


### PR DESCRIPTION
## Summary
- New `.cursor/rules/auto-trader-invariants.mdc` — hard never-violate rules for position state, market hours, attribution, EOD pipeline
- New `.cursor/rules/ai-guardrails.mdc` — process guardrails: classify changes before making them, check existing rules, never silently change user-visible behavior
- Updated `influencer-signals.mdc` with attribution preservation rules and 9:35 AM timing
- Updated `quality-checklist.mdc` with invariant check step
- ADR documenting today's EOD sweep and attribution decisions

These rules exist to prevent the pattern where each AI session re-derives (and sometimes gets wrong) product decisions that were already made. Rule files are the persistent memory that survives between sessions.

Made with [Cursor](https://cursor.com)