### PR TITLE
fix: refresh events and IB P&L when switching to Today tab

### DIFF
--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -287,10 +287,17 @@ export function PaperTrading() {
 
   useEffect(() => { loadAutoTraderConfig().then(setConfig); }, []);
 
-  // Load tab data lazily when the user switches tabs
+  // Load tab data lazily when the user switches tabs.
+  // Today tab forces a refresh of trades, events, and IB P&L so the headline
+  // total is always current (trade P&L values change as prices move intraday).
   useEffect(() => {
     if (loading) return;
-    loadTabData(tab);
+    const forceRefresh = tab === 'today';
+    loadTabData(tab, forceRefresh);
+    if (forceRefresh) {
+      getTodaysExecutedEvents().then(setTodaysExecuted).catch(() => {});
+      loadIBData();
+    }
   }, [tab]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Today tab now force-refreshes `allTrades`, `todaysExecuted` events, and `ibAccountPnl` every time you switch to it
- Previously these were only loaded on mount/Sync, causing stale "Today's Realized P&L" totals
- Fixes the issue where P&L showed wrong values until a full page refresh

## Test plan
- [x] TypeScript + build pass
- [ ] Switch away from Today tab and back — P&L should update without full refresh
- [ ] Verify no performance regression from the extra fetches

Made with [Cursor](https://cursor.com)