### PR TITLE
fix: correct signal attribution — scanner vs influencer

### DIFF
--- a/_bmad-output/planning-artifacts/prd-validation-report.md
+++ b/_bmad-output/planning-artifacts/prd-validation-report.md
@@ -1,0 +1,28 @@
+---
+validationTarget: '_bmad-output/planning-artifacts/prd.md'
+validationDate: '2026-05-04'
+inputDocuments:
+  - planning-artifacts/product-brief-portfolio-assistant-2026-02-04.md
+  - planning-artifacts/sprint-change-proposal-2026-02-05.md
+  - planning-artifacts/technical_spec_v1.md
+  - planning-artifacts/ux-design-specification.md
+validationStepsCompleted: []
+validationStatus: IN_PROGRESS
+---
+
+# PRD Validation Report
+
+**PRD Being Validated:** `_bmad-output/planning-artifacts/prd.md`  
+**Validation Date:** 2026-05-04
+
+## Input Documents
+
+- PRD: `prd.md` ✓
+- Product Brief: `product-brief-portfolio-assistant-2026-02-04.md` (from frontmatter)
+- Sprint Change Proposal: `sprint-change-proposal-2026-02-05.md` (from frontmatter)
+- Technical Spec: `technical_spec_v1.md` (from frontmatter)
+- UX Design Spec: `ux-design-specification.md` (from frontmatter)
+
+## Validation Findings
+
+[Findings will be appended as validation progresses]

--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -439,8 +439,7 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
               const matched = tradesByTicker.get(event.ticker)?.find(t =>
                 t.pnl != null || t.status === 'FILLED' || t.status === 'TARGET_HIT' || t.status === 'STOPPED' || t.status === 'CLOSED'
               );
-              const isGenericAuto = (matched?.notes ?? '').toLowerCase().includes('generic strategy auto');
-              const isInfluencer = event.source === 'external_signal' && !!event.strategy_source && !isGenericAuto;
+
               const isPositionSync = event.source === 'system' && !event.mode;
               const AUTO_CLOSE_SOURCES = new Set(['lt_auto_sell', 'swing_expiry', 'capital_pressure']);
               const isAutoClose = AUTO_CLOSE_SOURCES.has(event.source ?? '');
@@ -457,8 +456,7 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
               const qtyMatch = sharesMatch ?? externalMatch;
 
               const sourceLabel = event.source === 'scanner' ? 'Trade signal'
-                : isInfluencer ? `Trade signal + ${event.strategy_source}`
-                : event.source === 'external_signal' ? 'Trade signal'
+                : event.source === 'external_signal' ? `External signal + ${event.strategy_source}`
                 : event.source === 'suggested_finds' ? 'Suggested find'
                 : event.source === 'dip_buy' ? 'Dip buy'
                 : event.source === 'profit_take' ? 'Profit take'

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -3240,12 +3240,9 @@ async function executeExternalStrategySignal(
 
   // Check if our own scanner also identified this ticker today.
   const alsoInScanner = await isTickerInTodayScan(ticker);
-  // Generic strategy signals use scanner-picked tickers with an influencer's execution rules.
-  // The ticker source is the scanner, not the influencer — attribute accordingly.
-  // Daily signals are influencer-picked tickers — always preserve their attribution.
-  const isGenericAutoSignal = (signal.notes ?? '').toLowerCase().includes('generic strategy auto');
-  const stripInfluencerAttribution = isGenericAutoSignal && alsoInScanner;
-  const resolvedSource: AutoTradeSource = stripInfluencerAttribution ? 'scanner' : 'external_signal';
+  // Generic strategy signals use scanner-picked tickers — attribute to scanner, not influencer.
+  const isGenericAuto = (signal.notes ?? '').toLowerCase().includes('generic strategy auto');
+  const resolvedSource: AutoTradeSource = (isGenericAuto && alsoInScanner) ? 'scanner' : 'external_signal';
   const allocationSplit = Math.max(1, Math.floor(options?.allocationSplit ?? 1));
   const allocationIndex = Math.max(1, Math.floor(options?.allocationIndex ?? 1));
   const allowDuplicateTicker = options?.allowDuplicateTicker === true;


### PR DESCRIPTION
## Summary
- **UI**: Simplify Today's Activity source labels — `scanner` = "Trade signal", `external_signal` = "External signal + [influencer name]". Removed overcomplicated `SIGNAL_GENERATORS`/`EXECUTION_STRATEGIES`/`scannerTickers` logic and the DB query for trade_scans.
- **Scheduler**: Generic auto signals now attribute to `scanner` source when the ticker is also in today's scan. Videos with concrete price levels are skipped from the generic strategy queue (catches misclassified daily_signal videos).
- **Edge function**: Override `generic_strategy` → `daily_signal` when extracted signals have actual price levels (longTriggerAbove/shortTriggerBelow).

## Test plan
- [ ] Verify Today's Activity shows "Trade signal" for scanner trades and "External signal + [name]" for influencer trades
- [ ] Verify auto-trader build passes and service restarts cleanly


Made with [Cursor](https://cursor.com)