### PR TITLE
feat: shared modules — single source of truth for types, config, and constants

### DIFF
--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -5,6 +5,7 @@ import type { AutoTradeEventRecord, PaperTrade, PendingStrategySignal } from '..
 import { executeSignal } from '../../../lib/paperTradesApi';
 import { fmtUsd } from '../utils';
 import { supabase } from '../../../lib/supabaseClient';
+import { CLOSED_STATUSES, EXCLUDED_STATUSES } from '../../../../../shared/trade-status-sets.ts';
 
 // ── Options Wheel section ─────────────────────────────────
 
@@ -446,8 +447,8 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
               const metaPnl = isPositionSync && event.metadata ? (event.metadata as { pnl?: number }).pnl : undefined;
               const eventPnl = metaPnl ?? matched?.pnl;
               const pnl = eventPnl ?? null;
-              const CLOSED_STATUSES = ['CLOSED', 'TARGET_HIT', 'STOPPED', 'CANCELLED'];
-              const isClosed = isPositionSync || isAutoClose || (matched?.close_price != null) || CLOSED_STATUSES.includes(matched?.status ?? '');
+              const terminalStatuses = [...CLOSED_STATUSES, ...EXCLUDED_STATUSES] as string[];
+              const isClosed = isPositionSync || isAutoClose || (matched?.close_price != null) || terminalStatuses.includes(matched?.status ?? '');
               const isActive = !isClosed && matched && ['FILLED', 'PARTIAL'].includes(matched.status);
               const msg = event.message;
               // Match "7 shares @ $675" OR "BUY 7 @ $675" (external signal format)

--- a/app/src/components/PaperTrading/utils.ts
+++ b/app/src/components/PaperTrading/utils.ts
@@ -1,26 +1,5 @@
-/** Format a dollar amount with sign before $: +$500, -$718, $0 */
-export function fmtUsd(value: number, decimals = 2, showPlus = false): string {
-  const sign = value > 0 && showPlus ? '+' : value < 0 ? '-' : '';
-  return `${sign}$${Math.abs(value).toFixed(decimals)}`;
-}
-
-export function toEtIsoDate(value: string | null | undefined): string | null {
-  const raw = (value ?? '').trim();
-  if (!raw) return null;
-  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
-  const parsed = new Date(raw);
-  if (Number.isNaN(parsed.getTime())) return null;
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/New_York',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(parsed);
-  const year = parts.find(p => p.type === 'year')?.value ?? '0000';
-  const month = parts.find(p => p.type === 'month')?.value ?? '00';
-  const day = parts.find(p => p.type === 'day')?.value ?? '00';
-  return `${year}-${month}-${day}`;
-}
+export { fmtUsd } from '../../../../shared/format.ts';
+export { toEtIsoDate } from '../../../../shared/date-helpers.ts';
 
 export function formatRegimeLabel(key: string): string {
   const [above, vix] = key.split('_');

--- a/app/src/hooks/useAutoTradeScheduler.ts
+++ b/app/src/hooks/useAutoTradeScheduler.ts
@@ -12,6 +12,7 @@
  */
 
 import { useEffect, useRef } from 'react';
+import { isMarketOpen } from '../../../shared/date-helpers.ts';
 import { fetchTradeIdeas } from '../lib/tradeScannerApi';
 import {
   loadAutoTraderConfig,
@@ -62,15 +63,7 @@ async function isServerSchedulerRunning(): Promise<boolean> {
   }
 }
 
-/** Check if we're in US market hours (9:30 AM - 4:00 PM ET, weekdays) */
-function isMarketHoursET(): boolean {
-  const now = new Date();
-  const et = new Date(now.toLocaleString('en-US', { timeZone: 'America/New_York' }));
-  const day = et.getDay();
-  if (day === 0 || day === 6) return false;
-  const mins = et.getHours() * 60 + et.getMinutes();
-  return mins >= 9 * 60 + 30 && mins <= 16 * 60;
-}
+// isMarketOpen imported from shared/date-helpers.ts above.
 
 /** Interval between scanner checks (15 minutes, matches server scheduler) */
 const SCANNER_INTERVAL_MS = 15 * 60 * 1000;
@@ -131,7 +124,7 @@ async function preGenerateSuggestedFinds() {
   if (_lastSuggestedFindsDate === todayEt) return;
 
   // Discovery (page population) runs any time after 9:30 AM so the /finds page is
-  // always populated after login. Trading execution inside is further gated by isMarketHoursET().
+  // always populated after login. Trading execution inside is further gated by isMarketOpen().
   const now = new Date();
   const et = new Date(now.toLocaleString('en-US', { timeZone: 'America/New_York' }));
   const mins = et.getHours() * 60 + et.getMinutes();
@@ -148,7 +141,7 @@ async function preGenerateSuggestedFinds() {
 
     // Auto-trade qualifying Suggested Finds — only during market hours
     const config = await loadAutoTraderConfig();
-    if (config.enabled && config.suggestedFindsEnabled && config.accountId && isMarketHoursET()) {
+    if (config.enabled && config.suggestedFindsEnabled && config.accountId && isMarketOpen()) {
       const allStocks = [...result.compounders, ...result.goldMines];
 
       // Identify top picks (first in each list that meets minSuggestedFindsConviction).
@@ -262,7 +255,7 @@ export function useAutoTradeScheduler() {
         runDailyRehydration(config.accountId).catch(() => {});
       }
 
-      if (!isMarketHoursET()) return;
+      if (!isMarketOpen()) return;
 
       // Throttle: don't run more than once per 15 minutes
       const now = Date.now();

--- a/app/src/lib/aiFeedback.ts
+++ b/app/src/lib/aiFeedback.ts
@@ -19,6 +19,7 @@ import {
   type TradeLearning,
   type TradePerformance,
 } from './paperTradesApi';
+import { CLOSED_STATUSES } from '../../../shared/trade-status-sets.ts';
 
 // ── Trade Analysis ───────────────────────────────────────
 
@@ -225,7 +226,7 @@ export async function analyzeUnreviewedTrades(): Promise<number> {
   const { data: closedTrades, error: tErr } = await supabase
     .from('paper_trades')
     .select('*')
-    .in('status', ['STOPPED', 'TARGET_HIT', 'CLOSED'])
+    .in('status', [...CLOSED_STATUSES])
     .order('closed_at', { ascending: false })
     .limit(20);
 

--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -6,14 +6,8 @@
  * Runs entirely in the browser. No backend polling needed.
  */
 
-/** Returns true only during regular US market hours: 9:30 AM – 4:00 PM ET, Mon–Fri. */
-function isMarketOpen(): boolean {
-  const et = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
-  const day = et.getDay();
-  if (day === 0 || day === 6) return false;
-  const mins = et.getHours() * 60 + et.getMinutes();
-  return mins >= 9 * 60 + 30 && mins <= 16 * 60;
-}
+import { isMarketOpen } from '../../../shared/date-helpers.ts';
+import { fmtUsdCompact } from '../../../shared/format.ts';
 
 import type { TradeIdea } from './tradeScannerApi';
 import type { EnhancedSuggestedStock } from '../data/suggestedFinds';
@@ -108,159 +102,20 @@ async function getQuotePrice(ticker: string): Promise<number | null> {
   }
 }
 
-// ── Configuration ────────────────────────────────────────
+// ── Configuration (shared defaults + frontend-only extensions) ──
+import {
+  type AutoTraderConfig as SharedAutoTraderConfig,
+  DEFAULT_CONFIG as SHARED_DEFAULTS,
+} from '../../../shared/config-defaults.ts';
 
-export interface AutoTraderConfig {
-  enabled: boolean;
-  maxPositions: number;          // max concurrent positions
-  positionSize: number;          // $ per position (paper money) — fallback when dynamic sizing off
-  minScannerConfidence: number;  // min scanner confidence to consider
-  minFAConfidence: number;       // min FA confidence to execute
-  minSuggestedFindsConviction: number; // min conviction for Suggested Finds auto-buy
-  accountId: string | null;      // IB paper account ID
-  dayTradeAutoClose: boolean;    // auto-close day trades at 3:55 PM ET
-
-  // ── Allocation Cap ──
-  maxTotalAllocation: number;    // hard cap on total deployed capital ($400K default)
-  maxDailyDeployment: number;    // max NEW capital deployed in a single day ($50K default)
-
-  // ── Layer 1: Dynamic Position Sizing ──
-  useDynamicSizing: boolean;     // use conviction-weighted + risk-based sizing
-  portfolioValue: number;        // total portfolio value (auto-updated from IB)
-  baseAllocationPct: number;     // base % of portfolio per long-term position
-  maxPositionPct: number;        // max single-position % of portfolio
-  riskPerTradePct: number;       // max risk % per scanner trade
-
-  // ── Layer 2: Dip Buying ──
-  dipBuyEnabled: boolean;
-  dipBuyTier1Pct: number;        // dip % to trigger tier 1
-  dipBuyTier1SizePct: number;    // add-on % of original qty
-  dipBuyTier2Pct: number;
-  dipBuyTier2SizePct: number;
-  dipBuyTier3Pct: number;
-  dipBuyTier3SizePct: number;
-  dipBuyCooldownHours: number;   // min hours between dip buys for same ticker
-
-  // ── Layer 3: Profit Taking ──
-  profitTakeEnabled: boolean;
-  profitTakeTier1Pct: number;    // gain % to trigger tier 1
-  profitTakeTier1TrimPct: number;// trim % of position
-  profitTakeTier2Pct: number;
-  profitTakeTier2TrimPct: number;
-  profitTakeTier3Pct: number;
-  profitTakeTier3TrimPct: number;
-  minHoldPct: number;            // never sell below this % of original qty
-
-  // ── Layer 3b: Loss Cutting ──
-  lossCutEnabled: boolean;       // auto-sell losers to protect capital
-  lossCutTier1Pct: number;       // loss % to trigger tier 1 (e.g. 8%)
-  lossCutTier1SellPct: number;   // sell % of position at tier 1
-  lossCutTier2Pct: number;       // loss % for tier 2
-  lossCutTier2SellPct: number;
-  lossCutTier3Pct: number;       // loss % for tier 3 (full exit)
-  lossCutTier3SellPct: number;
-  lossCutMinHoldDays: number;    // minimum days held before loss-cutting (avoid intraday noise)
-
-  // ── Layer 4: Risk Management ──
-  marketRegimeEnabled: boolean;  // adjust sizing for VIX/SPY conditions
-  maxSectorPct: number;          // max portfolio % in one sector
-  earningsAvoidEnabled: boolean; // skip trades near earnings
-  earningsBlackoutDays: number;  // days before earnings to blackout
-  kellyAdaptiveEnabled: boolean; // use Half-Kelly from trade history win rate
-  longTermBucketPct: number;     // % of maxTotalAllocation reserved for long-term positions
-
-  // ── Layer 5: Capital Recycling ──
-  swingMaxHoldDays: number;         // auto-exit filled swing trades after N days (0 = off)
-  capitalPressureEnabled: boolean;  // when at cap, auto-close best swing to make room
-  ltStopLossPct: number;            // long-term fixed stop-loss (0 = disabled, replaced by trailing)
-  ltProfitTakePct: number;          // long-term profit-take threshold (e.g. 15 = +15%)
-  ltMaxHoldDays: number;            // long-term max hold days (0 = disabled)
-  ltTrailingStopPct: number;        // trailing stop: sell if price falls this % from peak (only after profit peak)
-
-  // ── Module Toggles ──
-  tradeSignalsEnabled: boolean;      // enable/disable day/swing trade scanner
-  suggestedFindsEnabled: boolean;    // enable/disable Suggested Finds auto-buy
-  optionsWheelEnabled: boolean;      // enable/disable options wheel scanner
-
-  // ── Suggested Finds ──
-  suggestedFindPositionSize: number; // flat $ per Suggested Find (0 = use dynamic sizing)
+export interface AutoTraderConfig extends SharedAutoTraderConfig {
+  suggestedFindPositionSize: number;
 }
 
 const CONFIG_KEY = 'auto-trader-config';
 
 const DEFAULT_CONFIG: AutoTraderConfig = {
-  enabled: false,
-  maxPositions: 3,
-  positionSize: 1000,
-  minScannerConfidence: 7,
-  minFAConfidence: 7,
-  minSuggestedFindsConviction: 8,
-  accountId: null,
-  dayTradeAutoClose: true,
-
-  // Allocation Cap
-  maxTotalAllocation: 500_000,
-  maxDailyDeployment: 50_000,
-
-  // Layer 1: Dynamic Sizing
-  useDynamicSizing: true,
-  portfolioValue: 1_000_000,
-  baseAllocationPct: 2.0,
-  maxPositionPct: 5.0,
-  riskPerTradePct: 1.0,
-
-  // Layer 2: Dip Buying (conservative — don't throw good money after bad)
-  dipBuyEnabled: true,
-  dipBuyTier1Pct: 10,
-  dipBuyTier1SizePct: 25,
-  dipBuyTier2Pct: 20,
-  dipBuyTier2SizePct: 50,
-  dipBuyTier3Pct: 30,
-  dipBuyTier3SizePct: 75,
-  dipBuyCooldownHours: 72,
-
-  // Layer 3: Profit Taking (aggressive — generate income, trim winners early)
-  profitTakeEnabled: true,
-  profitTakeTier1Pct: 8,
-  profitTakeTier1TrimPct: 25,
-  profitTakeTier2Pct: 15,
-  profitTakeTier2TrimPct: 30,
-  profitTakeTier3Pct: 25,
-  profitTakeTier3TrimPct: 30,
-  minHoldPct: 15,
-
-  // Layer 3b: Loss Cutting (protect capital — sell losers before they get worse)
-  lossCutEnabled: true,
-  lossCutTier1Pct: 8,
-  lossCutTier1SellPct: 30,
-  lossCutTier2Pct: 15,
-  lossCutTier2SellPct: 50,
-  lossCutTier3Pct: 25,
-  lossCutTier3SellPct: 100,
-  lossCutMinHoldDays: 2,
-
-  // Layer 4: Risk Management
-  marketRegimeEnabled: true,
-  maxSectorPct: 30,
-  earningsAvoidEnabled: true,
-  earningsBlackoutDays: 3,
-  kellyAdaptiveEnabled: false,
-  longTermBucketPct: 50, // matches DB default: 50% of maxTotalAllocation for long-term sleeve
-
-  // Layer 5: Capital Recycling
-  swingMaxHoldDays: 5,
-  capitalPressureEnabled: true,
-  ltStopLossPct: 0,
-  ltProfitTakePct: 15,
-  ltMaxHoldDays: 0,
-  ltTrailingStopPct: 10,
-
-  // Module Toggles
-  tradeSignalsEnabled: true,
-  suggestedFindsEnabled: true,
-  optionsWheelEnabled: true,
-
-  // Suggested Finds
+  ...SHARED_DEFAULTS,
   suggestedFindPositionSize: 2000,
 };
 
@@ -351,6 +206,8 @@ export async function loadAutoTraderConfig(): Promise<AutoTraderConfig> {
         ltMaxHoldDays: Number(data.lt_max_hold_days ?? DEFAULT_CONFIG.ltMaxHoldDays),
         ltTrailingStopPct: Number(data.lt_trailing_stop_pct ?? DEFAULT_CONFIG.ltTrailingStopPct),
         suggestedFindPositionSize: Number(data.suggested_find_position_size ?? DEFAULT_CONFIG.suggestedFindPositionSize),
+        externalSignalPositionSize: Number(data.external_signal_position_size ?? DEFAULT_CONFIG.externalSignalPositionSize),
+        dayTradeMaxDailyLoss: Number(data.day_trade_max_daily_loss ?? DEFAULT_CONFIG.dayTradeMaxDailyLoss),
 
         // Module Toggles
         tradeSignalsEnabled: data.trade_signals_enabled ?? DEFAULT_CONFIG.tradeSignalsEnabled,
@@ -1715,7 +1572,7 @@ export async function checkLossCutOpportunities(
       });
 
       const realizedLoss = sellQty * (ibPos.mktPrice - ibPos.avgCost);
-      const msg = `Loss cut ${triggered.label}: sold ${sellQty} shares at $${ibPos.mktPrice.toFixed(2)} (-${lossPct.toFixed(1)}%, ~${fmtUsdSimple(realizedLoss)})`;
+      const msg = `Loss cut ${triggered.label}: sold ${sellQty} shares at $${ibPos.mktPrice.toFixed(2)} (-${lossPct.toFixed(1)}%, ~${fmtUsdCompact(realizedLoss)})`;
       logEvent(trade.ticker, 'success', msg);
       persistEvent(trade.ticker, 'success', msg, {
         action: 'executed', source: 'loss_cut', mode: trade.mode as 'LONG_TERM',
@@ -1737,12 +1594,6 @@ export async function checkLossCutOpportunities(
   }
 
   return results;
-}
-
-/** Simple USD format for log messages */
-function fmtUsdSimple(val: number): string {
-  const sign = val >= 0 ? '+' : '-';
-  return `${sign}$${Math.abs(val).toFixed(0)}`;
 }
 
 // ── Smart Trading: Pre-Trade Checks ──────────────────────

--- a/app/src/lib/optionsApi.ts
+++ b/app/src/lib/optionsApi.ts
@@ -4,6 +4,7 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
+import { ACTIVE_STATUSES, CLOSED_STATUSES } from '../../../shared/trade-status-sets.ts';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
@@ -258,7 +259,7 @@ export async function getOpenOptionsPositions(): Promise<OpenOptionsPosition[]> 
     .from('paper_trades')
     .select('id, ticker, mode, option_strike, option_expiry, option_premium, option_contracts, option_capital_req, option_prob_profit, option_iv_rank, option_annual_yield, option_net_price, option_delta, option_assigned, status, close_reason, pnl, opened_at, closed_at, notes, scanner_reason')
     .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
-    .in('status', ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL'])
+    .in('status', [...ACTIVE_STATUSES])
     .order('option_expiry', { ascending: true });
   if (error) throw error;
   return (data ?? []) as OpenOptionsPosition[];
@@ -281,7 +282,7 @@ export async function getClosedOptionsPositions(limit = 50): Promise<OpenOptions
     .from('paper_trades')
     .select('id, ticker, mode, option_strike, option_expiry, option_premium, option_capital_req, option_prob_profit, option_iv_rank, option_annual_yield, option_net_price, option_delta, option_assigned, status, close_reason, pnl, opened_at, closed_at, notes, scanner_reason')
     .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
-    .in('status', ['CLOSED', 'TARGET_HIT', 'STOPPED'])
+    .in('status', [...CLOSED_STATUSES])
     .order('closed_at', { ascending: false })
     .limit(limit);
   if (error) throw error;
@@ -300,13 +301,13 @@ export async function getOptionsMonthlyStats(): Promise<OptionsMonthlyStats> {
       .from('paper_trades')
       .select('pnl, option_capital_req')
       .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
-      .in('status', ['CLOSED', 'TARGET_HIT', 'STOPPED'])
+      .in('status', [...CLOSED_STATUSES])
       .gte('closed_at', monthStart.toISOString()),
     supabase
       .from('paper_trades')
       .select('id, option_premium, option_contracts')
       .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
-      .in('status', ['FILLED', 'PARTIAL', 'PENDING', 'SUBMITTED']),
+      .in('status', [...ACTIVE_STATUSES]),
   ]);
 
   // Only count trades with meaningful P&L (> $1) — excludes spurious $0 closes

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -6,6 +6,19 @@
 import { supabase } from './supabaseClient';
 import { getExemptFromAutoDeactivationSources } from './strategyVideosApi';
 
+import type { PaperTrade, TradeStatus, CloseReason, TradeMode } from '../../../shared/trade-types.ts';
+export type { PaperTrade, TradeStatus, CloseReason, TradeMode };
+
+import type { AutoTradeEventRecord, AutoTradeAction, AutoTradeSource } from '../../../shared/auto-trade-events.ts';
+export type { AutoTradeEventRecord, AutoTradeAction, AutoTradeSource };
+
+import {
+  ACTIVE_STATUSES,
+  CLOSED_STATUSES,
+  EXCLUDED_STATUSES,
+  ALL_TERMINAL_STATUSES,
+} from '../../../shared/trade-status-sets.ts';
+
 // ── Shared cache: dedup parallel paper_trades fetches ────
 // The recalculate*() functions all query paper_trades independently.
 // This cache ensures only one round-trip happens when they run in parallel.
@@ -59,71 +72,7 @@ export function clearSharedTradesCache(): void {
 }
 
 // ── Types ────────────────────────────────────────────────
-
-export type TradeStatus =
-  | 'PENDING'
-  | 'SUBMITTED'
-  | 'FILLED'
-  | 'PARTIAL'
-  | 'STOPPED'
-  | 'TARGET_HIT'
-  | 'CLOSED'
-  | 'CANCELLED'
-  | 'REJECTED';
-
-export type CloseReason =
-  | 'stop_loss'
-  | 'target_hit'
-  | 'eod_close'
-  | 'manual'
-  | 'cancelled';
-
-export interface PaperTrade {
-  id: string;
-  ticker: string;
-  mode: 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL';
-  signal: 'BUY' | 'SELL';
-  strategy_source: string | null;
-  strategy_source_url: string | null;
-  strategy_video_id: string | null;
-  strategy_video_heading: string | null;
-  scanner_confidence: number | null;
-  fa_confidence: number | null;
-  fa_recommendation: string | null;
-  entry_price: number | null;
-  stop_loss: number | null;
-  target_price: number | null;
-  target_price2: number | null;
-  risk_reward: string | null;
-  quantity: number | null;
-  position_size: number | null;
-  ib_order_id: string | null;
-  ib_parent_order_id: string | null;
-  status: TradeStatus;
-  fill_price: number | null;
-  close_price: number | null;
-  pnl: number | null;
-  pnl_percent: number | null;
-  opened_at: string;
-  filled_at: string | null;
-  closed_at: string | null;
-  close_reason: CloseReason | null;
-  scanner_reason: string | null;
-  fa_rationale: { technical?: string; sentiment?: string; risk?: string } | null;
-  notes: string | null;
-  created_at: string;
-  // Validation log (day-trade analysis)
-  in_play_score?: number | null;
-  pass1_confidence?: number | null;
-  entry_trigger_type?: string | null;
-  r_multiple?: number | null;
-  market_condition?: string | null;
-  // Swing entry log (post-trade metrics — collect only)
-  pct_distance_sma20_at_entry?: number | null;
-  macd_histogram_slope_at_entry?: string | null;
-  volume_vs_10d_avg_at_entry?: number | null;
-  regime_alignment_at_entry?: string | null;
-}
+// PaperTrade, TradeStatus, CloseReason, TradeMode imported from shared/trade-types.ts above.
 
 export interface TradeLearning {
   id: string;
@@ -212,7 +161,7 @@ export async function getActiveTrades(): Promise<PaperTrade[]> {
   const { data, error } = await supabase
     .from('paper_trades')
     .select('*')
-    .in('status', ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL'])
+    .in('status', [...ACTIVE_STATUSES])
     .order('opened_at', { ascending: false });
 
   if (error) throw new Error(`Failed to fetch active trades: ${error.message}`);
@@ -424,7 +373,7 @@ export async function getSwingTradeValidationReport(): Promise<SwingTradeValidat
   funnel.signalsPerWeek = days >= 1 ? Math.round((funnel.signals / days) * 5) : 0; // ~5 trading days/week
 
   const closed = trades.filter(
-    t => t.fill_price != null && ['STOPPED', 'TARGET_HIT', 'CLOSED'].includes(t.status)
+    t => t.fill_price != null && (CLOSED_STATUSES as readonly string[]).includes(t.status)
   );
   const bracketOrders = trades.filter(t => t.entry_trigger_type === 'bracket_limit');
   const filled = bracketOrders.filter(t => t.fill_price != null);
@@ -531,7 +480,7 @@ export async function hasActiveTrade(ticker: string): Promise<boolean> {
     .from('paper_trades')
     .select('id', { count: 'exact', head: true })
     .eq('ticker', ticker)
-    .in('status', ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL']);
+    .in('status', [...ACTIVE_STATUSES]);
 
   if (error) return false;
   return (count ?? 0) > 0;
@@ -542,7 +491,7 @@ export async function countActivePositions(): Promise<number> {
   const { count, error } = await supabase
     .from('paper_trades')
     .select('id', { count: 'exact', head: true })
-    .in('status', ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL']);
+    .in('status', [...ACTIVE_STATUSES]);
 
   if (error) return 0;
   return count ?? 0;
@@ -576,30 +525,7 @@ export async function getRecentLearnings(limit = 20): Promise<TradeLearning[]> {
 
 // ── Auto Trade Events ────────────────────────────────────
 
-/**
- * Canonical action/source/mode values — must stay in sync with
- * AutoTradeAction / AutoTradeSource / AutoTradeMode in auto-trader/src/lib/supabase.ts
- */
-export interface AutoTradeEventRecord {
-  id: string;
-  ticker: string;
-  event_type: 'info' | 'success' | 'warning' | 'error';
-  action: 'executed' | 'skipped' | 'failed' | 'closed' | 'proceeding' | 'health_check' | 'RECONCILIATION' | 'scan_complete' | null;
-  source: 'scanner' | 'suggested_finds' | 'manual' | 'system' | 'dip_buy' | 'profit_take' | 'loss_cut' | 'lt_auto_sell' | 'swing_expiry' | 'capital_pressure' | 'external_signal' | 'spx_level_scanner' | 'earnings_scanner' | 'watchlist_screener' | 'compounder_health' | null;
-  mode: 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL' | 'EARNINGS_CALENDAR' | null;
-  message: string;
-  strategy_source: string | null;
-  strategy_source_url: string | null;
-  strategy_video_id: string | null;
-  strategy_video_heading: string | null;
-  scanner_signal: string | null;
-  scanner_confidence: number | null;
-  fa_recommendation: string | null;
-  fa_confidence: number | null;
-  skip_reason: string | null;
-  metadata: Record<string, unknown> | null;
-  created_at: string;
-}
+// AutoTradeEventRecord, AutoTradeAction, AutoTradeSource imported from shared/auto-trade-events.ts above.
 
 /** Persist an auto-trade event to Supabase */
 export async function createAutoTradeEvent(
@@ -763,7 +689,7 @@ export async function recalculatePerformance(): Promise<TradePerformance | null>
   const { data: trades, error } = await supabase
     .from('paper_trades')
     .select('*')
-    .in('status', ['STOPPED', 'TARGET_HIT', 'CLOSED']);
+    .in('status', [...CLOSED_STATUSES]);
 
   if (error || !trades || trades.length === 0) return null;
 
@@ -958,17 +884,11 @@ export async function recalculatePerformanceByCategory(): Promise<CategoryPerfor
 
   for (const cat of categories) {
     const catTrades = trades.filter(cat.filter);
-    // Exclude cancelled/rejected — these never executed, no money at risk
-    const excludedStatuses = ['CANCELLED', 'REJECTED'];
-    const meaningful = catTrades.filter(t => !excludedStatuses.includes(t.status));
+    const meaningful = catTrades.filter(t => !(EXCLUDED_STATUSES as readonly string[]).includes(t.status));
 
-    const activeStatuses = ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL'];
-    const closedStatuses = ['STOPPED', 'TARGET_HIT', 'CLOSED'];
-
-    const active = meaningful.filter(t => activeStatuses.includes(t.status));
-    // Only count completed trades that actually filled
+    const active = meaningful.filter(t => (ACTIVE_STATUSES as readonly string[]).includes(t.status));
     const completed = meaningful.filter(
-      t => closedStatuses.includes(t.status) && t.fill_price != null
+      t => (CLOSED_STATUSES as readonly string[]).includes(t.status) && t.fill_price != null
     );
     const wins = completed.filter(t => (t.pnl ?? 0) > 0);
     const losses = completed.filter(t => (t.pnl ?? 0) < 0);
@@ -1027,8 +947,8 @@ export async function recalculatePerformanceByStrategySource(): Promise<Strategy
   }
   const trades = allTrades.filter(t => t.strategy_source != null);
 
-  const activeStatuses = new Set(['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL']);
-  const closedStatuses = new Set(['STOPPED', 'TARGET_HIT', 'CLOSED']);
+  const activeStatusSet = new Set(ACTIVE_STATUSES);
+  const closedStatusSet = new Set(CLOSED_STATUSES);
 
   const groups = new Map<string, {
     sourceUrl: string | null;
@@ -1063,14 +983,14 @@ export async function recalculatePerformanceByStrategySource(): Promise<Strategy
     }
 
     curr.totalTrades += 1;
-    if (activeStatuses.has(trade.status)) {
+    if (activeStatusSet.has(trade.status)) {
       curr.activeTrades += 1;
       if (trade.status === 'FILLED' && trade.pnl != null) {
         curr.activeUnrealizedPnl += trade.pnl;
       }
     }
 
-    if (closedStatuses.has(trade.status) && trade.fill_price != null) {
+    if (closedStatusSet.has(trade.status) && trade.fill_price != null) {
       curr.closedCount += 1;
       const pnl = trade.pnl ?? 0;
       curr.closedPnl += pnl;
@@ -1131,8 +1051,8 @@ export async function recalculatePerformanceByStrategyVideo(): Promise<StrategyV
   }
   const trades = allTrades.filter(t => t.strategy_source != null);
 
-  const activeStatuses = new Set(['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL']);
-  const closedStatuses = new Set(['STOPPED', 'TARGET_HIT', 'CLOSED']);
+  const activeStatusSet = new Set(ACTIVE_STATUSES);
+  const closedStatusSet = new Set(CLOSED_STATUSES);
 
   const groups = new Map<string, {
     source: string;
@@ -1205,14 +1125,14 @@ export async function recalculatePerformanceByStrategyVideo(): Promise<StrategyV
     });
 
     curr.totalTrades += 1;
-    if (activeStatuses.has(trade.status)) {
+    if (activeStatusSet.has(trade.status)) {
       curr.activeTrades += 1;
       if (trade.status === 'FILLED' && trade.pnl != null) {
         curr.activeUnrealizedPnl += trade.pnl;
       }
     }
 
-    if (closedStatuses.has(trade.status) && trade.fill_price != null) {
+    if (closedStatusSet.has(trade.status) && trade.fill_price != null) {
       curr.closedCount += 1;
       const pnl = trade.pnl ?? 0;
       curr.closedPnl += pnl;
@@ -1716,10 +1636,11 @@ export async function fetchInfluencerTradePatterns(): Promise<InfluencerTradePat
   const spyAligned = { wins: 0, losses: 0, total: 0 };
   const spyAgainst = { wins: 0, losses: 0, total: 0 };
 
-  const CLOSED_STATUSES = ['CLOSED', 'STOPPED', 'TARGET_HIT', 'CANCELLED', 'EXPIRED', 'REJECTED'];
+  // All terminal statuses + 'EXPIRED' (not a formal TradeStatus but can appear in data)
+  const ALL_TERMINAL_WITH_EXPIRED = [...ALL_TERMINAL_STATUSES, 'EXPIRED'] as string[];
 
   for (const trade of trades) {
-    const isClosed = CLOSED_STATUSES.includes(trade.status);
+    const isClosed = ALL_TERMINAL_WITH_EXPIRED.includes(trade.status);
     const isWin = isClosed && (trade.pnl ?? 0) > 0;
     const isLoss = isClosed && (trade.pnl ?? 0) <= 0;
 
@@ -1763,7 +1684,7 @@ export async function fetchInfluencerTradePatterns(): Promise<InfluencerTradePat
     };
   });
 
-  const closedTrades = trades.filter(t => CLOSED_STATUSES.includes(t.status)).length;
+  const closedTrades = trades.filter(t => ALL_TERMINAL_WITH_EXPIRED.includes(t.status)).length;
 
   return {
     timeBuckets,

--- a/app/tsconfig.app.json
+++ b/app/tsconfig.app.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src", "../shared"]
 }

--- a/auto-trader/package.json
+++ b/auto-trader/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "node dist/auto-trader/src/index.js",
     "dev": "tsx watch src/index.ts",
     "test": "tsx src/lib/tradePerformanceMetrics.test.ts"
   },

--- a/auto-trader/src/lib/feedback.ts
+++ b/auto-trader/src/lib/feedback.ts
@@ -8,6 +8,7 @@
  */
 
 import { getSupabase } from './supabase.js';
+import { CLOSED_STATUSES } from '../../../shared/trade-status-sets.js';
 
 const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions';
 const GROQ_MODEL = 'meta-llama/llama-4-scout-17b-16e-instruct';
@@ -234,7 +235,7 @@ export async function recalculatePerformance(): Promise<boolean> {
   const { data: trades, error } = await sb
     .from('paper_trades')
     .select('*')
-    .in('status', ['STOPPED', 'TARGET_HIT', 'CLOSED']);
+    .in('status', [...CLOSED_STATUSES]);
 
   if (error || !trades || trades.length === 0) return false;
 
@@ -330,7 +331,7 @@ export async function analyzeUnreviewedTrades(): Promise<number> {
   const { data: closedTrades, error: tErr } = await sb
     .from('paper_trades')
     .select('*')
-    .in('status', ['STOPPED', 'TARGET_HIT', 'CLOSED'])
+    .in('status', [...CLOSED_STATUSES])
     .order('closed_at', { ascending: false })
     .limit(20);
 

--- a/auto-trader/src/lib/options-manager.ts
+++ b/auto-trader/src/lib/options-manager.ts
@@ -10,11 +10,14 @@
  */
 
 import { getSupabase, createAutoTradeEvent } from './supabase.js';
+import { ACTIVE_STATUSES, CLOSED_STATUSES, OPTIONS_MODES } from '../../../shared/trade-status-sets.js';
 import { getOptionsAutoTradeConfig, autoTradeOption, type OptionsTradeTicket } from './options-scanner.js';
 import { getOptionsChain } from './options-chain.js';
 import { isConnected, requestOpenOrders, placeOptionsOrder, getDefaultAccount } from '../ib-connection.js';
 
-function persistEvent(ticker: string, eventType: string, message: string, extra?: Record<string, unknown>): void {
+import type { AutoTradeEventType } from '../../../shared/auto-trade-events.js';
+
+function persistEvent(ticker: string, eventType: AutoTradeEventType, message: string, extra?: Record<string, unknown>): void {
   createAutoTradeEvent({ ticker, event_type: eventType, message, ...extra })
     .catch(err => console.warn(`[Options persistEvent] ${ticker}/${eventType} failed:`, err instanceof Error ? err.message : err));
 }
@@ -267,8 +270,8 @@ export async function getOpenOptionsPositions(): Promise<OpenOptionsPosition[]> 
   const { data, error } = await sb
     .from('paper_trades')
     .select('id, ticker, mode, option_strike, option_expiry, option_premium, option_capital_req, option_assigned, fill_price, status, pnl')
-    .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
-    .in('status', ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL']);
+    .in('mode', [...OPTIONS_MODES])
+    .in('status', [...ACTIVE_STATUSES]);
 
   if (error || !data) return [];
 
@@ -347,7 +350,7 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
     const { data: submitted } = await sb
       .from('paper_trades')
       .select('id, ticker, option_strike, option_premium, ib_order_id')
-      .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
+      .in('mode', [...OPTIONS_MODES])
       .eq('status', 'SUBMITTED')
       .not('ib_order_id', 'is', null);
 
@@ -377,7 +380,7 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
   const { data, error } = await sb
     .from('paper_trades')
     .select('id, ticker, mode, option_strike, option_expiry, option_premium, option_capital_req, option_assigned, fill_price, status, ib_order_id, roll_count, rolled_from_id')
-    .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
+    .in('mode', [...OPTIONS_MODES])
     .in('status', ['FILLED', 'PARTIAL']);
 
   if (error || !data) return result;
@@ -1010,15 +1013,15 @@ export async function getOptionsMonthlyStats(): Promise<{
   const { data: closed } = await sb
     .from('paper_trades')
     .select('pnl, option_capital_req')
-    .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
-    .in('status', ['CLOSED', 'TARGET_HIT', 'STOPPED'])
+    .in('mode', [...OPTIONS_MODES])
+    .in('status', [...CLOSED_STATUSES])
     .gte('closed_at', monthStart.toISOString());
 
   const { data: open } = await sb
     .from('paper_trades')
     .select('id')
-    .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
-    .in('status', ['FILLED', 'PARTIAL', 'PENDING', 'SUBMITTED']);
+    .in('mode', [...OPTIONS_MODES])
+    .in('status', [...ACTIVE_STATUSES]);
 
   const trades = closed ?? [];
   // Filter out phantom $0 closes (data integrity guard)

--- a/auto-trader/src/lib/options-scanner.ts
+++ b/auto-trader/src/lib/options-scanner.ts
@@ -34,6 +34,7 @@
  */
 
 import { getSupabase, createAutoTradeEvent } from './supabase.js';
+import { ACTIVE_STATUSES } from '../../../shared/trade-status-sets.js';
 import { getOptionsChain, type OptionGreeks } from './options-chain.js';
 import { isConnected, placeOptionsOrder, getDefaultAccount } from '../ib-connection.js';
 import { fetchDailyBars, fetchQuote, sma as calcSma, estimateHistoricalVol } from './yahoo-finance.js';
@@ -505,7 +506,7 @@ async function buildScanContext(
     sb.from('paper_trades')
       .select('ticker, mode, position_size')
       .eq('mode', 'OPTIONS_PUT')
-      .in('status', ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL']),
+      .in('status', [...ACTIVE_STATUSES]),
   ]);
 
   const sectorByTicker = new Map<string, string>();

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -6,6 +6,7 @@
  */
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { ACTIVE_STATUSES, CLOSED_STATUSES } from '../../../shared/trade-status-sets.js';
 
 const SUPABASE_URL = process.env.SUPABASE_URL ?? '';
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
@@ -32,97 +33,10 @@ export function isConfigured(): boolean {
   return !!(SUPABASE_URL && SUPABASE_SERVICE_KEY && SUPABASE_ANON_KEY);
 }
 
-// ── Auto-Trader Config ──────────────────────────────────
-
-export interface AutoTraderConfig {
-  enabled: boolean;
-  maxPositions: number;
-  positionSize: number;
-  minScannerConfidence: number;
-  minFAConfidence: number;
-  minSuggestedFindsConviction: number;
-  accountId: string | null;
-  dayTradeAutoClose: boolean;
-  maxTotalAllocation: number;
-  maxDailyDeployment: number;
-  useDynamicSizing: boolean;
-  portfolioValue: number;
-  baseAllocationPct: number;
-  maxPositionPct: number;
-  riskPerTradePct: number;
-  dipBuyEnabled: boolean;
-  dipBuyTier1Pct: number; dipBuyTier1SizePct: number;
-  dipBuyTier2Pct: number; dipBuyTier2SizePct: number;
-  dipBuyTier3Pct: number; dipBuyTier3SizePct: number;
-  dipBuyCooldownHours: number;
-  profitTakeEnabled: boolean;
-  profitTakeTier1Pct: number; profitTakeTier1TrimPct: number;
-  profitTakeTier2Pct: number; profitTakeTier2TrimPct: number;
-  profitTakeTier3Pct: number; profitTakeTier3TrimPct: number;
-  minHoldPct: number;
-  lossCutEnabled: boolean;
-  lossCutTier1Pct: number; lossCutTier1SellPct: number;
-  lossCutTier2Pct: number; lossCutTier2SellPct: number;
-  lossCutTier3Pct: number; lossCutTier3SellPct: number;
-  lossCutMinHoldDays: number;
-  marketRegimeEnabled: boolean;
-  maxSectorPct: number;
-  earningsAvoidEnabled: boolean;
-  earningsBlackoutDays: number;
-  kellyAdaptiveEnabled: boolean;
-  longTermBucketPct: number;
-  /** Flat dollar size for influencer daily signal trades. 0 = use dynamic sizing. */
-  externalSignalPositionSize: number;
-  swingMaxHoldDays: number;        // auto-exit filled swing trades after N days (0 = off)
-  capitalPressureEnabled: boolean; // when at cap, auto-close best swing to make room
-  ltStopLossPct: number;           // long-term fixed stop-loss (0 = disabled, replaced by trailing)
-  ltProfitTakePct: number;         // long-term profit-take: close if PnL% > this (e.g. 15)
-  ltMaxHoldDays: number;           // long-term max hold days (0 = disabled)
-  ltTrailingStopPct: number;       // trailing stop: sell if price falls this % from peak (only after being in profit)
-  dayTradeMaxDailyLoss: number;    // stop new day-trade entries when session realized P&L < -$X (0 = disabled)
-  tradeSignalsEnabled: boolean;    // enable/disable day/swing trade scanner
-  suggestedFindsEnabled: boolean;  // enable/disable Suggested Finds auto-buy
-  optionsWheelEnabled: boolean;    // enable/disable options wheel scanner
-}
-
-const DEFAULT_CONFIG: AutoTraderConfig = {
-  enabled: false, maxPositions: 3, positionSize: 1000,
-  minScannerConfidence: 7, minFAConfidence: 7, minSuggestedFindsConviction: 8,
-  accountId: null, dayTradeAutoClose: true,
-  maxTotalAllocation: 500_000, maxDailyDeployment: 50_000,
-  useDynamicSizing: true, portfolioValue: 1_000_000,
-  baseAllocationPct: 2.0, maxPositionPct: 5.0, riskPerTradePct: 1.0,
-  dipBuyEnabled: true,
-  dipBuyTier1Pct: 10, dipBuyTier1SizePct: 25,
-  dipBuyTier2Pct: 20, dipBuyTier2SizePct: 50,
-  dipBuyTier3Pct: 30, dipBuyTier3SizePct: 75,
-  dipBuyCooldownHours: 72,
-  profitTakeEnabled: true,
-  profitTakeTier1Pct: 8, profitTakeTier1TrimPct: 25,
-  profitTakeTier2Pct: 15, profitTakeTier2TrimPct: 30,
-  profitTakeTier3Pct: 25, profitTakeTier3TrimPct: 30,
-  minHoldPct: 15,
-  lossCutEnabled: true,
-  lossCutTier1Pct: 6, lossCutTier1SellPct: 30,
-  lossCutTier2Pct: 12, lossCutTier2SellPct: 50,
-  lossCutTier3Pct: 20, lossCutTier3SellPct: 100,
-  lossCutMinHoldDays: 1,
-  marketRegimeEnabled: true, maxSectorPct: 30,
-  earningsAvoidEnabled: true, earningsBlackoutDays: 3,
-  kellyAdaptiveEnabled: false,
-  longTermBucketPct: 50,
-  externalSignalPositionSize: 5000,
-  swingMaxHoldDays: 5,
-  capitalPressureEnabled: true,
-  ltStopLossPct: -12,
-  ltProfitTakePct: 15,
-  ltMaxHoldDays: 0,
-  ltTrailingStopPct: 10,
-  dayTradeMaxDailyLoss: 500,
-  tradeSignalsEnabled: true,
-  suggestedFindsEnabled: true,
-  optionsWheelEnabled: true,
-};
+// ── Auto-Trader Config (shared single source of truth) ──
+export type { AutoTraderConfig } from '../../../shared/config-defaults.js';
+import { type AutoTraderConfig, DEFAULT_CONFIG as SHARED_DEFAULTS } from '../../../shared/config-defaults.js';
+const DEFAULT_CONFIG = SHARED_DEFAULTS;
 
 export async function loadConfig(): Promise<AutoTraderConfig> {
   const sb = getSupabase();
@@ -210,56 +124,8 @@ export async function saveConfigPartial(
 
 // ── Paper Trades ─────────────────────────────────────────
 
-export interface PaperTrade {
-  id: string;
-  ticker: string;
-  mode: 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL';
-  signal: 'BUY' | 'SELL';
-  strategy_source: string | null;
-  strategy_source_url: string | null;
-  strategy_video_id: string | null;
-  strategy_video_heading: string | null;
-  scanner_confidence: number | null;
-  fa_confidence: number | null;
-  fa_recommendation: string | null;
-  entry_price: number | null;
-  stop_loss: number | null;
-  target_price: number | null;
-  target_price2: number | null;
-  risk_reward: string | null;
-  quantity: number | null;
-  position_size: number | null;
-  ib_order_id: string | null;
-  ib_tp_order_id: string | null;
-  ib_sl_order_id: string | null;
-  status: string;
-  fill_price: number | null;
-  close_price: number | null;
-  pnl: number | null;
-  pnl_percent: number | null;
-  opened_at: string;
-  filled_at: string | null;
-  closed_at: string | null;
-  close_reason: string | null;
-  scanner_reason: string | null;
-  fa_rationale: Record<string, string> | null;
-  notes: string | null;
-  created_at: string;
-  in_play_score?: number | null;
-  pass1_confidence?: number | null;
-  entry_trigger_type?: string | null;
-  r_multiple?: number | null;
-  market_condition?: string | null;
-  // Swing entry log (post-trade metrics — collect only)
-  pct_distance_sma20_at_entry?: number | null;
-  macd_histogram_slope_at_entry?: string | null;
-  volume_vs_10d_avg_at_entry?: number | null;
-  regime_alignment_at_entry?: string | null;
-  // Long-term trailing stop tracking
-  price_peak?: number | null;
-  price_peak_date?: string | null;
-  missing_since?: string | null;
-}
+export type { PaperTrade, TradeStatus, TradeMode, CloseReason, TradeSignal } from '../../../shared/trade-types.js';
+import type { PaperTrade } from '../../../shared/trade-types.js';
 
 export type ExternalStrategySignalStatus =
   | 'PENDING'
@@ -313,25 +179,14 @@ export interface StrategyClosedTradeOutcome {
   opened_at: string | null;
 }
 
-function formatDateToEtIso(date: Date): string {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/New_York',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(date);
-  const year = parts.find(p => p.type === 'year')?.value ?? '0000';
-  const month = parts.find(p => p.type === 'month')?.value ?? '00';
-  const day = parts.find(p => p.type === 'day')?.value ?? '00';
-  return `${year}-${month}-${day}`;
-}
+import { formatDateToEtIso } from '../../../shared/date-helpers.js';
 
 export async function getActiveTrades(): Promise<PaperTrade[]> {
   const sb = getSupabase();
   const { data, error } = await sb
     .from('paper_trades')
     .select('*')
-    .in('status', ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL'])
+    .in('status', [...ACTIVE_STATUSES])
     .order('opened_at', { ascending: false });
   if (error) throw new Error(`getActiveTrades: ${error.message}`);
   return (data ?? []) as PaperTrade[];
@@ -392,7 +247,7 @@ export async function hasActiveTrade(
     .from('paper_trades')
     .select('id', { count: 'exact', head: true })
     .eq('ticker', ticker)
-    .in('status', ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL']);
+    .in('status', [...ACTIVE_STATUSES]);
   if (opts?.excludeMode) {
     query = query.neq('mode', opts.excludeMode);
   }
@@ -492,7 +347,7 @@ export async function countActivePositions(): Promise<number> {
   const { count } = await sb
     .from('paper_trades')
     .select('id', { count: 'exact', head: true })
-    .in('status', ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL'])
+    .in('status', [...ACTIVE_STATUSES])
     .not('mode', 'in', '(OPTIONS_PUT,OPTIONS_CALL)');
   return count ?? 0;
 }
@@ -677,8 +532,8 @@ export async function getStrategySourcePerformance(): Promise<StrategySourcePerf
     activeUnrealizedPnl: number;
   }>();
 
-  const activeStatuses = new Set(['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL']);
-  const closedStatuses = new Set(['STOPPED', 'TARGET_HIT', 'CLOSED']);
+  const activeStatuses = new Set<string>(ACTIVE_STATUSES);
+  const closedStatuses = new Set<string>(CLOSED_STATUSES);
 
   for (const trade of trades) {
     const source = (trade.strategy_source ?? '').trim();
@@ -747,7 +602,7 @@ export async function getRecentClosedStrategyOutcomes(params: {
     .from('paper_trades')
     .select('pnl, closed_at, opened_at')
     .eq('strategy_source', params.sourceName)
-    .in('status', ['STOPPED', 'TARGET_HIT', 'CLOSED'])
+    .in('status', [...CLOSED_STATUSES])
     .not('fill_price', 'is', null)
     .order('closed_at', { ascending: false, nullsFirst: false })
     .order('opened_at', { ascending: false });
@@ -767,30 +622,8 @@ export async function getRecentClosedStrategyOutcomes(params: {
 
 // ── Auto Trade Events ────────────────────────────────────
 
-export type AutoTradeAction = 'executed' | 'closed' | 'skipped' | 'failed' | 'proceeding' | 'health_check' | 'RECONCILIATION' | 'scan_complete';
-export type AutoTradeSource = 'scanner' | 'suggested_finds' | 'manual' | 'system' | 'dip_buy' | 'profit_take' | 'loss_cut' | 'lt_auto_sell' | 'swing_expiry' | 'capital_pressure' | 'external_signal' | 'spx_level_scanner' | 'earnings_scanner' | 'watchlist_screener' | 'compounder_health';
-export type AutoTradeMode = 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL' | 'EARNINGS_CALENDAR';
-
-export interface AutoTradeEventInput {
-  ticker: string;
-  event_type?: string;
-  message: string;
-  action?: AutoTradeAction;
-  source?: AutoTradeSource;
-  mode?: AutoTradeMode;
-  scanner_signal?: string | null;
-  scanner_confidence?: number | null;
-  fa_recommendation?: string | null;
-  fa_confidence?: number | null;
-  skip_reason?: string | null;
-  strategy_source?: string | null;
-  strategy_source_url?: string | null;
-  strategy_video_id?: string | null;
-  strategy_video_heading?: string | null;
-  metadata?: Record<string, unknown>;
-  candle_patterns?: string[];
-  [key: string]: unknown;
-}
+export type { AutoTradeAction, AutoTradeSource, AutoTradeEventInput, AutoTradeEventRecord } from '../../../shared/auto-trade-events.js';
+import type { AutoTradeAction, AutoTradeSource, AutoTradeEventInput } from '../../../shared/auto-trade-events.js';
 
 export async function createAutoTradeEvent(
   event: AutoTradeEventInput

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -64,6 +64,8 @@ import {
   type ExternalStrategySignal,
   type PaperTrade,
 } from './lib/supabase.js';
+import { ACTIVE_STATUSES, CLOSED_STATUSES } from '../../shared/trade-status-sets.js';
+import type { AutoTradeEventType } from '../../shared/auto-trade-events.js';
 import {
   recalculatePerformance,
   analyzeCompletedTrade,
@@ -1086,22 +1088,7 @@ function getETMinutes(): number {
   return et.getHours() * 60 + et.getMinutes();
 }
 
-function formatDateToEtIso(date: Date): string {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/New_York',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(date);
-  const year = parts.find(p => p.type === 'year')?.value ?? '0000';
-  const month = parts.find(p => p.type === 'month')?.value ?? '00';
-  const day = parts.find(p => p.type === 'day')?.value ?? '00';
-  return `${year}-${month}-${day}`;
-}
-
-function getETDateString(): string {
-  return formatDateToEtIso(new Date());
-}
+import { formatDateToEtIso, getETDateString } from '../../shared/date-helpers.js';
 
 /** Returns current ET time as "HH:MM" (24h) — used for entry-time pattern analysis */
 function getETTimeString(): string {
@@ -1372,7 +1359,7 @@ async function getGenericStrategyEVScores(): Promise<
     const { data, error } = await sb
       .from('paper_trades')
       .select('strategy_video_id, pnl, pnl_percent, fill_price')
-      .in('status', ['STOPPED', 'TARGET_HIT', 'CLOSED'])
+      .in('status', [...CLOSED_STATUSES])
       .not('strategy_video_id', 'is', null)
       .not('fill_price', 'is', null)
       .not('pnl', 'is', null)
@@ -1978,7 +1965,7 @@ async function getEnrichedPositions(): Promise<EnrichedPosition[]> {
   });
 }
 
-const VALID_EVENT_TYPES = new Set(['info', 'success', 'warning', 'error']);
+const VALID_EVENT_TYPES = new Set<AutoTradeEventType>(['info', 'success', 'warning', 'error']);
 
 function isPermanentDbError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
@@ -1994,8 +1981,8 @@ async function persistEvent(
   message: string,
   extra?: Omit<AutoTradeEventInput, 'ticker' | 'message'>
 ): Promise<void> {
-  const safeType = VALID_EVENT_TYPES.has(eventType) ? eventType : 'info';
-  const payload = { ticker, event_type: safeType, message, ...extra };
+  const safeType = (VALID_EVENT_TYPES.has(eventType as AutoTradeEventType) ? eventType : 'info') as AutoTradeEventType;
+  const payload: AutoTradeEventInput = { ticker, event_type: safeType, message, ...extra };
   const delays = [1000, 2000];
   for (let attempt = 0; attempt <= delays.length; attempt++) {
     try {
@@ -2285,25 +2272,27 @@ async function checkAllocationCap(
     return false;
   }
 
-  // Bucket cap — long-term gets longTermBucketPct, day/swing gets the rest
+  // Bucket cap — long-term gets longTermBucketPct, day/swing gets the rest.
+  // When suggestedFindsEnabled=false, LT bucket allocation flows to day/swing automatically.
+  const effectiveLtPct = config.suggestedFindsEnabled ? config.longTermBucketPct : 0;
   const buckets = await getDeployedByBucket(positions);
   if (mode === 'LONG_TERM') {
-    const ltCap = cap * (config.longTermBucketPct / 100);
+    const ltCap = cap * (effectiveLtPct / 100);
     if (buckets.longTerm + positionSize > ltCap) {
-      log(`Long-term bucket cap for ${ticker}: $${buckets.longTerm.toFixed(0)} + $${positionSize.toFixed(0)} > $${ltCap.toFixed(0)} (${config.longTermBucketPct}% of $${cap})`);
-      persistEvent(ticker, 'warning', `Long-term bucket full (${config.longTermBucketPct}% cap)`, {
+      log(`Long-term bucket cap for ${ticker}: $${buckets.longTerm.toFixed(0)} + $${positionSize.toFixed(0)} > $${ltCap.toFixed(0)} (${effectiveLtPct}% of $${cap})`);
+      persistEvent(ticker, 'warning', `Long-term bucket full (${effectiveLtPct}% cap)`, {
         action: 'skipped', source: 'system',
-        skip_reason: `Long-term bucket cap: ${config.longTermBucketPct}% of allocation`,
+        skip_reason: `Long-term bucket cap: ${effectiveLtPct}% of allocation`,
       });
       return false;
     }
   } else {
-    const dsCap = cap * ((100 - config.longTermBucketPct) / 100);
+    const dsCap = cap * ((100 - effectiveLtPct) / 100);
     if (buckets.daySwing + positionSize > dsCap) {
-      log(`Day/swing bucket cap for ${ticker}: $${buckets.daySwing.toFixed(0)} + $${positionSize.toFixed(0)} > $${dsCap.toFixed(0)} (${100 - config.longTermBucketPct}% of $${cap})`);
-      persistEvent(ticker, 'warning', `Day/swing bucket full (${100 - config.longTermBucketPct}% cap)`, {
+      log(`Day/swing bucket cap for ${ticker}: $${buckets.daySwing.toFixed(0)} + $${positionSize.toFixed(0)} > $${dsCap.toFixed(0)} (${100 - effectiveLtPct}% of $${cap})`);
+      persistEvent(ticker, 'warning', `Day/swing bucket full (${100 - effectiveLtPct}% cap)`, {
         action: 'skipped', source: 'system',
-        skip_reason: `Day/swing bucket cap: ${100 - config.longTermBucketPct}% of allocation`,
+        skip_reason: `Day/swing bucket cap: ${100 - effectiveLtPct}% of allocation`,
       });
       return false;
     }
@@ -2339,7 +2328,7 @@ async function calculateKellyMultiplier(config: AutoTraderConfig): Promise<numbe
     const { data, error } = await sb
       .from('paper_trades')
       .select('pnl_percent, fill_price, mode')
-      .in('status', ['CLOSED', 'STOPPED', 'TARGET_HIT'])
+      .in('status', [...CLOSED_STATUSES])
       .in('mode', ['DAY_TRADE', 'SWING_TRADE'])
       .not('pnl_percent', 'is', null)
       .not('fill_price', 'is', null)
@@ -3995,7 +3984,7 @@ async function syncPositions(
         ? (actual - fillPrice) * qty
         : (fillPrice - actual) * qty;
 
-      let closeReason: string = 'manual';
+      let closeReason: import('../../shared/trade-types.js').CloseReason = 'manual';
       if (trade.stop_loss && trade.target_price) {
         if (isLong) {
           if (actual >= trade.target_price) closeReason = 'target_hit';
@@ -4008,7 +3997,7 @@ async function syncPositions(
       if (closeReason === 'manual' && pnl > 0) closeReason = 'target_hit';
       if (closeReason === 'manual' && pnl < 0) closeReason = 'stop_loss';
 
-      const status = closeReason === 'stop_loss' ? 'STOPPED'
+      const status: import('../../shared/trade-types.js').TradeStatus = closeReason === 'stop_loss' ? 'STOPPED'
         : closeReason === 'target_hit' ? 'TARGET_HIT' : 'CLOSED';
 
       const closedAt = new Date().toISOString();
@@ -4046,10 +4035,10 @@ async function syncPositions(
         })
         .catch(err => log(`Trade analysis failed for ${trade.ticker}: ${err instanceof Error ? err.message : 'unknown'}`));
       if (trade.mode === 'LONG_TERM' && !(trade.notes ?? '').startsWith('Dip buy')) {
-        const tradeForLog: import('./lib/supabase.js').PaperTrade = {
+        const tradeForLog = {
           ...closedTrade,
           opened_at: trade.opened_at ?? trade.created_at ?? closedAt,
-        };
+        } as import('./lib/supabase.js').PaperTrade;
         logLongTermPerformance(tradeForLog)
           .catch(err => log(`Performance log failed for ${trade.ticker}: ${err instanceof Error ? err.message : 'unknown'}`));
       }
@@ -4235,7 +4224,7 @@ async function reconcileOrphanedPositions(
     .select('ticker')
     .eq('mode', 'LONG_TERM')
     .eq('signal', 'BUY')
-    .in('status', ['CLOSED', 'STOPPED', 'TARGET_HIT']);
+    .in('status', [...CLOSED_STATUSES]);
   const knownLTTickers = new Set(
     (historicalLT ?? []).map((r: { ticker: string }) => r.ticker.toUpperCase())
   );
@@ -5723,7 +5712,7 @@ Check the Options Wheel → Open tab to review the covered call position.`,
           .select('id')
           .eq('mode', 'OPTIONS_PUT')
           .gte('created_at', todayStart)
-          .in('status', ['PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL']);
+          .in('status', [...ACTIVE_STATUSES]);
         const newPositionsToday = (openedToday ?? []).length;
 
         if (newPositionsToday >= OPTIONS_MAX_NEW_PER_DAY) {

--- a/auto-trader/start.sh
+++ b/auto-trader/start.sh
@@ -58,7 +58,7 @@ if [ -n "$listener_pids" ]; then
   while IFS= read -r pid; do
     [ -z "$pid" ] && continue
     cmd="$(ps -p "$pid" -o command= 2>/dev/null || true)"
-    if echo "$cmd" | grep -Eq "portfolio-assistant/auto-trader.*dist/index\\.js|node( .*)?dist/index\\.js"; then
+    if echo "$cmd" | grep -Eq "portfolio-assistant/auto-trader.*dist/(auto-trader/src/)?index\\.js|node( .*)?dist/(auto-trader/src/)?index\\.js"; then
       running_our_service="yes"
       break
     fi

--- a/auto-trader/tsconfig.json
+++ b/auto-trader/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "..",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -14,6 +14,6 @@
     "declarationMap": true,
     "sourceMap": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "../shared/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/docs/cursor/2026-05-14-shared-modules.md
+++ b/docs/cursor/2026-05-14-shared-modules.md
@@ -1,0 +1,65 @@
+# Shared Modules — Single Source of Truth
+
+**Date:** 2026-05-14
+**Goal:** Eliminate config/type/constant duplication across auto-trader, frontend, and edge functions.
+
+## Problem
+
+The codebase had identical types, constants, and utility functions duplicated across three runtimes:
+- **Auto-trader** (Node.js/tsc) — `auto-trader/src/`
+- **Frontend** (Vite/React) — `app/src/`
+- **Edge functions** (Deno) — `supabase/functions/`
+
+This caused drift: e.g., `minScannerConfidence` defaulted to 6 in the frontend but 7 in the backend, `lossCutTier1Pct` was 8 vs 6, status arrays had different members across files.
+
+## Solution
+
+Created `shared/` at the repo root with pure TypeScript modules (no runtime dependencies). All three consumers import from it.
+
+### Shared modules
+
+| File | Contents |
+|------|----------|
+| `config-defaults.ts` | `AutoTraderConfig` interface + `DEFAULT_CONFIG` object |
+| `trade-types.ts` | `PaperTrade`, `TradeStatus`, `TradeMode`, `CloseReason`, `TradeSignal` |
+| `auto-trade-events.ts` | `AutoTradeAction`, `AutoTradeSource`, `AutoTradeEventType`, `AutoTradeEventInput`, `AutoTradeEventRecord` |
+| `trade-status-sets.ts` | `ACTIVE_STATUSES`, `CLOSED_STATUSES`, `EXCLUDED_STATUSES`, `ALL_TERMINAL_STATUSES`, `EQUITY_MODES`, `OPTIONS_MODES` |
+| `date-helpers.ts` | `getETNow`, `getETDateString`, `formatDateToEtIso`, `toEtIsoDate`, `isMarketOpen` |
+| `format.ts` | `fmtUsd`, `fmtUsdCompact` |
+| `index.ts` | Barrel re-export |
+
+### How imports work per runtime
+
+- **Auto-trader (NodeNext)**: `tsconfig.json` sets `rootDir: ".."` and includes `../shared/**/*`. Import with `.js` extension: `import { X } from '../../../shared/module.js'`
+- **Frontend (Vite)**: `tsconfig.app.json` includes `../shared`. Import with `.ts` extension: `import { X } from '../../../shared/module.ts'`
+- **Edge functions (Deno)**: Direct `.ts` imports: `import { X } from '../../../shared/module.ts'`
+- **`shared/package.json`** contains `{ "type": "module" }` so tsc emits ESM for the auto-trader build.
+
+### Build output change
+
+The auto-trader's `rootDir: ".."` change means compiled output goes to `dist/auto-trader/src/` instead of `dist/`. The `npm start` script was updated to `node dist/auto-trader/src/index.js`.
+
+## Key decisions
+
+- **Backend is source of truth** — shared defaults match `auto-trader/src/lib/supabase.ts` values.
+- **Superset interface** — `PaperTrade` in shared includes all fields from both frontend and backend. Optional fields (`price_peak`, `ib_tp_order_id`, etc.) are nullable.
+- **Consumer extensions** — Frontend extends `AutoTraderConfig` with `suggestedFindPositionSize` (frontend-only field).
+- **`[...ARRAY]` for Supabase** — Supabase `.in()` requires mutable arrays, so shared readonly arrays are spread.
+- **Local functions can wrap shared ones** — e.g., scheduler keeps `isMarketHoursET()` with extended hours while importing shared `isMarketOpen()` for standard RTH.
+
+## Dynamic bucket rebalancing
+
+Also added: when `suggestedFindsEnabled=false`, the long-term bucket allocation (`longTermBucketPct`) is effectively 0, redirecting all capital to day/swing. Existing long-term positions are still managed (profit-taking, loss-cutting) regardless.
+
+## Adding a new config field
+
+1. Add the field to `shared/config-defaults.ts` (interface + default value)
+2. Add the snake_case DB column mapping in `auto-trader/src/lib/supabase.ts` `loadConfig()`
+3. Add the same mapping in `app/src/lib/autoTrader.ts` `loadAutoTraderConfig()`
+4. If auto-tune should adjust it, add bounds in `supabase/functions/auto-tune-strategy-config/index.ts`
+
+## Adding a new trade status
+
+1. Add it to `TradeStatus` in `shared/trade-types.ts`
+2. Add it to the appropriate set in `shared/trade-status-sets.ts`
+3. Add styling in `app/src/components/PaperTrading/shared/StatusBadge.tsx`

--- a/shared/auto-trade-events.ts
+++ b/shared/auto-trade-events.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared auto-trade event types — Single Source of Truth
+ *
+ * String-literal unions and interfaces for auto_trade_events table.
+ * Imported by: auto-trader, frontend app.
+ * DO NOT duplicate these types elsewhere.
+ */
+
+import type { TradeMode } from './trade-types.js';
+
+export type AutoTradeAction =
+  | 'executed'
+  | 'closed'
+  | 'skipped'
+  | 'failed'
+  | 'proceeding'
+  | 'health_check'
+  | 'RECONCILIATION'
+  | 'scan_complete';
+
+export type AutoTradeSource =
+  | 'scanner'
+  | 'suggested_finds'
+  | 'manual'
+  | 'system'
+  | 'dip_buy'
+  | 'profit_take'
+  | 'loss_cut'
+  | 'lt_auto_sell'
+  | 'swing_expiry'
+  | 'capital_pressure'
+  | 'external_signal'
+  | 'spx_level_scanner'
+  | 'earnings_scanner'
+  | 'watchlist_screener'
+  | 'compounder_health';
+
+export type AutoTradeEventType = 'info' | 'success' | 'warning' | 'error';
+
+/** Shape for inserting into auto_trade_events (auto-trader side) */
+export interface AutoTradeEventInput {
+  ticker: string;
+  event_type?: AutoTradeEventType;
+  message: string;
+  action?: AutoTradeAction;
+  source?: AutoTradeSource;
+  mode?: TradeMode;
+  scanner_signal?: string | null;
+  scanner_confidence?: number | null;
+  fa_recommendation?: string | null;
+  fa_confidence?: number | null;
+  skip_reason?: string | null;
+  strategy_source?: string | null;
+  strategy_source_url?: string | null;
+  strategy_video_id?: string | null;
+  strategy_video_heading?: string | null;
+  metadata?: Record<string, unknown>;
+  candle_patterns?: string[];
+  [key: string]: unknown;
+}
+
+/** Shape for reading from auto_trade_events (frontend/consumer side) */
+export interface AutoTradeEventRecord {
+  id: string;
+  ticker: string;
+  event_type: AutoTradeEventType;
+  action: AutoTradeAction | null;
+  source: AutoTradeSource | null;
+  mode: TradeMode | null;
+  message: string;
+  strategy_source: string | null;
+  strategy_source_url: string | null;
+  strategy_video_id: string | null;
+  strategy_video_heading: string | null;
+  scanner_signal: string | null;
+  scanner_confidence: number | null;
+  fa_recommendation: string | null;
+  fa_confidence: number | null;
+  skip_reason: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}

--- a/shared/config-defaults.ts
+++ b/shared/config-defaults.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared Auto-Trader Config — Single Source of Truth
+ *
+ * This file defines the AutoTraderConfig interface and DEFAULT values.
+ * Imported by: auto-trader, frontend app, auto-tune edge function.
+ * DO NOT duplicate these defaults elsewhere.
+ */
+
+export interface AutoTraderConfig {
+  enabled: boolean;
+  maxPositions: number;
+  positionSize: number;
+  minScannerConfidence: number;
+  minFAConfidence: number;
+  minSuggestedFindsConviction: number;
+  accountId: string | null;
+  dayTradeAutoClose: boolean;
+  maxTotalAllocation: number;
+  maxDailyDeployment: number;
+  useDynamicSizing: boolean;
+  portfolioValue: number;
+  baseAllocationPct: number;
+  maxPositionPct: number;
+  riskPerTradePct: number;
+  dipBuyEnabled: boolean;
+  dipBuyTier1Pct: number; dipBuyTier1SizePct: number;
+  dipBuyTier2Pct: number; dipBuyTier2SizePct: number;
+  dipBuyTier3Pct: number; dipBuyTier3SizePct: number;
+  dipBuyCooldownHours: number;
+  profitTakeEnabled: boolean;
+  profitTakeTier1Pct: number; profitTakeTier1TrimPct: number;
+  profitTakeTier2Pct: number; profitTakeTier2TrimPct: number;
+  profitTakeTier3Pct: number; profitTakeTier3TrimPct: number;
+  minHoldPct: number;
+  lossCutEnabled: boolean;
+  lossCutTier1Pct: number; lossCutTier1SellPct: number;
+  lossCutTier2Pct: number; lossCutTier2SellPct: number;
+  lossCutTier3Pct: number; lossCutTier3SellPct: number;
+  lossCutMinHoldDays: number;
+  marketRegimeEnabled: boolean;
+  maxSectorPct: number;
+  earningsAvoidEnabled: boolean;
+  earningsBlackoutDays: number;
+  kellyAdaptiveEnabled: boolean;
+  longTermBucketPct: number;
+  /** Flat dollar size for influencer daily signal trades. 0 = use dynamic sizing. */
+  externalSignalPositionSize: number;
+  swingMaxHoldDays: number;
+  capitalPressureEnabled: boolean;
+  ltStopLossPct: number;
+  ltProfitTakePct: number;
+  ltMaxHoldDays: number;
+  ltTrailingStopPct: number;
+  dayTradeMaxDailyLoss: number;
+  tradeSignalsEnabled: boolean;
+  suggestedFindsEnabled: boolean;
+  optionsWheelEnabled: boolean;
+}
+
+export const DEFAULT_CONFIG: AutoTraderConfig = {
+  enabled: false,
+  maxPositions: 3,
+  positionSize: 1000,
+  minScannerConfidence: 7,
+  minFAConfidence: 7,
+  minSuggestedFindsConviction: 8,
+  accountId: null,
+  dayTradeAutoClose: true,
+  maxTotalAllocation: 500_000,
+  maxDailyDeployment: 50_000,
+  useDynamicSizing: true,
+  portfolioValue: 1_000_000,
+  baseAllocationPct: 2.0,
+  maxPositionPct: 5.0,
+  riskPerTradePct: 1.0,
+  dipBuyEnabled: true,
+  dipBuyTier1Pct: 10, dipBuyTier1SizePct: 25,
+  dipBuyTier2Pct: 20, dipBuyTier2SizePct: 50,
+  dipBuyTier3Pct: 30, dipBuyTier3SizePct: 75,
+  dipBuyCooldownHours: 72,
+  profitTakeEnabled: true,
+  profitTakeTier1Pct: 8, profitTakeTier1TrimPct: 25,
+  profitTakeTier2Pct: 15, profitTakeTier2TrimPct: 30,
+  profitTakeTier3Pct: 25, profitTakeTier3TrimPct: 30,
+  minHoldPct: 15,
+  lossCutEnabled: true,
+  lossCutTier1Pct: 6, lossCutTier1SellPct: 30,
+  lossCutTier2Pct: 12, lossCutTier2SellPct: 50,
+  lossCutTier3Pct: 20, lossCutTier3SellPct: 100,
+  lossCutMinHoldDays: 1,
+  marketRegimeEnabled: true,
+  maxSectorPct: 30,
+  earningsAvoidEnabled: true,
+  earningsBlackoutDays: 3,
+  kellyAdaptiveEnabled: false,
+  longTermBucketPct: 50,
+  externalSignalPositionSize: 5000,
+  swingMaxHoldDays: 5,
+  capitalPressureEnabled: true,
+  ltStopLossPct: -12,
+  ltProfitTakePct: 15,
+  ltMaxHoldDays: 0,
+  ltTrailingStopPct: 10,
+  dayTradeMaxDailyLoss: 500,
+  tradeSignalsEnabled: true,
+  suggestedFindsEnabled: true,
+  optionsWheelEnabled: true,
+};

--- a/shared/date-helpers.ts
+++ b/shared/date-helpers.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared ET (Eastern Time) date/time helpers — Single Source of Truth
+ *
+ * Pure functions for US market time operations.
+ * No runtime dependencies — works in Node, browser, and Deno.
+ */
+
+export interface ETTime {
+  hour: number;
+  minute: number;
+  dayOfWeek: number; // 0=Sun, 6=Sat
+}
+
+/** Get current time in US Eastern (handles DST automatically). */
+export function getETNow(now?: Date): ETTime {
+  const d = now ?? new Date();
+  const et = new Date(d.toLocaleString('en-US', { timeZone: 'America/New_York' }));
+  return { hour: et.getHours(), minute: et.getMinutes(), dayOfWeek: et.getDay() };
+}
+
+/** Get today's date as YYYY-MM-DD in US Eastern. */
+export function getETDateString(now?: Date): string {
+  return formatDateToEtIso(now ?? new Date());
+}
+
+/** Format any Date to YYYY-MM-DD in US Eastern. */
+export function formatDateToEtIso(d: Date): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(d);
+  const year = parts.find(p => p.type === 'year')?.value ?? '0000';
+  const month = parts.find(p => p.type === 'month')?.value ?? '00';
+  const day = parts.find(p => p.type === 'day')?.value ?? '00';
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Parse a timestamp string to ET ISO date (YYYY-MM-DD).
+ * Returns null for empty/invalid input. Passes through if already YYYY-MM-DD.
+ */
+export function toEtIsoDate(value: string | null | undefined): string | null {
+  const raw = (value ?? '').trim();
+  if (!raw) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return formatDateToEtIso(parsed);
+}
+
+/**
+ * True during US regular trading hours: 9:30 AM – 4:00 PM ET, Mon–Fri.
+ * Does NOT account for market holidays.
+ */
+export function isMarketOpen(now?: Date): boolean {
+  const { hour, minute, dayOfWeek } = getETNow(now);
+  if (dayOfWeek === 0 || dayOfWeek === 6) return false;
+  const mins = hour * 60 + minute;
+  return mins >= 570 && mins < 960; // 9:30=570, 16:00=960
+}

--- a/shared/format.ts
+++ b/shared/format.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared formatting helpers — Single Source of Truth
+ *
+ * Currency and number formatting. Pure functions, no runtime deps.
+ */
+
+/**
+ * Format a dollar amount with sign before $: +$500, -$718, $0.
+ * Handles negative values correctly (never produces "$-718").
+ */
+export function fmtUsd(value: number, decimals = 2, showPlus = false): string {
+  const sign = value > 0 && showPlus ? '+' : value < 0 ? '-' : '';
+  return `${sign}$${Math.abs(value).toFixed(decimals)}`;
+}
+
+/** Compact USD format for log messages: +$500, -$718 (always shows sign, 0 decimals) */
+export function fmtUsdCompact(value: number): string {
+  const sign = value >= 0 ? '+' : '-';
+  return `${sign}$${Math.abs(value).toFixed(0)}`;
+}

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,0 +1,6 @@
+export * from './config-defaults.js';
+export * from './trade-types.js';
+export * from './auto-trade-events.js';
+export * from './trade-status-sets.js';
+export * from './date-helpers.js';
+export * from './format.js';

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/shared/trade-status-sets.ts
+++ b/shared/trade-status-sets.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared trade status sets — Single Source of Truth
+ *
+ * Canonical arrays for filtering paper_trades by lifecycle stage.
+ * Use these instead of inline ['PENDING', 'SUBMITTED', ...] arrays.
+ * Imported by: auto-trader, frontend app, edge functions.
+ */
+
+import type { TradeStatus, TradeMode } from './trade-types.js';
+
+/** Trades that are open / in-flight (not yet resolved) */
+export const ACTIVE_STATUSES: readonly TradeStatus[] = [
+  'PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL',
+] as const;
+
+/** Trades that reached a terminal state with a fill (for P&L calculation) */
+export const CLOSED_STATUSES: readonly TradeStatus[] = [
+  'STOPPED', 'TARGET_HIT', 'CLOSED',
+] as const;
+
+/** Trades that never executed — exclude from performance metrics */
+export const EXCLUDED_STATUSES: readonly TradeStatus[] = [
+  'CANCELLED', 'REJECTED',
+] as const;
+
+/**
+ * All terminal statuses (closed + excluded) — useful for "is this trade done?"
+ * Includes CANCELLED/REJECTED so UI can show them as resolved.
+ */
+export const ALL_TERMINAL_STATUSES: readonly TradeStatus[] = [
+  ...CLOSED_STATUSES, ...EXCLUDED_STATUSES,
+] as const;
+
+/** Equity trade modes (excludes options and earnings) */
+export const EQUITY_MODES: readonly TradeMode[] = [
+  'DAY_TRADE', 'SWING_TRADE', 'LONG_TERM',
+] as const;
+
+/** Options trade modes */
+export const OPTIONS_MODES: readonly TradeMode[] = [
+  'OPTIONS_PUT', 'OPTIONS_CALL',
+] as const;

--- a/shared/trade-types.ts
+++ b/shared/trade-types.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared trade types — Single Source of Truth
+ *
+ * Canonical types for paper_trades, trade modes, statuses, and signals.
+ * Imported by: auto-trader, frontend app, edge functions.
+ * DO NOT duplicate these types elsewhere.
+ */
+
+export type TradeMode =
+  | 'DAY_TRADE'
+  | 'SWING_TRADE'
+  | 'LONG_TERM'
+  | 'OPTIONS_PUT'
+  | 'OPTIONS_CALL'
+  | 'EARNINGS_CALENDAR';
+
+export type TradeSignal = 'BUY' | 'SELL';
+
+export type TradeStatus =
+  | 'PENDING'
+  | 'SUBMITTED'
+  | 'FILLED'
+  | 'PARTIAL'
+  | 'STOPPED'
+  | 'TARGET_HIT'
+  | 'CLOSED'
+  | 'CANCELLED'
+  | 'REJECTED';
+
+export type CloseReason =
+  | 'stop_loss'
+  | 'target_hit'
+  | 'eod_close'
+  | 'manual'
+  | 'cancelled';
+
+/**
+ * Full paper_trades row — superset of all columns used by any consumer.
+ * Individual consumers may treat unused fields as optional/null.
+ */
+export interface PaperTrade {
+  id: string;
+  ticker: string;
+  mode: TradeMode;
+  signal: TradeSignal;
+  strategy_source: string | null;
+  strategy_source_url: string | null;
+  strategy_video_id: string | null;
+  strategy_video_heading: string | null;
+  scanner_confidence: number | null;
+  fa_confidence: number | null;
+  fa_recommendation: string | null;
+  entry_price: number | null;
+  stop_loss: number | null;
+  target_price: number | null;
+  target_price2: number | null;
+  risk_reward: string | null;
+  quantity: number | null;
+  position_size: number | null;
+  ib_order_id: string | null;
+  ib_parent_order_id: string | null;
+  ib_tp_order_id: string | null;
+  ib_sl_order_id: string | null;
+  status: TradeStatus;
+  fill_price: number | null;
+  close_price: number | null;
+  pnl: number | null;
+  pnl_percent: number | null;
+  opened_at: string;
+  filled_at: string | null;
+  closed_at: string | null;
+  close_reason: CloseReason | null;
+  scanner_reason: string | null;
+  fa_rationale: Record<string, string> | null;
+  notes: string | null;
+  created_at: string;
+  in_play_score?: number | null;
+  pass1_confidence?: number | null;
+  entry_trigger_type?: string | null;
+  r_multiple?: number | null;
+  market_condition?: string | null;
+  pct_distance_sma20_at_entry?: number | null;
+  macd_histogram_slope_at_entry?: string | null;
+  volume_vs_10d_avg_at_entry?: number | null;
+  regime_alignment_at_entry?: string | null;
+  price_peak?: number | null;
+  price_peak_date?: string | null;
+  missing_since?: string | null;
+}

--- a/supabase/functions/auto-tune-strategy-config/index.ts
+++ b/supabase/functions/auto-tune-strategy-config/index.ts
@@ -63,15 +63,17 @@ interface ConfigRow {
   options_max_contracts_per_scan: number | null;
 }
 
-// ── Defaults (must match auto-trader DEFAULT_CONFIG) ──────
+// ── Defaults (derived from shared single source of truth) ──────
+import { DEFAULT_CONFIG } from '../../../shared/config-defaults.ts';
+import { CLOSED_STATUSES } from '../../../shared/trade-status-sets.ts';
 
 const DEFAULTS = {
-  external_signal_position_size: 5000,
-  min_scanner_confidence: 7,
-  base_allocation_pct: 2.0,
-  long_term_bucket_pct: 40,
-  kelly_adaptive_enabled: false,
-  max_positions: 3,
+  external_signal_position_size: DEFAULT_CONFIG.externalSignalPositionSize,
+  min_scanner_confidence: DEFAULT_CONFIG.minScannerConfidence,
+  base_allocation_pct: DEFAULT_CONFIG.baseAllocationPct,
+  long_term_bucket_pct: DEFAULT_CONFIG.longTermBucketPct,
+  kelly_adaptive_enabled: DEFAULT_CONFIG.kellyAdaptiveEnabled,
+  max_positions: DEFAULT_CONFIG.maxPositions,
 };
 
 // ── Bounds (hard limits on what auto-tune can change) ─────
@@ -146,7 +148,7 @@ Deno.serve(async (req) => {
     const { data: tradesData, error: tradesError } = await supabase
       .from('paper_trades')
       .select('id, mode, pnl, pnl_percent, fill_price, strategy_video_id, notes, status, closed_at')
-      .in('status', ['STOPPED', 'TARGET_HIT', 'CLOSED'])
+      .in('status', [...CLOSED_STATUSES])
       .not('fill_price', 'is', null)
       .not('closed_at', 'is', null)
       .gte('closed_at', since.toISOString())

--- a/supabase/functions/paper-trading-performance/index.ts
+++ b/supabase/functions/paper-trading-performance/index.ts
@@ -3,6 +3,7 @@
 // GET ?window=7d|30d|90d — returns aggregated metrics for deployed website (no localhost).
 
 import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { EQUITY_MODES } from '../../../shared/trade-status-sets.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -194,9 +195,8 @@ Deno.serve(async (req) => {
     // Exclude dip-buy add-ons (same as trade_performance_log)
     const filteredTrades = trades.filter(t => !(t.notes ?? '').startsWith('Dip buy'));
 
-    // Only include DAY_TRADE, SWING_TRADE, LONG_TERM (same as log)
     const validTrades = filteredTrades.filter(t =>
-      ['DAY_TRADE', 'SWING_TRADE', 'LONG_TERM'].includes(t.mode)
+      (EQUITY_MODES as readonly string[]).includes(t.mode)
     );
 
     if (validTrades.length === 0) {

--- a/supabase/functions/trade-performance-log-close/index.ts
+++ b/supabase/functions/trade-performance-log-close/index.ts
@@ -1,6 +1,7 @@
 // POST — log closed trade to trade_performance_log. Replaces localhost:3001/api/trade-performance-log/close.
 
 import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { EQUITY_MODES } from '../../../shared/trade-status-sets.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -67,7 +68,7 @@ Deno.serve(async (req) => {
     }
 
     const strategy = trade.mode as string;
-    if (!['DAY_TRADE', 'SWING_TRADE', 'LONG_TERM'].includes(strategy)) {
+    if (!(EQUITY_MODES as readonly string[]).includes(strategy)) {
       return new Response(JSON.stringify({ ok: true }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 

--- a/supabase/functions/trade-scanner/index.ts
+++ b/supabase/functions/trade-scanner/index.ts
@@ -38,6 +38,7 @@ import {
   formatIndicatorsForPrompt,
 } from '../_shared/indicators.ts';
 import { buildFeedbackContext } from '../_shared/feedback.ts';
+import { getETNow as sharedGetETNow, formatDateToEtIso as sharedFormatDateToEtIso, isMarketOpen as sharedIsMarketOpen } from '../../../shared/date-helpers.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -413,31 +414,9 @@ const YAHOO_HEADERS = {
 
 // ── Market hours check (ET) ─────────────────────────────
 
-function getETNow(): { hour: number; minute: number; dayOfWeek: number } {
-  const now = new Date();
-  const et = new Date(now.toLocaleString('en-US', { timeZone: 'America/New_York' }));
-  return { hour: et.getHours(), minute: et.getMinutes(), dayOfWeek: et.getDay() };
-}
-
-function formatDateToEtIso(date: Date): string {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/New_York',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(date);
-  const year = parts.find(p => p.type === 'year')?.value ?? '0000';
-  const month = parts.find(p => p.type === 'month')?.value ?? '00';
-  const day = parts.find(p => p.type === 'day')?.value ?? '00';
-  return `${year}-${month}-${day}`;
-}
-
-function isMarketOpen(): boolean {
-  const { hour, minute, dayOfWeek } = getETNow();
-  if (dayOfWeek === 0 || dayOfWeek === 6) return false;
-  const mins = hour * 60 + minute;
-  return mins >= 9 * 60 + 30 && mins <= 16 * 60;
-}
+const getETNow = sharedGetETNow;
+const formatDateToEtIso = sharedFormatDateToEtIso;
+const isMarketOpen = sharedIsMarketOpen;
 
 function isSwingRefreshWindow(): boolean {
   const { hour, minute, dayOfWeek } = getETNow();


### PR DESCRIPTION
## Summary

- **Creates `shared/` directory** at repo root with 7 pure TypeScript modules that centralize types, config defaults, trade status sets, date helpers, and currency formatters that were previously duplicated across auto-trader, frontend, and edge functions
- **Eliminates config drift** — `AutoTraderConfig` interface + `DEFAULT_CONFIG` now defined once and imported by all three runtimes (previously had divergent defaults like `minScannerConfidence: 6` vs `7`)
- **Adds dynamic bucket rebalancing** — when Suggested Finds is disabled, LT bucket allocation automatically redirects to day/swing trades

### Shared modules created
| File | Contents |
|------|----------|
| `config-defaults.ts` | `AutoTraderConfig` + `DEFAULT_CONFIG` |
| `trade-types.ts` | `PaperTrade`, `TradeStatus`, `TradeMode`, `CloseReason`, `TradeSignal` |
| `auto-trade-events.ts` | `AutoTradeAction`, `AutoTradeSource`, `AutoTradeEventType`, event interfaces |
| `trade-status-sets.ts` | `ACTIVE_STATUSES`, `CLOSED_STATUSES`, `EXCLUDED_STATUSES`, `EQUITY_MODES`, etc. |
| `date-helpers.ts` | `getETNow`, `getETDateString`, `isMarketOpen`, `toEtIsoDate` |
| `format.ts` | `fmtUsd`, `fmtUsdCompact` |

### Files updated (20 consumer files)
- **Auto-trader**: `supabase.ts`, `scheduler.ts`, `feedback.ts`, `options-manager.ts`, `options-scanner.ts`, `tsconfig.json`, `package.json`, `start.sh`
- **Frontend**: `paperTradesApi.ts`, `autoTrader.ts`, `optionsApi.ts`, `aiFeedback.ts`, `useAutoTradeScheduler.ts`, `PaperTrading/utils.ts`, `TodayActivityTab.tsx`, `tsconfig.app.json`
- **Edge functions**: `auto-tune-strategy-config`, `paper-trading-performance`, `trade-performance-log-close`, `trade-scanner`

## Test plan
- [x] `npx tsc --noEmit` passes for auto-trader
- [x] `npx tsc -b --noEmit` passes for frontend
- [x] `npm run build` succeeds for both auto-trader and frontend
- [x] Auto-trader LaunchAgent restarted and confirmed running with IB connected
- [x] No import errors in stderr log


Made with [Cursor](https://cursor.com)