### PR TITLE
fix: stop P&L discrepancies and add activity filtering/sorting

### DIFF
--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { Zap, Play, Clock, PlayCircle, AlertCircle } from 'lucide-react';
+import { useState, useEffect, useMemo } from 'react';
+import { Zap, Play, Clock, PlayCircle, AlertCircle, ChevronUp, ChevronDown, ChevronsUpDown } from 'lucide-react';
 import { cn } from '../../../lib/utils';
 import type { AutoTradeEventRecord, PaperTrade, PendingStrategySignal } from '../../../lib/paperTradesApi';
 import { executeSignal } from '../../../lib/paperTradesApi';
@@ -204,9 +204,16 @@ export interface TodayActivityTabProps {
   ibRealizedPnl?: number | null;
 }
 
+type FilterMode = 'all' | 'day' | 'long_term';
+type SortKey = 'ticker' | 'pnl' | 'time' | null;
+type SortDir = 'asc' | 'desc';
+
 export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], onExecuteSignal, ibRealizedPnl }: TodayActivityTabProps) {
   const [executingId, setExecutingId] = useState<string | null>(null);
   const [executingAll, setExecutingAll] = useState(false);
+  const [filterMode, setFilterMode] = useState<FilterMode>('all');
+  const [sortKey, setSortKey] = useState<SortKey>(null);
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
   const todayStart = (() => {
     const d = new Date();
     d.setHours(0, 0, 0, 0);
@@ -406,6 +413,62 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
   const todayPnl = ibRealizedPnl ?? eventBasedPnl;
   const pnlSource = ibRealizedPnl != null ? 'ib' : 'events';
 
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'pnl' ? 'desc' : 'asc');
+    }
+  }
+
+  function SortIcon({ col }: { col: SortKey }) {
+    if (sortKey !== col) return <ChevronsUpDown className="inline w-3 h-3 ml-0.5 opacity-40" />;
+    return sortDir === 'asc'
+      ? <ChevronUp className="inline w-3 h-3 ml-0.5 opacity-80" />
+      : <ChevronDown className="inline w-3 h-3 ml-0.5 opacity-80" />;
+  }
+
+  const filteredSortedEvents = useMemo(() => {
+    let filtered = events;
+
+    if (filterMode !== 'all') {
+      filtered = events.filter(ev => {
+        const mode = ev.mode;
+        if (filterMode === 'day') return mode === 'DAY_TRADE';
+        if (filterMode === 'long_term') return mode === 'LONG_TERM' || mode === 'SWING_TRADE';
+        return true;
+      });
+    }
+
+    if (!sortKey) return filtered;
+
+    return [...filtered].sort((a, b) => {
+      let aVal: string | number | null = null;
+      let bVal: string | number | null = null;
+
+      if (sortKey === 'ticker') {
+        aVal = a.ticker;
+        bVal = b.ticker;
+      } else if (sortKey === 'time') {
+        aVal = a.created_at;
+        bVal = b.created_at;
+      } else if (sortKey === 'pnl') {
+        const matchA = tradesByTicker.get(a.ticker)?.find(t => t.pnl != null);
+        const matchB = tradesByTicker.get(b.ticker)?.find(t => t.pnl != null);
+        aVal = matchA?.pnl ?? null;
+        bVal = matchB?.pnl ?? null;
+      }
+
+      if (aVal === null && bVal === null) return 0;
+      if (aVal === null) return 1;
+      if (bVal === null) return -1;
+
+      const cmp = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [events, filterMode, sortKey, sortDir, tradesByTicker]);
+
   return (
     <div className="space-y-3">
       {todayPnl !== 0 && (
@@ -422,21 +485,59 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
         </div>
       )}
 
+      {/* Filter + count bar */}
+      <div className="flex items-center gap-1.5">
+        {(['all', 'day', 'long_term'] as FilterMode[]).map(f => (
+          <button
+            key={f}
+            onClick={() => setFilterMode(f)}
+            className={cn(
+              'px-2.5 py-1 text-[11px] font-medium rounded-md border transition-colors',
+              filterMode === f
+                ? 'bg-[hsl(var(--foreground))] text-[hsl(var(--background))] border-[hsl(var(--foreground))]'
+                : 'bg-white text-[hsl(var(--muted-foreground))] border-[hsl(var(--border))] hover:border-[hsl(var(--foreground))]/40'
+            )}
+          >
+            {f === 'all' ? 'All' : f === 'day' ? 'Day Trades' : 'LT / Swing'}
+          </button>
+        ))}
+        {filterMode !== 'all' && (
+          <span className="text-[10px] text-[hsl(var(--muted-foreground))] ml-1">
+            {filteredSortedEvents.length} of {events.length}
+          </span>
+        )}
+      </div>
+
       <div className="rounded-xl border border-[hsl(var(--border))] bg-white overflow-hidden">
         <table className="w-full text-sm">
           <thead>
             <tr className="bg-[hsl(var(--secondary))] text-[hsl(var(--muted-foreground))] text-xs">
-              <th className="text-left px-4 py-2.5 font-medium">Ticker</th>
+              <th
+                className="text-left px-4 py-2.5 font-medium cursor-pointer select-none hover:text-[hsl(var(--foreground))]"
+                onClick={() => handleSort('ticker')}
+              >
+                Ticker <SortIcon col="ticker" />
+              </th>
               <th className="text-left px-4 py-2.5 font-medium">Signal</th>
               <th className="text-left px-4 py-2.5 font-medium">Type</th>
               <th className="text-left px-4 py-2.5 font-medium">Details</th>
-              <th className="text-right px-4 py-2.5 font-medium">P&L</th>
+              <th
+                className="text-right px-4 py-2.5 font-medium cursor-pointer select-none hover:text-[hsl(var(--foreground))]"
+                onClick={() => handleSort('pnl')}
+              >
+                P&L <SortIcon col="pnl" />
+              </th>
               <th className="text-left px-4 py-2.5 font-medium">Status</th>
-              <th className="text-right px-4 py-2.5 font-medium">Time</th>
+              <th
+                className="text-right px-4 py-2.5 font-medium cursor-pointer select-none hover:text-[hsl(var(--foreground))]"
+                onClick={() => handleSort('time')}
+              >
+                Time <SortIcon col="time" />
+              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-[hsl(var(--border))]">
-            {events.map((event) => {
+            {filteredSortedEvents.map((event) => {
               const matched = tradesByTicker.get(event.ticker)?.find(t =>
                 t.pnl != null || t.status === 'FILLED' || t.status === 'TARGET_HIT' || t.status === 'STOPPED' || t.status === 'CLOSED'
               );

--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -2321,23 +2321,24 @@ export async function syncPositions(accountId: string): Promise<void> {
 
       } else if (trade.status === 'FILLED') {
         // ── Position was open but now gone — closed (stop/target/manual) ──
-        // Fetch current price to approximate close price
+        // Fetch current price to approximate close price.
+        // IMPORTANT: Only close if we have a real price. If getQuotePrice returns null,
+        // skip — the server-side scheduler handles this more reliably (checks ib_fills
+        // for actual bracket fill prices, has a 30-min guard). Using fillPrice as a
+        // fallback produces pnl=0 which corrupts the P&L record permanently.
         const closePrice = await getQuotePrice(trade.ticker);
+        if (!closePrice || closePrice <= 0) {
+          // No price available — defer to scheduler's position sync which has IB fill lookup
+          logEvent(trade.ticker, 'info', 'Position gone but no quote available — deferring to server sync');
+          continue;
+        }
+
         const fillPrice = trade.fill_price ?? trade.entry_price ?? 0;
         const qty = trade.quantity ?? 1;
         const isLong = trade.signal === 'BUY';
+        const actualClosePrice = closePrice;
 
-        let pnl: number;
-        let actualClosePrice: number;
-
-        if (closePrice) {
-          actualClosePrice = closePrice;
-        } else {
-          // Fallback: use target or stop based on position direction
-          actualClosePrice = fillPrice; // worst case: breakeven
-        }
-
-        pnl = isLong
+        const pnl = isLong
           ? (actualClosePrice - fillPrice) * qty
           : (fillPrice - actualClosePrice) * qty;
 

--- a/auto-trader/src/lib/reconcile-executions.ts
+++ b/auto-trader/src/lib/reconcile-executions.ts
@@ -108,6 +108,39 @@ export async function runEndOfDayReconciliation(): Promise<void> {
     }
 
     if (!trade) {
+      // Before giving up, check if this is a cover buy for a reconcile_cover short.
+      // reconcileIBShorts stores the cover orderId in ib_order_id so we can match here.
+      const isCoverBuy = exec.side === 'BOT' || exec.side === 'BUY';
+      if (isCoverBuy) {
+        const { data: coverTrade } = await sb
+          .from('paper_trades')
+          .select('*')
+          .eq('ticker', exec.ticker)
+          .eq('close_reason', 'reconcile_cover')
+          .or('close_price.is.null,close_price.eq.0')
+          .order('opened_at', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+
+        if (coverTrade) {
+          const ct = coverTrade as PaperTrade;
+          const fillPrice = ct.fill_price ?? ct.entry_price ?? 0;
+          const qty = ct.quantity ?? 1;
+          // For a covered short: entry was SELL (fill_price is the short entry), cover is BUY (exec.price)
+          const pnl = (fillPrice - exec.price) * qty;
+          await sb.from('paper_trades').update({
+            close_price: exec.price,
+            pnl: parseFloat(pnl.toFixed(2)),
+            pnl_percent: fillPrice > 0 ? parseFloat(((pnl / (fillPrice * qty)) * 100).toFixed(2)) : null,
+          }).eq('id', ct.id);
+          corrected++;
+          correctionDetails.push(`${exec.ticker}: reconcile_cover close_price → ${exec.price.toFixed(2)} (pnl $${pnl.toFixed(2)})`);
+          log(`Reconciled cover for ${exec.ticker}: close_price=$${exec.price.toFixed(2)}, pnl=$${pnl.toFixed(2)}`);
+          matched++;
+          continue;
+        }
+      }
+
       orphaned++;
       log(`Orphaned execution: order ${exec.orderId} ${exec.side} ${exec.shares}x ${exec.ticker} @ $${exec.price.toFixed(2)}`);
       continue;
@@ -139,9 +172,17 @@ export async function runEndOfDayReconciliation(): Promise<void> {
         log(`Corrected ${trade.ticker} fill_price: $${currentFill.toFixed(2)} → $${exec.price.toFixed(2)}`);
       }
     } else {
-      // TP or SL fill — check close price
-      if (['STOPPED', 'TARGET_HIT', 'CLOSED'].includes(trade.status) && trade.close_price != null) {
-        if (Math.abs(trade.close_price - exec.price) > 0.005) {
+      // TP, SL, or trailing-stop fill — correct close price.
+      // Also handles cases where close_price was null (e.g. trailing stop wrote CLOSED
+      // without close_price) or was set to fill_price with pnl=0 (browser sync fallback).
+      if (['STOPPED', 'TARGET_HIT', 'CLOSED'].includes(trade.status)) {
+        const currentClose = trade.close_price ?? 0;
+        const needsCorrection = currentClose === null
+          || currentClose === 0
+          || (trade.fill_price != null && Math.abs(currentClose - (trade.fill_price as number)) < 0.005 && (trade.pnl ?? 0) === 0)
+          || Math.abs(currentClose - exec.price) > 0.005;
+
+        if (needsCorrection) {
           const fillPrice = trade.fill_price ?? trade.entry_price ?? 0;
           const qty = trade.quantity ?? 1;
           const isLong = trade.signal === 'BUY';
@@ -155,8 +196,9 @@ export async function runEndOfDayReconciliation(): Promise<void> {
             pnl_percent: fillPrice > 0 ? parseFloat(((pnl / (fillPrice * qty)) * 100).toFixed(2)) : null,
           }).eq('id', trade.id);
           corrected++;
-          correctionDetails.push(`${trade.ticker}: close_price ${trade.close_price.toFixed(2)} → ${exec.price.toFixed(2)}`);
-          log(`Corrected ${trade.ticker} close_price: $${trade.close_price.toFixed(2)} → $${exec.price.toFixed(2)}`);
+          const prevStr = currentClose != null ? currentClose.toFixed(2) : 'null';
+          correctionDetails.push(`${trade.ticker}: close_price ${prevStr} → ${exec.price.toFixed(2)} (pnl $${pnl.toFixed(2)})`);
+          log(`Corrected ${trade.ticker} close_price: $${prevStr} → $${exec.price.toFixed(2)}, pnl: $${pnl.toFixed(2)}`);
         }
       }
     }

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -853,20 +853,50 @@ export async function reconcileIBShorts(): Promise<{ closed: string[]; errors: s
   const closed: string[] = [];
   const errors: string[] = [];
 
+  const sb = getSupabase();
   for (const pos of shorts) {
     const qty = Math.abs(pos.position);
     log(`[IBReconcile] Covering short: ${pos.symbol} × ${qty} @ avg ${pos.avgCost}`);
     try {
-      await placeMarketOrder({ symbol: pos.symbol, side: 'BUY', quantity: qty });
-      log(`[IBReconcile] ✓ ${pos.symbol}: BUY ${qty} order placed`);
+      const { orderId: coverOrderId } = await placeMarketOrder({ symbol: pos.symbol, side: 'BUY', quantity: qty });
+      log(`[IBReconcile] ✓ ${pos.symbol}: BUY ${qty} order placed (orderId=${coverOrderId})`);
       closed.push(pos.symbol);
+
+      // Find the orphaned SELL paper_trade for this ticker and mark it for EOD reconciliation.
+      // The actual cover fill price will be written by runEndOfDayReconciliation (4:15 PM)
+      // once the IB execution is available. We store the cover orderId so the reconciler
+      // can match the fill by orderId in ib_fills.
+      const since = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+      const { data: orphanTrades } = await sb
+        .from('paper_trades')
+        .select('id, fill_price, quantity')
+        .eq('ticker', pos.symbol)
+        .eq('signal', 'SELL')
+        .in('status', ['CLOSED'])
+        .or('close_price.is.null,close_price.eq.0')
+        .gte('opened_at', since)
+        .order('opened_at', { ascending: false })
+        .limit(1);
+
+      const orphan = (orphanTrades ?? [])[0] as { id: string; fill_price: number | null; quantity: number | null } | undefined;
+      if (orphan) {
+        await sb.from('paper_trades').update({
+          close_reason: 'reconcile_cover',
+          ib_order_id: String(coverOrderId), // overwrite with cover orderId so EOD reconciler can match the fill
+          notes: `Cover orderId=${coverOrderId} placed by reconcileIBShorts at ${new Date().toISOString()}`,
+        }).eq('id', orphan.id);
+        log(`[IBReconcile] Linked cover orderId=${coverOrderId} to paper_trade ${orphan.id} for ${pos.symbol}`);
+      } else {
+        log(`[IBReconcile] No orphaned SELL paper_trade found for ${pos.symbol} — EOD reconciler will log as orphaned execution`);
+      }
+
       await createAutoTradeEvent({
         ticker: pos.symbol,
         event_type: 'warning',
         action: 'executed',
         source: 'system',
         message: `[IBReconcile] Orphaned short covered: BUY ${qty} shares (avg cost ${pos.avgCost})`,
-        metadata: { reconcile_type: 'ib_short_reconcile', qty, avg_cost: pos.avgCost },
+        metadata: { reconcile_type: 'ib_short_reconcile', qty, avg_cost: pos.avgCost, cover_order_id: coverOrderId },
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'unknown';
@@ -4881,15 +4911,24 @@ async function checkDayTradeTrailingStops(
 
     try {
       await placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });
+      const pnl = isBuy
+        ? parseFloat(((currentPrice - fillPrice) * qty).toFixed(2))
+        : parseFloat(((fillPrice - currentPrice) * qty).toFixed(2));
+      const pnlPct = fillPrice > 0
+        ? parseFloat(((pnl / (fillPrice * qty)) * 100).toFixed(2))
+        : null;
       await updatePaperTrade(trade.id, {
         status:       'CLOSED',
         close_reason: 'trailing_stop',
+        close_price:  currentPrice,
+        pnl,
+        pnl_percent:  pnlPct,
         closed_at:    new Date().toISOString(),
       });
       log(
         `${trade.ticker}: DAY_TRADE trailing stop closed — peak ${newPeak.toFixed(2)}, ` +
         `current ${currentPrice.toFixed(2)}, trail stop ${trailStop.toFixed(2)}, ` +
-        `locked in ~${((newPeak - fillPrice) * (TRAIL_RETRACE_PCT)).toFixed(2)} of peak gain`,
+        `P&L $${pnl.toFixed(2)}`,
       );
     } catch (err) {
       log(`${trade.ticker}: trailing stop close failed — ${err instanceof Error ? err.message : 'unknown'}`);


### PR DESCRIPTION
## Summary

Three root causes of the recurring P&L discrepancy — all fixed permanently, not patched.

### Root causes fixed

**1. `autoTrader.ts` — browser position sync null-price fallback (WOLF today)**
When the browser's `syncPositions` detected a position as gone and `getQuotePrice` returned null, it fell back to `fill_price` as the close price → `pnl = 0`. This is what caused WOLF to show `$0.00` P&L today (actual: `+$274.55`). Now it skips and defers to the server-side scheduler, which has actual IB fill lookup via `ib_fills`.

**2. `scheduler.ts` — trailing stop wrote `CLOSED` without `close_price`/`pnl`**
`checkDayTradeTrailingStops` placed the market order and wrote `{status: CLOSED}` with nothing else. The EOD reconciler's gate `close_price != null` then skipped it. Now writes `close_price: currentPrice`, `pnl`, and `pnl_percent` immediately.

**3. `scheduler.ts` / `reconcile-executions.ts` — orphaned shorts never got P&L written back**
`reconcileIBShorts` covered shorts in IB but never called `updatePaperTrade`. The cover `orderId` is now stored on the paper_trade and the EOD reconciler now also matches orphaned BUY executions to `reconcile_cover` shorts by ticker when orderId lookup fails.

**4. `reconcile-executions.ts` — EOD reconciler skipped null-close_price records**
The gate `trade.close_price != null` on the correction path meant any trade closed without a close_price was invisible to the reconciler. Removed; now also detects `close_price = fill_price` with `pnl = 0` as a signal that the price needs correcting.

### New feature: Activity log filtering + sorting

- **Filter toggle**: All / Day Trades / LT + Swing — persists within session
- **Sortable columns**: Ticker (A→Z), P&L (highest first), Time — click to toggle, click again to reverse

## Test plan
- [ ] Verify WOLF-style trades (trailing stop fires intraday) now show correct P&L in activity
- [ ] Verify filter toggle shows/hides day trades vs long-term correctly
- [ ] Verify P&L sort puts biggest wins/losses at top
- [ ] Verify auto-trader logs show reconcileIBShorts linking cover orderId to paper_trade

Made with [Cursor](https://cursor.com)