### PR TITLE
fix: capture IB orderId and fill price in profit-take records

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -5091,25 +5091,31 @@ async function checkProfitTakeOpportunities(
     try {
       if (!isConnected()) continue;
 
-      await placeMarketOrder({
+      const { orderId, avgFillPrice } = await placeMarketOrder({
         symbol: trade.ticker, side: 'SELL', quantity: actualTrimQty,
       });
 
+      const realizedPnl = actualTrimQty * (avgFillPrice - ibPos.avgCost);
+
       await createPaperTrade({
         ticker: trade.ticker, mode: 'LONG_TERM', signal: 'SELL',
-        entry_price: ibPos.mktPrice,
+        entry_price: avgFillPrice,
+        fill_price: avgFillPrice,
         quantity: actualTrimQty,
-        position_size: actualTrimQty * ibPos.mktPrice,
-        status: 'SUBMITTED',
+        position_size: actualTrimQty * avgFillPrice,
+        status: 'FILLED',
+        ib_order_id: String(orderId),
+        pnl: realizedPnl,
+        close_reason: 'profit_take',
+        closed_at: new Date().toISOString(),
         notes: `Profit take ${triggered.label} at +${gainPct.toFixed(1)}%`,
         entry_trigger_type: 'profit_take',
       });
 
-      const realizedPnl = actualTrimQty * (ibPos.mktPrice - ibPos.avgCost);
-      log(`${trade.ticker}: PROFIT TAKE ${triggered.label} — sold ${actualTrimQty} shares at +${gainPct.toFixed(1)}% ($${realizedPnl.toFixed(2)})`);
-      persistEvent(trade.ticker, 'success', `Profit take ${triggered.label}: sold ${actualTrimQty} shares`, {
+      log(`${trade.ticker}: PROFIT TAKE ${triggered.label} — sold ${actualTrimQty} shares @ $${avgFillPrice.toFixed(2)}, +${gainPct.toFixed(1)}% ($${realizedPnl.toFixed(2)})`);
+      persistEvent(trade.ticker, 'success', `Profit take ${triggered.label}: sold ${actualTrimQty} shares @ $${avgFillPrice.toFixed(2)}`, {
         action: 'executed', source: 'profit_take', mode: 'LONG_TERM',
-        metadata: { tier: triggered.label, gainPct, trimQty: actualTrimQty, realizedPnl },
+        metadata: { tier: triggered.label, gainPct, trimQty: actualTrimQty, realizedPnl, fillPrice: avgFillPrice, orderId },
       });
     } catch (err) {
       log(`${trade.ticker}: Profit take failed — ${err instanceof Error ? err.message : 'unknown'}`);


### PR DESCRIPTION
## Summary
- `checkProfitTakeOpportunities` was discarding the `placeMarketOrder` result, so profit-take SELL records were created with `ib_order_id=null` and `status='SUBMITTED'`
- This caused them to show as 'Pending' forever and never be tracked as filled
- Fix captures `{ orderId, avgFillPrice }` from the fill, creates the record as `FILLED` with proper `ib_order_id`, `fill_price`, `pnl`, `close_reason='profit_take'`, and `closed_at`
- Also patched AMAT DB: re-activated the 8-share live IB position as a new `FILLED` paper_trade (original was wrongly marked `STOPPED` while IB still holds shares)

## Root Cause
The old code called `await placeMarketOrder(...)` without capturing the return value. `placeMarketOrder` awaits the IB fill and resolves with `{ orderId, avgFillPrice, filledQty }` — all of this was dropped.

## Test plan
- [ ] Tomorrow when market opens, verify profit-take SELL records appear as `FILLED` in DB with `ib_order_id` set
- [ ] Verify AMAT profit-take triggers at Tier 3 (Tiers 1+2 already done)
- [ ] Verify CSCO Tier 2 triggers if still above threshold

Made with [Cursor](https://cursor.com)