### PR TITLE
feat: feed day-trade gainers + influencer tickers into scanner universe

### DIFF
--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -859,6 +859,85 @@ export async function writeScanEvaluations(
   }
 }
 
+// ── Scanner Watchlist helpers ──────────────────────────────────────────────
+
+const SCANNER_WATCHLIST_TTL_DAYS = 10;
+
+export interface ScannerWatchlistRow {
+  ticker: string;
+  added_at: string;
+  expires_at: string;
+  last_win_at: string;
+  win_count: number;
+  consecutive_wins: number;
+  avg_pnl: number | null;
+  source: string;
+  notes: string | null;
+  active: boolean;
+}
+
+export async function upsertScannerWatchlistTicker(
+  ticker: string,
+  pnl: number,
+  source = 'day_trade_gainer',
+): Promise<void> {
+  const sb = getSupabase();
+  const now = new Date().toISOString();
+  const expiresAt = new Date(Date.now() + SCANNER_WATCHLIST_TTL_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: existing } = await sb
+    .from('scanner_watchlist')
+    .select('win_count, consecutive_wins, avg_pnl')
+    .eq('ticker', ticker.toUpperCase())
+    .maybeSingle();
+
+  if (existing) {
+    const newWinCount = existing.win_count + 1;
+    const newConsec = existing.consecutive_wins + 1;
+    const oldAvg = existing.avg_pnl ?? 0;
+    const newAvg = (oldAvg * existing.win_count + pnl) / newWinCount;
+    await sb.from('scanner_watchlist').update({
+      last_win_at: now,
+      expires_at: expiresAt,
+      win_count: newWinCount,
+      consecutive_wins: newConsec,
+      avg_pnl: newAvg,
+      active: true,
+      source,
+    }).eq('ticker', ticker.toUpperCase());
+  } else {
+    await sb.from('scanner_watchlist').insert({
+      ticker: ticker.toUpperCase(),
+      added_at: now,
+      expires_at: expiresAt,
+      last_win_at: now,
+      win_count: 1,
+      consecutive_wins: 1,
+      avg_pnl: pnl,
+      source,
+      active: true,
+    });
+  }
+}
+
+export async function getActiveScannerWatchlist(): Promise<ScannerWatchlistRow[]> {
+  const sb = getSupabase();
+  const now = new Date().toISOString();
+  const { data } = await sb
+    .from('scanner_watchlist')
+    .select('*')
+    .eq('active', true)
+    .gte('expires_at', now);
+  return (data ?? []) as ScannerWatchlistRow[];
+}
+
+export async function resetScannerWatchlistStreak(ticker: string): Promise<void> {
+  const sb = getSupabase();
+  await sb.from('scanner_watchlist')
+    .update({ consecutive_wins: 0 })
+    .eq('ticker', ticker.toUpperCase());
+}
+
 export async function upsertHeartbeat(payload: HeartbeatPayload): Promise<void> {
   try {
     const sb = getSupabase();

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -59,6 +59,8 @@ import {
   getPerformance,
   upsertHeartbeat,
   writeScanEvaluations,
+  upsertScannerWatchlistTicker,
+  resetScannerWatchlistStreak,
   type ScanEvaluationStatus,
   type AutoTraderConfig,
   type ExternalStrategySignal,
@@ -318,6 +320,17 @@ export function startScheduler(): void {
       await closeAllDayTrades(config);
     }
   }, { timezone: 'America/New_York' });
+
+  // 4:05 PM — promote today's profitable day-trade tickers to the scanner watchlist
+  // so they get re-scanned tomorrow. Runs after EOD close (3:55) settles.
+  cron.schedule('5 16 * * 1-5', async () => {
+    try {
+      await promoteDayTradeGainersToWatchlist();
+    } catch (err) {
+      console.error('[Scheduler] promoteDayTradeGainersToWatchlist failed:', err instanceof Error ? err.message : err);
+    }
+  }, { timezone: 'America/New_York' });
+  log('Day-trade gainer promotion: 4:05 PM ET (winners → scanner watchlist)');
 
   // 4:10 PM IB position-level reconciliation — queries IB directly to find any
   // short or long positions that survived the EOD sweep (the sweep only checks
@@ -817,6 +830,70 @@ async function checkStaleDayTrades(positions: EnrichedPosition[]): Promise<void>
 // naked short positions that will lose money tomorrow.
 //
 // This function pulls ACTUAL IB positions and BUYs to cover any shorts it finds.
+// ── Promote Day-Trade Gainers to Scanner Watchlist ───────────────────────────
+//
+// Runs at 4:05 PM ET after the EOD sweep settles. Queries today's closed
+// day trades, upserts winners into scanner_watchlist (10-day TTL, win streak
+// tracking), and resets consecutive_wins for losers already on the list.
+// The trade-scanner edge function reads this table to expand its universe.
+
+async function promoteDayTradeGainersToWatchlist(): Promise<void> {
+  const todayEt = getETDateString();
+  const sb = getSupabase();
+  const { data: closedToday } = await sb
+    .from('paper_trades')
+    .select('ticker, pnl, strategy_source')
+    .eq('mode', 'DAY_TRADE')
+    .in('status', [...CLOSED_STATUSES])
+    .not('pnl', 'is', null)
+    .gte('opened_at', `${todayEt}T00:00:00Z`);
+
+  if (!closedToday || closedToday.length === 0) {
+    log('[ScannerWatchlist] No closed day trades today — nothing to promote');
+    return;
+  }
+
+  const bestByTicker = new Map<string, { pnl: number; source: string }>();
+  for (const t of closedToday) {
+    const tk = t.ticker.toUpperCase();
+    const prev = bestByTicker.get(tk);
+    const pnl = Number(t.pnl);
+    if (!prev || pnl > prev.pnl) {
+      bestByTicker.set(tk, { pnl, source: t.strategy_source ?? 'scanner' });
+    }
+  }
+
+  const promoted: string[] = [];
+  const streakReset: string[] = [];
+
+  for (const [ticker, info] of bestByTicker) {
+    if (info.pnl > 0) {
+      try {
+        await upsertScannerWatchlistTicker(ticker, info.pnl, `day_trade_gainer:${info.source}`);
+        promoted.push(ticker);
+      } catch (err) {
+        log(`[ScannerWatchlist] Failed to upsert ${ticker}: ${err instanceof Error ? err.message : 'unknown'}`);
+      }
+    } else {
+      try {
+        await resetScannerWatchlistStreak(ticker);
+        streakReset.push(ticker);
+      } catch { /* no-op if ticker not on watchlist */ }
+    }
+  }
+
+  if (promoted.length > 0) {
+    log(`[ScannerWatchlist] Promoted ${promoted.length} gainer(s): ${promoted.join(', ')}`);
+    persistEvent('*', 'info', `Scanner watchlist: promoted ${promoted.length} day-trade gainer(s) — ${promoted.join(', ')}`, {
+      action: 'executed', source: 'system', mode: 'DAY_TRADE',
+      metadata: { promoted, streakReset },
+    });
+  }
+  if (streakReset.length > 0) {
+    log(`[ScannerWatchlist] Reset streak for ${streakReset.length} loser(s): ${streakReset.join(', ')}`);
+  }
+}
+
 // Safe to call at any time: it only acts on negative (short) stock positions.
 // Exposed via POST /api/scheduler/reconcile-ib so the user can trigger it from
 // the UI or curl without waiting for tomorrow's stale-trade check.

--- a/supabase/functions/trade-scanner/index.ts
+++ b/supabase/functions/trade-scanner/index.ts
@@ -1384,9 +1384,36 @@ async function runKeyLevelScan(
       .filter(Boolean);
     for (const s of liquidMovers) {
       if (!universe.includes(s)) universe.push(s);
-      if (universe.length >= 45) break;
+      if (universe.length >= 50) break;
     }
   } catch { /* movers optional */ }
+
+  // Layer 3: scanner_watchlist — past day-trade gainers with TTL
+  try {
+    const { data: watchlistRows } = await sb
+      .from('scanner_watchlist')
+      .select('ticker')
+      .eq('active', true)
+      .gte('expires_at', new Date().toISOString());
+    for (const row of watchlistRows ?? []) {
+      if (!universe.includes(row.ticker)) universe.push(row.ticker);
+    }
+  } catch { /* watchlist optional */ }
+
+  // Layer 4: recent influencer/strategy signals for day trades
+  try {
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const { data: signals } = await sb
+      .from('external_strategy_signals')
+      .select('ticker')
+      .eq('mode', 'DAY_TRADE')
+      .in('status', ['EXECUTED', 'PENDING'])
+      .gte('created_at', fiveDaysAgo);
+    for (const row of signals ?? []) {
+      const tk = row.ticker?.toUpperCase();
+      if (tk && !universe.includes(tk)) universe.push(tk);
+    }
+  } catch { /* signals optional */ }
 
   // Fetch quotes with full OHLCV bars
   const quotes = await fetchSwingQuotes([...new Set(universe)]);
@@ -2140,6 +2167,44 @@ Deno.serve(async (req) => {
           }
           console.log(`[Trade Scanner] Pre-market gappers injected: ${gapTickers.join(', ')}`);
         }
+      }
+
+      // Inject scanner_watchlist (past day-trade gainers) + recent influencer signals
+      const extraTickers: string[] = [];
+      try {
+        const { data: watchlistRows } = await sb
+          .from('scanner_watchlist')
+          .select('ticker')
+          .eq('active', true)
+          .gte('expires_at', new Date().toISOString());
+        for (const row of watchlistRows ?? []) {
+          if (!deduped.has(row.ticker)) extraTickers.push(row.ticker);
+        }
+      } catch { /* optional */ }
+      try {
+        const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+        const { data: signals } = await sb
+          .from('external_strategy_signals')
+          .select('ticker')
+          .eq('mode', 'DAY_TRADE')
+          .in('status', ['EXECUTED', 'PENDING'])
+          .gte('created_at', fiveDaysAgo);
+        for (const row of signals ?? []) {
+          const tk = row.ticker?.toUpperCase();
+          if (tk && !deduped.has(tk) && !extraTickers.includes(tk)) extraTickers.push(tk);
+        }
+      } catch { /* optional */ }
+      if (extraTickers.length > 0) {
+        const extraQuotes = await fetchSwingQuotes(extraTickers);
+        for (const q of extraQuotes) {
+          if (!q.symbol) continue;
+          const price = rawVal(q.regularMarketPrice);
+          const volume = rawVal(q.regularMarketVolume);
+          if (price >= 10 && volume >= 500_000) {
+            deduped.set(q.symbol, q);
+          }
+        }
+        console.log(`[Trade Scanner] Watchlist+signals injected: ${extraTickers.join(', ')}`);
       }
 
       let candidates = [...deduped.values()];

--- a/supabase/migrations/20260514000003_scanner_watchlist.sql
+++ b/supabase/migrations/20260514000003_scanner_watchlist.sql
@@ -1,0 +1,20 @@
+-- Scanner watchlist: tickers promoted from profitable day trades and influencer signals.
+-- Fed into the trade-scanner universe so winning tickers get re-evaluated.
+CREATE TABLE scanner_watchlist (
+  ticker           TEXT PRIMARY KEY,
+  added_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at       TIMESTAMPTZ NOT NULL,
+  last_win_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  win_count        INTEGER NOT NULL DEFAULT 1,
+  consecutive_wins INTEGER NOT NULL DEFAULT 1,
+  avg_pnl          NUMERIC,
+  source           TEXT NOT NULL DEFAULT 'day_trade_gainer',
+  notes            TEXT,
+  active           BOOLEAN NOT NULL DEFAULT true
+);
+
+ALTER TABLE scanner_watchlist ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read scanner_watchlist"   ON scanner_watchlist FOR SELECT USING (true);
+CREATE POLICY "Anyone can insert scanner_watchlist"  ON scanner_watchlist FOR INSERT WITH CHECK (true);
+CREATE POLICY "Anyone can update scanner_watchlist"  ON scanner_watchlist FOR UPDATE USING (true);
+CREATE POLICY "Anyone can delete scanner_watchlist"  ON scanner_watchlist FOR DELETE USING (true);


### PR DESCRIPTION
## Summary
- New `scanner_watchlist` table with 10-day TTL and win streak tracking
- `promoteDayTradeGainersToWatchlist()` runs at 4:05 PM ET — upserts today's profitable day-trade tickers, resets streaks for losers
- Trade scanner (`trade-scanner` edge function) now merges two extra sources into its universe:
  - `scanner_watchlist` rows (past day-trade winners)
  - `external_strategy_signals` (recent day-trade influencer/strategy video picks from the last 5 days)
- Key-level universe cap raised from 45 to 50 to accommodate extra tickers

## How it works
```
4:05 PM ET: query today's closed day trades
  → winners → upsert into scanner_watchlist (10-day TTL)
  → losers already on watchlist → reset consecutive_wins

Next morning scanner run:
  → DAY_CORE + Yahoo movers + scanner_watchlist + influencer signals
  → deduped, enriched, ranked → AI evaluation → trade ideas
```

## Test plan
- [ ] Verify `scanner_watchlist` table created in Supabase
- [ ] Tomorrow after market close, check that winning tickers appear in `scanner_watchlist`
- [ ] Next scanner refresh should log "Watchlist+signals injected: ..." for any extra tickers

Made with [Cursor](https://cursor.com)