### PR TITLE
fix: accept /reels/ (plural) in Instagram URL parser

### DIFF
--- a/app/src/lib/strategyVideoQueueApi.ts
+++ b/app/src/lib/strategyVideoQueueApi.ts
@@ -19,7 +19,7 @@ export interface StrategyVideoQueueItem {
   processed_at: string | null;
 }
 
-const INSTAGRAM_REEL = /instagram\.com\/(?:[^/]+\/)?reel\/([A-Za-z0-9_-]+)/i;
+const INSTAGRAM_REEL = /instagram\.com\/(?:[^/]+\/)?reels?\/([A-Za-z0-9_-]+)/i;
 const TWITTER_STATUS = /(?:twitter|x)\.com\/(?:[^/]+\/)?status\/(\d+)/i;
 const YOUTUBE = /(?:youtube\.com\/watch\?v=|youtu\.be\/)([A-Za-z0-9_-]{11})/i;
 

--- a/supabase/functions/fix-unknown-strategy-sources/index.ts
+++ b/supabase/functions/fix-unknown-strategy-sources/index.ts
@@ -13,7 +13,7 @@ const corsHeaders = {
 
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
-const INSTAGRAM_REEL = /instagram\.com\/(?:([^/]+)\/)?reel\/([A-Za-z0-9_-]+)/i;
+const INSTAGRAM_REEL = /instagram\.com\/(?:([^/]+)\/)?reels?\/([A-Za-z0-9_-]+)/i;
 
 // Instagram system paths / CDN paths that are never real account handles
 const IG_SYSTEM_PATHS = new Set([
@@ -47,7 +47,7 @@ async function extractInstagramHandle(url: string): Promise<string | null> {
     const html = await res.text();
     // Prefer og:url — most reliable
     const ogUrl = html.match(/<meta[^>]+property="og:url"[^>]+content="([^"]*)"/i)?.[1] ?? '';
-    const m2 = /instagram\.com\/([^/]+)\/(?:reel|p)\//i.exec(ogUrl);
+    const m2 = /instagram\.com\/([^/]+)\/(?:reels?|p)\//i.exec(ogUrl);
     if (m2?.[1] && !isIgSystemPath(m2[1])) return m2[1].trim().toLowerCase();
 
     // Fallback: first instagram.com/<handle>/ match in HTML

--- a/supabase/functions/process-strategy-video-queue/index.ts
+++ b/supabase/functions/process-strategy-video-queue/index.ts
@@ -11,7 +11,7 @@ const corsHeaders = {
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
 };
 
-const INSTAGRAM_REEL = /instagram\.com\/(?:([^/]+)\/)?reel\/([A-Za-z0-9_-]+)/i;
+const INSTAGRAM_REEL = /instagram\.com\/(?:([^/]+)\/)?reels?\/([A-Za-z0-9_-]+)/i;
 const TWITTER_STATUS = /(?:twitter|x)\.com\/(?:[^/]+\/)?status\/(\d+)/i;
 const YOUTUBE = /(?:youtube\.com\/watch\?v=|youtu\.be\/)([A-Za-z0-9_-]{11})/i;
 
@@ -60,7 +60,7 @@ async function fetchInstagramHandle(url: string): Promise<string | null> {
     const html = await res.text();
     // Prefer og:url — most reliable
     const ogUrl = html.match(/<meta[^>]+property="og:url"[^>]+content="([^"]*)"/i)?.[1] ?? '';
-    const m = /instagram\.com\/([^/]+)\/(?:reel|p)\//i.exec(ogUrl);
+    const m = /instagram\.com\/([^/]+)\/(?:reels?|p)\//i.exec(ogUrl);
     if (m?.[1] && !isIgSystemPath(m[1])) return m[1].trim().toLowerCase();
 
     // Fallback: first instagram.com/<handle>/ match in HTML


### PR DESCRIPTION
## Summary
- Instagram URLs use both `/reel/` and `/reels/` — our regex only matched singular `/reel/`
- This silently rejected every URL the user pasted (they always use the `/reels/` format)
- Fixed regex to `reels?` in all 3 files: client parser, process-queue, fix-unknown-sources

## Test plan
- [x] Paste `https://www.instagram.com/reels/DYVlBf5zp2P/` — should parse correctly now

Made with [Cursor](https://cursor.com)