### PR TITLE
Fix duplicate activity log entries for profit-take + lt_auto_sell

### DIFF
--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -380,7 +380,8 @@ export function PaperTrading() {
     const seen = new Map<string, number>();
     for (const e of executions) {
       const signal = (e.scanner_signal ?? 'BUY').toUpperCase();
-      const key = `${e.ticker}|${signal}|${e.action ?? 'executed'}`;
+      const action = (e.action ?? 'executed') === 'closed' ? 'executed' : (e.action ?? 'executed');
+      const key = `${e.ticker}|${signal}|${action}`;
       const existingIdx = seen.get(key);
       if (existingIdx != null) {
         const existing = finalExecs[existingIdx];


### PR DESCRIPTION
## Summary
- Normalizes `action: 'closed'` to `'executed'` in the Today's Activity dedup key so `lt_auto_sell` and `profit_take` events for the same ticker collapse into one row
- Previously both appeared because the dedup key was `ticker|signal|action` and the two event types used different `action` values (`closed` vs `executed`)

## Test plan
- [x] Verified in local dev: CSCO and AMAT each appear once instead of twice
- [x] `npm run build` passes cleanly


Made with [Cursor](https://cursor.com)