### PR TITLE
feat: activate daily credit spread scanning + add momentum watchlist

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -440,10 +440,10 @@ export function startScheduler(): void {
   }, { timezone: 'America/New_York' });
   log('Calendar spread scan: every Monday 11:00 AM ET');
 
-  // Credit spread scan — Tuesday & Thursday 10:30 AM ET.
+  // Credit spread scan — Mon-Fri 10:30 AM ET.
   // Scans for vertical credit spread entries (bull puts / bear calls).
   // Executes qualifying trades automatically (≥40% credit/width, trend-following pullbacks).
-  cron.schedule('30 10 * * 2,4', async () => {
+  cron.schedule('30 10 * * 1-5', async () => {
     try {
       log('[Scheduler] Running credit spread scan...');
       const { runCreditSpreadScan } = await import('./lib/credit-spread-scanner.js');
@@ -453,7 +453,7 @@ export function startScheduler(): void {
       console.error('[Scheduler] Credit spread scan error:', err instanceof Error ? err.message : err);
     }
   }, { timezone: 'America/New_York' });
-  log('Credit spread scan: Tue/Thu 10:30 AM ET');
+  log('Credit spread scan: Mon-Fri 10:30 AM ET');
 
   // Credit spread position management — every 30 min during market hours.
   // Checks 50% profit-take, 100% stop-loss, and 21 DTE time exit rules.

--- a/supabase/migrations/20260515000002_credit_spread_watchlist.sql
+++ b/supabase/migrations/20260515000002_credit_spread_watchlist.sql
@@ -1,0 +1,18 @@
+-- Add credit-spread-focused tickers from OptionsPlay Growth Lab (Bryan Overby, May 2026).
+-- AI/Semiconductors (sector leaders), Travel/Leisure (breakout sector), Utilities (dividend).
+
+INSERT INTO options_watchlist (ticker, added_by, notes, tier) VALUES
+  ('MRVL',  'credit_spread', 'Marvell Tech — AI/semi leader, strong momentum',           'GROWTH'),
+  ('MU',    'credit_spread', 'Micron — memory/AI play, breakout after earnings',          'GROWTH'),
+  ('ADI',   'credit_spread', 'Analog Devices — analog semi, steady growth',               'STABLE'),
+  ('ON',    'credit_spread', 'ON Semiconductor — power/auto semi',                        'GROWTH'),
+  ('HLT',   'credit_spread', 'Hilton — travel/leisure breakout sector',                   'STABLE'),
+  ('MAR',   'credit_spread', 'Marriott — travel/leisure breakout sector',                 'STABLE'),
+  ('NEE',   'credit_spread', 'NextEra Energy — utility/power grid, AI infrastructure',    'STABLE'),
+  ('IWM',   'credit_spread', 'Russell 2000 ETF — small cap strength signal',              'STABLE'),
+  ('VIK',   'credit_spread', 'Viking Holdings — cruise line breakout',                    'HIGH_VOL'),
+  ('LRCX',  'credit_spread', 'Lam Research — semi equipment, CCI pullback entry',         'GROWTH')
+ON CONFLICT (ticker) DO UPDATE SET
+  notes = EXCLUDED.notes,
+  active = true,
+  updated_at = NOW();


### PR DESCRIPTION
## Summary
- Increases credit spread scan frequency from Tue/Thu only to **Mon-Fri 10:30 AM ET** — Bryan Overby's approach suggests daily opportunity scanning for credit spread entries
- Adds 10 momentum tickers from OptionsPlay Growth Lab analysis: MRVL, MU, ADI, ON, HLT, MAR, NEE, IWM, VIK, LRCX (AI/semis, travel/leisure breakouts, utility/power grid)

## Context
The credit spread system (scanner + execution + position management) was deployed in #230. This PR activates it at full daily cadence and seeds the watchlist with current sector leaders identified in Bryan Overby's Growth Lab session.

## Test plan
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Auto-trader rebuilt and LaunchAgent restarted
- [x] Confirmed scheduler logs: "Credit spread scan: Mon-Fri 10:30 AM ET"
- [x] Migration applied to remote Supabase (tickers visible in options_watchlist)

Made with [Cursor](https://cursor.com)