### PR TITLE
fix: friendly Strike Sniper error for far-OTM strikes

### DIFF
--- a/app/src/components/PaperTrading/tabs/OptionsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/OptionsTab.tsx
@@ -768,7 +768,11 @@ export function OptionsTab() {
       const res = await fetch(`http://localhost:3001/api/options/strike-sniper?symbol=${ticker}&targetStrike=${target}`);
       if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error ?? 'Request failed');
       const data = await res.json();
-      setSniperResults(data);
+      if (!data.contracts || data.contracts.length === 0) {
+        setSniperError(`No contracts found near $${target} for ${ticker} (current price: $${data.currentPrice?.toFixed(0) ?? '?'}). Try a strike closer to the current price.`);
+      } else {
+        setSniperResults(data);
+      }
     } catch (err) {
       setSniperError(err instanceof Error ? err.message : 'Failed to fetch');
     } finally {

--- a/auto-trader/src/routes/options.ts
+++ b/auto-trader/src/routes/options.ts
@@ -21,6 +21,12 @@ router.get('/options/strike-sniper', async (req, res) => {
     const quote = await fetchQuote(symbol);
     const currentPrice = quote?.price ?? null;
 
+    if (currentPrice && targetStrike < currentPrice * 0.40) {
+      return res.status(400).json({
+        error: `Target strike $${targetStrike} is too far below ${symbol}'s current price ($${currentPrice.toFixed(0)}). Try a strike within 10-30% below the current price.`,
+      });
+    }
+
     const contracts = await findBestContractForStrike(symbol, targetStrike, minReturn, currentPrice ?? undefined);
     const fundamental = await getFundamentalGrade(symbol);
 


### PR DESCRIPTION
## Summary
- Backend rejects strikes >60% below current price with a helpful message
- Frontend shows "No contracts found" with current price context when results are empty
- Fixes the confusing "Failed to fetch" error when entering unrealistic target strikes

## Test plan
- [x] Builds clean
- [x] Auto-trader restarted
- Try TSLA $150 → see clear error; TSLA $300 → works as before


Made with [Cursor](https://cursor.com)