### PR TITLE
fix: capture fill price + P&L on short cover reconciliation

### DIFF
--- a/.cursor/rules/ib-paper-account.mdc
+++ b/.cursor/rules/ib-paper-account.mdc
@@ -1,0 +1,38 @@
+---
+description: IB paper account context — no manual trades, auto-trader is sole operator
+alwaysApply: true
+---
+
+# IB Paper Account — Single Operator
+
+## Context
+
+- We are using an **IB paper trading account** (not a live account).
+- **All trades are placed by the auto-trader.** No manual trades are ever placed.
+- The auto-trader is the **sole operator** of this IB account.
+
+## Implications
+
+1. **IB and paper_trades should always agree.** There is no legitimate reason for
+   a position to exist in IB without a corresponding `paper_trades` record, or vice
+   versa. Any discrepancy is a bug in the auto-trader, not a manual trade.
+
+2. **Orphaned positions are always bugs.** When `reconcileIBShorts()` or
+   `reconcileIBLongs()` finds an IB position with no matching paper_trade, that
+   means the auto-trader created it (accidental short from overselling, duplicate
+   order, etc.). Treat the root cause as a bug to fix, not just a reconciliation
+   event to log.
+
+3. **IB's realized P&L is the source of truth** for today's total P&L. The
+   `reqPnL` subscription returns the exact same number as the IB mobile app.
+   When IB is connected, always prefer `ibRealizedPnl` over event-based
+   calculations. The event-based fallback exists only for when IB is disconnected.
+
+4. **Every IB execution was initiated by our code.** When debugging fill price
+   discrepancies, check the auto-trader logs — the order ID, fill price, and
+   quantity are all logged. No external party is placing orders.
+
+5. **Position quantity must match exactly.** If the auto-trader intends to close
+   a position of N shares, it must verify IB holds exactly N shares before selling.
+   Selling more than held creates an accidental short. This has happened with CSCO
+   and AMAT (May 15, 2026) where two separate sell orders fired for the same ticker.

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -1027,8 +1027,10 @@ export async function reconcileIBShorts(): Promise<{ closed: string[]; errors: s
     const qty = Math.abs(pos.position);
     log(`[IBReconcile] Covering short: ${pos.symbol} × ${qty} @ avg ${pos.avgCost}`);
     try {
-      const { orderId: coverOrderId } = await placeMarketOrder({ symbol: pos.symbol, side: 'BUY', quantity: qty });
-      log(`[IBReconcile] ✓ ${pos.symbol}: BUY ${qty} order placed (orderId=${coverOrderId})`);
+      const { orderId: coverOrderId, avgFillPrice } = await placeMarketOrder({ symbol: pos.symbol, side: 'BUY', quantity: qty });
+      // Short P&L: sold at avgCost, covered at avgFillPrice
+      const coverPnl = parseFloat(((pos.avgCost - avgFillPrice) * qty).toFixed(2));
+      log(`[IBReconcile] ✓ ${pos.symbol}: BUY ${qty} filled @ $${avgFillPrice.toFixed(2)} (orderId=${coverOrderId}), est P&L: $${coverPnl.toFixed(2)}`);
       closed.push(pos.symbol);
 
       // Find the orphaned SELL paper_trade for this ticker and mark it for EOD reconciliation.
@@ -1051,10 +1053,13 @@ export async function reconcileIBShorts(): Promise<{ closed: string[]; errors: s
       if (orphan) {
         await sb.from('paper_trades').update({
           close_reason: 'reconcile_cover',
-          ib_order_id: String(coverOrderId), // overwrite with cover orderId so EOD reconciler can match the fill
-          notes: `Cover orderId=${coverOrderId} placed by reconcileIBShorts at ${new Date().toISOString()}`,
+          close_price: avgFillPrice,
+          pnl: coverPnl,
+          pnl_percent: pos.avgCost > 0 ? parseFloat(((coverPnl / (pos.avgCost * qty)) * 100).toFixed(2)) : null,
+          ib_order_id: String(coverOrderId),
+          notes: `Cover orderId=${coverOrderId} filled @ $${avgFillPrice.toFixed(2)} by reconcileIBShorts at ${new Date().toISOString()}`,
         }).eq('id', orphan.id);
-        log(`[IBReconcile] Linked cover orderId=${coverOrderId} to paper_trade ${orphan.id} for ${pos.symbol}`);
+        log(`[IBReconcile] Linked cover orderId=${coverOrderId} to paper_trade ${orphan.id} for ${pos.symbol} (pnl $${coverPnl.toFixed(2)})`);
       } else {
         log(`[IBReconcile] No orphaned SELL paper_trade found for ${pos.symbol} — EOD reconciler will log as orphaned execution`);
       }
@@ -1062,10 +1067,10 @@ export async function reconcileIBShorts(): Promise<{ closed: string[]; errors: s
       await createAutoTradeEvent({
         ticker: pos.symbol,
         event_type: 'warning',
-        action: 'executed',
+        action: 'closed',
         source: 'system',
-        message: `[IBReconcile] Orphaned short covered: BUY ${qty} shares (avg cost ${pos.avgCost})`,
-        metadata: { reconcile_type: 'ib_short_reconcile', qty, avg_cost: pos.avgCost, cover_order_id: coverOrderId },
+        message: `[IBReconcile] Orphaned short covered: BUY ${qty} @ $${avgFillPrice.toFixed(2)} (avg cost $${pos.avgCost.toFixed(2)})`,
+        metadata: { reconcile_type: 'ib_short_reconcile', qty, avg_cost: pos.avgCost, cover_order_id: coverOrderId, fillPrice: avgFillPrice, pnl: coverPnl },
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'unknown';


### PR DESCRIPTION
Records fill price and P&L directly when covering accidental short positions, instead of leaving it for EOD reconciliation.

Made with [Cursor](https://cursor.com)