### PR TITLE
feat: DAY_PENNY penny stock momentum scanner

### DIFF
--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -38,7 +38,7 @@ export interface TodayActivityTabProps {
   ibRealizedPnl?: number | null;
 }
 
-type FilterMode = 'all' | 'day' | 'long_term' | 'gainers' | 'losers';
+type FilterMode = 'all' | 'day' | 'penny' | 'long_term' | 'gainers' | 'losers';
 type SortKey = 'ticker' | 'pnl' | 'time' | null;
 type SortDir = 'asc' | 'desc';
 
@@ -267,7 +267,8 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
     if (filterMode !== 'all') {
       filtered = events.filter(ev => {
         const mode = ev.mode;
-        if (filterMode === 'day') return mode === 'DAY_TRADE';
+        if (filterMode === 'day') return mode === 'DAY_TRADE' || mode === 'DAY_PENNY';
+        if (filterMode === 'penny') return mode === 'DAY_PENNY';
         if (filterMode === 'long_term') return mode === 'LONG_TERM' || mode === 'SWING_TRADE';
         if (filterMode === 'gainers' || filterMode === 'losers') {
           const trade = tradesByTicker.get(ev.ticker)?.find(t => t.pnl != null);
@@ -325,7 +326,7 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
 
       {/* Filter + count bar */}
       <div className="flex items-center gap-1.5 flex-wrap">
-        {(['all', 'day', 'long_term'] as FilterMode[]).map(f => (
+        {(['all', 'day', 'penny', 'long_term'] as FilterMode[]).map(f => (
           <button
             key={f}
             onClick={() => setFilterMode(f)}
@@ -336,7 +337,7 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
                 : 'bg-white text-[hsl(var(--muted-foreground))] border-[hsl(var(--border))] hover:border-[hsl(var(--foreground))]/40'
             )}
           >
-            {f === 'all' ? 'All' : f === 'day' ? 'Day Trades' : 'LT / Swing'}
+            {f === 'all' ? 'All' : f === 'day' ? 'Day Trades' : f === 'penny' ? 'Penny' : 'LT / Swing'}
           </button>
         ))}
         <button
@@ -431,6 +432,7 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
                 : 'Trade';
 
               const modeLabel = event.mode === 'DAY_TRADE' ? 'Day'
+                : event.mode === 'DAY_PENNY' ? 'Penny'
                 : event.mode === 'SWING_TRADE' ? 'Swing'
                 : event.mode === 'LONG_TERM' ? 'Long Term'
                 : isPositionSync ? 'Close' : '—';

--- a/app/src/components/TradeIdeas.tsx
+++ b/app/src/components/TradeIdeas.tsx
@@ -15,10 +15,12 @@ import {
   ArrowUpRight,
   ArrowDownRight,
   Ban,
+  Coins,
 } from 'lucide-react';
 import { cn } from '../lib/utils';
 import {
   fetchTradeIdeas,
+  fetchPennyTradeIdeas,
   fetchScanEvaluations,
   type TradeIdea,
   type ScanResult,
@@ -108,10 +110,10 @@ if (_persisted) {
 // ── Props ───────────────────────────────────────────────
 
 interface TradeIdeasProps {
-  onSelectTicker: (ticker: string, mode: 'DAY_TRADE' | 'SWING_TRADE') => void;
+  onSelectTicker: (ticker: string, mode: 'DAY_TRADE' | 'SWING_TRADE' | 'DAY_PENNY') => void;
 }
 
-type Tab = 'day' | 'swing' | 'gameplan';
+type Tab = 'day' | 'swing' | 'penny' | 'gameplan';
 
 function formatScanAge(ts: number): string {
   const diffMs = Date.now() - ts;
@@ -133,6 +135,7 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
   const [error, setError] = useState<string | null>(null);
   const [tradedTickers, setTradedTickers] = useState<Set<string>>(new Set());
   const [evaluations, setEvaluations] = useState<ScanEvaluations>({});
+  const [pennyTrades, setPennyTrades] = useState<TradeIdea[]>([]);
   const [marketOpen, setMarketOpen] = useState(() => isMarketHoursWindow());
 
   // Re-check market hours every minute so the badge updates as windows open/close.
@@ -148,7 +151,7 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
     const todayET = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
     Promise.all([getActiveTrades(), getAllTrades(50)])
       .then(([active, all]) => {
-        const relevantModes = new Set(['DAY_TRADE', 'SWING_TRADE']);
+        const relevantModes = new Set(['DAY_TRADE', 'SWING_TRADE', 'DAY_PENNY']);
         const tickers = new Set<string>();
         // Only include active or recent trades that were actually opened today
         [...active, ...all]
@@ -168,6 +171,15 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
     fetchScanEvaluations().then(setEvaluations).catch(() => {});
     const interval = setInterval(() => {
       fetchScanEvaluations().then(setEvaluations).catch(() => {});
+    }, 2 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Load penny stock scan candidates from the trade_scans table.
+  useEffect(() => {
+    fetchPennyTradeIdeas().then(setPennyTrades).catch(() => {});
+    const interval = setInterval(() => {
+      fetchPennyTradeIdeas().then(setPennyTrades).catch(() => {});
     }, 2 * 60 * 1000);
     return () => clearInterval(interval);
   }, []);
@@ -227,7 +239,7 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
   const dayIdeas = data?.dayTrades ?? [];
   const swingIdeas = data?.swingTrades ?? [];
   const gameplanSetups = data?.keyLevelSetups ?? [];
-  const totalCount = dayIdeas.length + swingIdeas.length; // key level setups excluded from badge count
+  const totalCount = dayIdeas.length + swingIdeas.length + pennyTrades.length; // key level setups excluded from badge count
 
   // Sort order: executed/armed → watching → no-eval → blocked
   const evalSortWeight = (ticker: string, signal: 'BUY' | 'SELL') => {
@@ -244,7 +256,9 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
     ? sortedIdeas(dayIdeas)
     : tab === 'swing'
       ? sortedIdeas(swingIdeas)
-      : [];
+      : tab === 'penny'
+        ? sortedIdeas(pennyTrades)
+        : [];
 
   return (
     <div className="rounded-xl border border-[hsl(var(--border))] bg-white shadow-sm overflow-hidden">
@@ -405,6 +419,27 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
             </button>
             <button
               type="button"
+              onClick={() => setTab('penny')}
+              className={cn(
+                'flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-all',
+                tab === 'penny'
+                  ? 'bg-green-50 text-green-700 border border-green-200 shadow-sm'
+                  : 'text-[hsl(var(--muted-foreground))] hover:bg-[hsl(var(--secondary))]'
+              )}
+            >
+              <Coins className="w-3.5 h-3.5" />
+              Penny
+              {pennyTrades.length > 0 && (
+                <span className={cn(
+                  'ml-0.5 text-[10px] px-1.5 rounded-full font-semibold',
+                  tab === 'penny' ? 'bg-green-200/70 text-green-700' : 'bg-[hsl(var(--secondary))] text-[hsl(var(--muted-foreground))]'
+                )}>
+                  {pennyTrades.length}
+                </span>
+              )}
+            </button>
+            <button
+              type="button"
               onClick={() => setTab('gameplan')}
               className={cn(
                 'flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-all',
@@ -462,13 +497,15 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
             {/* Day / Swing tab content */}
             {tab !== 'gameplan' && (
               <>
-                {ideas.length === 0 && !loading && !error && data && (
+                {ideas.length === 0 && !loading && !error && (data || tab === 'penny') && (
                   <div className="flex flex-col items-center py-6 gap-2 text-center">
                     <BarChart3 className="w-8 h-8 text-[hsl(var(--muted-foreground))] opacity-40" />
                     <p className="text-sm text-[hsl(var(--muted-foreground))]">
                       {tab === 'day'
                         ? 'No high-confidence day trade setups right now.'
-                        : 'No confirmed swing setups found.'}
+                        : tab === 'swing'
+                          ? 'No confirmed swing setups found.'
+                          : 'No penny stock setups found.'}
                     </p>
                     <p className="text-xs text-[hsl(var(--muted-foreground))] opacity-70">
                       Market may be closed or the AI didn't find setups worth recommending.
@@ -688,7 +725,7 @@ function IdeaCard({
   traded: boolean;
   hasOpenPosition?: boolean;
   evaluation?: ScanEvaluation;
-  onSelect: (ticker: string, mode: 'DAY_TRADE' | 'SWING_TRADE') => void;
+  onSelect: (ticker: string, mode: 'DAY_TRADE' | 'SWING_TRADE' | 'DAY_PENNY') => void;
 }) {
   const isPositive = idea.changePercent >= 0;
   // SELL signal with no matching open position — auto-trader will skip this

--- a/app/src/components/TradingSignals.tsx
+++ b/app/src/components/TradingSignals.tsx
@@ -583,10 +583,11 @@ export function TradingSignals() {
     }
   };
 
-  const handleSelectIdea = (t: string, m: 'DAY_TRADE' | 'SWING_TRADE') => {
+  const handleSelectIdea = (t: string, m: 'DAY_TRADE' | 'SWING_TRADE' | 'DAY_PENNY') => {
     setTicker(t);
-    setMode(m);
-    setStoredMode(m);
+    const analysisMode = m === 'DAY_PENNY' ? 'DAY_TRADE' : m;
+    setMode(analysisMode);
+    setStoredMode(analysisMode);
     setResult(null);  // Clear stale result so old analysis doesn't show
     setError(null);
     // Don't auto-run the full AI analysis — let the user click Analyze.

--- a/app/src/lib/aiFeedback.ts
+++ b/app/src/lib/aiFeedback.ts
@@ -119,7 +119,7 @@ function generateLesson(ctx: TradeContext, outcome: 'WIN' | 'LOSS' | 'BREAKEVEN'
     if (ctx.closeReason === 'target_hit') worked.push('Target price was well-calibrated');
 
     // Duration analysis
-    if (ctx.duration && ctx.mode === 'DAY_TRADE') {
+    if (ctx.duration && (ctx.mode === 'DAY_TRADE' || ctx.mode === 'DAY_PENNY')) {
       if (ctx.duration < 60) worked.push('Quick execution — momentum was strong');
       else if (ctx.duration > 240) parts.push('Took longer than expected for a day trade');
     }

--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -213,6 +213,10 @@ export async function loadAutoTraderConfig(): Promise<AutoTraderConfig> {
         tradeSignalsEnabled: data.trade_signals_enabled ?? DEFAULT_CONFIG.tradeSignalsEnabled,
         suggestedFindsEnabled: data.suggested_finds_enabled ?? DEFAULT_CONFIG.suggestedFindsEnabled,
         optionsWheelEnabled: data.options_wheel_enabled ?? DEFAULT_CONFIG.optionsWheelEnabled,
+        pennyEnabled: data.penny_enabled ?? DEFAULT_CONFIG.pennyEnabled,
+        pennyPositionSize: Number(data.penny_position_size ?? DEFAULT_CONFIG.pennyPositionSize),
+        pennyMaxDailyLoss: Number(data.penny_max_daily_loss ?? DEFAULT_CONFIG.pennyMaxDailyLoss),
+        pennyMaxDailyTrades: Number(data.penny_max_daily_trades ?? DEFAULT_CONFIG.pennyMaxDailyTrades),
       };
       localStorage.setItem(CONFIG_KEY, JSON.stringify(config));
       return config;
@@ -301,6 +305,10 @@ export async function saveAutoTraderConfig(config: Partial<AutoTraderConfig>): P
         trade_signals_enabled: updated.tradeSignalsEnabled,
         suggested_finds_enabled: updated.suggestedFindsEnabled,
         options_wheel_enabled: updated.optionsWheelEnabled,
+        penny_enabled: updated.pennyEnabled,
+        penny_position_size: updated.pennyPositionSize,
+        penny_max_daily_loss: updated.pennyMaxDailyLoss,
+        penny_max_daily_trades: updated.pennyMaxDailyTrades,
         updated_at: new Date().toISOString(),
       });
   } catch (err) {
@@ -520,7 +528,7 @@ function persistEvent(
   extra?: {
     action?: 'executed' | 'skipped' | 'failed';
     source?: 'scanner' | 'suggested_finds' | 'manual' | 'system' | 'dip_buy' | 'profit_take' | 'loss_cut';
-    mode?: 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM';
+    mode?: 'DAY_TRADE' | 'DAY_PENNY' | 'SWING_TRADE' | 'LONG_TERM';
     scanner_signal?: string;
     scanner_confidence?: number;
     fa_recommendation?: string;
@@ -627,7 +635,7 @@ async function checkAllocationCap(
   config: AutoTraderConfig,
   positionSize: number,
   ticker: string,
-  mode: 'LONG_TERM' | 'DAY_TRADE' | 'SWING_TRADE' = 'DAY_TRADE',
+  mode: 'LONG_TERM' | 'DAY_TRADE' | 'DAY_PENNY' | 'SWING_TRADE' = 'DAY_TRADE',
 ): Promise<boolean> {
   const deployed = await getTotalDeployed();
   const cap = config.maxTotalAllocation;
@@ -711,7 +719,7 @@ export function calculatePositionSize(
   config: AutoTraderConfig,
   params: {
     price: number;
-    mode: 'LONG_TERM' | 'DAY_TRADE' | 'SWING_TRADE';
+    mode: 'LONG_TERM' | 'DAY_TRADE' | 'DAY_PENNY' | 'SWING_TRADE';
     conviction?: number;      // for long-term holds
     suggestedFindTag?: 'Steady Compounder' | 'Gold Mine' | 'Dip Discovery';
     entryPrice?: number;      // for scanner trades
@@ -734,7 +742,7 @@ export function calculatePositionSize(
   // sizing or risk-based formula. The risk-based formula can balloon when stops are tight
   // (e.g. $2 stop on a $200 stock → 2,750 shares), causing outsized day-trade losses.
   // Swing and long-term trades keep the larger allocation-based cap.
-  const modeMaxDollar = mode === 'DAY_TRADE' ? config.positionSize : hardMaxDollar;
+  const modeMaxDollar = (mode === 'DAY_TRADE' || mode === 'DAY_PENNY') ? config.positionSize : hardMaxDollar;
 
   if (!config.useDynamicSizing || price <= 0) {
     // Fallback: flat position sizing, but STILL capped by mode
@@ -1548,7 +1556,7 @@ async function runPreTradeChecks(
   config: AutoTraderConfig,
   ticker: string,
   positionSize: number,
-  mode: 'LONG_TERM' | 'DAY_TRADE' | 'SWING_TRADE' = 'DAY_TRADE',
+  mode: 'LONG_TERM' | 'DAY_TRADE' | 'DAY_PENNY' | 'SWING_TRADE' = 'DAY_TRADE',
 ): Promise<boolean> {
   // 0. Drawdown protection — block new day/swing entries during critical drawdown.
   // LONG_TERM is exempt: long-term positions deploy idle cash into a months-long thesis
@@ -1776,7 +1784,7 @@ async function processSingleIdea(
       entryPrice,
       stopLoss,
       takeProfit: targetPrice,
-      tif: mode === 'DAY_TRADE' ? 'DAY' : 'GTC',
+      tif: (mode === 'DAY_TRADE' || mode === 'DAY_PENNY') ? 'DAY' : 'GTC',
     });
 
     // Handle any confirmation prompts
@@ -2358,7 +2366,7 @@ export async function syncPositions(accountId: string): Promise<void> {
         const tradeAge = Date.now() - new Date(trade.created_at).getTime();
         const oneDayMs = 24 * 60 * 60 * 1000;
 
-        if (trade.mode === 'DAY_TRADE' && tradeAge > oneDayMs) {
+        if ((trade.mode === 'DAY_TRADE' || trade.mode === 'DAY_PENNY') && tradeAge > oneDayMs) {
           await updatePaperTrade(trade.id, {
             status: 'CLOSED' as PaperTrade['status'],
             close_reason: 'manual',

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -735,7 +735,7 @@ export async function recalculatePerformance(): Promise<TradePerformance | null>
 // ── Category Performance (Signal Quality) ────────────────
 
 export interface CategoryPerformance {
-  category: 'suggested_finds' | 'day_trade' | 'scanner_day_trade' | 'influencer_day_trade' | 'swing_trade' | 'dip_buy' | 'profit_take';
+  category: 'suggested_finds' | 'day_trade' | 'scanner_day_trade' | 'influencer_day_trade' | 'day_penny' | 'swing_trade' | 'dip_buy' | 'profit_take';
   totalTrades: number;
   activeTrades: number;
   wins: number;
@@ -816,7 +816,7 @@ export interface PendingStrategySignal {
   id: string;
   ticker: string;
   signal: 'BUY' | 'SELL';
-  mode: 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL';
+  mode: 'DAY_TRADE' | 'DAY_PENNY' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL';
   source_name: string;
   source_url: string | null;
   strategy_video_id: string | null;
@@ -865,6 +865,10 @@ export async function recalculatePerformanceByCategory(): Promise<CategoryPerfor
     {
       key: 'influencer_day_trade',
       filter: (t) => t.mode === 'DAY_TRADE' && !!t.strategy_video_id,
+    },
+    {
+      key: 'day_penny',
+      filter: (t) => t.mode === 'DAY_PENNY',
     },
     {
       key: 'swing_trade',

--- a/app/src/lib/tradeScannerApi.ts
+++ b/app/src/lib/tradeScannerApi.ts
@@ -16,7 +16,7 @@ export interface TradeIdea {
   confidence: number;     // 0-10 Pass 2 confidence (same scale as full analysis)
   reason: string;        // AI-generated 1-sentence rationale
   tags: string[];        // e.g. ["momentum", "volume-surge"]
-  mode: 'DAY_TRADE' | 'SWING_TRADE';
+  mode: 'DAY_TRADE' | 'SWING_TRADE' | 'DAY_PENNY';
   // Pass 2 FA-grade levels — carried through so auto-trader can skip redundant FA call
   entryPrice?: number | null;
   stopLoss?: number | null;
@@ -73,7 +73,7 @@ export async function fetchScanEvaluations(): Promise<ScanEvaluations> {
   const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
   try {
     const res = await fetch(
-      `${supabaseUrl}/rest/v1/trade_scans?id=in.(day_trades,swing_trades)&select=auto_evaluations`,
+      `${supabaseUrl}/rest/v1/trade_scans?id=in.(day_trades,swing_trades,penny_trades)&select=auto_evaluations`,
       { headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` } }
     );
     if (!res.ok) return {};
@@ -107,4 +107,20 @@ export async function fetchTradeIdeas(
     throw new Error(data?.error ?? `Scanner request failed: ${res.status}`);
   }
   return data as ScanResult;
+}
+
+export async function fetchPennyTradeIdeas(): Promise<TradeIdea[]> {
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+  const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+  try {
+    const res = await fetch(
+      `${supabaseUrl}/rest/v1/trade_scans?id=eq.penny_trades&select=data`,
+      { headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` } }
+    );
+    if (!res.ok) return [];
+    const rows: Array<{ data: TradeIdea[] }> = await res.json();
+    return rows[0]?.data ?? [];
+  } catch {
+    return [];
+  }
 }

--- a/auto-trader/src/lib/feedback.ts
+++ b/auto-trader/src/lib/feedback.ts
@@ -75,7 +75,7 @@ function generateLesson(
     if (avgConf >= 8) worked.push('High confidence (8+) signals are reliable');
     if (avgConf >= 7 && avgConf < 8) worked.push('7+ confidence met threshold and delivered');
     if (ctx.closeReason === 'target_hit') worked.push('Target price was well-calibrated');
-    if (ctx.duration && ctx.mode === 'DAY_TRADE') {
+    if (ctx.duration && (ctx.mode === 'DAY_TRADE' || ctx.mode === 'DAY_PENNY')) {
       if (ctx.duration < 60) worked.push('Quick execution — momentum was strong');
       else if (ctx.duration > 240) parts.push('Took longer than expected for a day trade');
     }

--- a/auto-trader/src/lib/penny-scanner.ts
+++ b/auto-trader/src/lib/penny-scanner.ts
@@ -1,0 +1,562 @@
+/**
+ * Penny Stock Momentum Scanner — Ross Cameron's mechanical rules.
+ *
+ * Stock selection: $2-$20, float <10M, 25%+ daily gain, 5x relative volume, news catalyst.
+ * Entry: first green candle making new high after pullback, MACD + volume confirm, R:R >= 2:1.
+ * Exit: MACD bearish cross, 9 EMA break, VWAP break, high-volume red candle, topping tail.
+ * Risk: half-size first trade, full after winner, 3 consecutive losses = done for day.
+ *
+ * Runs as a local polling loop during 7:00-10:00 AM ET.
+ * Writes candidates to trade_scans (id: 'penny_trades') for UI visibility.
+ */
+
+import type { AutoTraderConfig } from '../../../shared/config-defaults.js';
+
+// ── Types ────────────────────────────────────────────────
+
+export interface PennyCandidate {
+  ticker: string;
+  price: number;
+  changePct: number;
+  volume: number;
+  avgVolume: number;
+  relativeVolume: number;
+  float: number | null;
+  hasCatalyst: boolean;
+  catalystHeadline: string | null;
+  rank: number;
+  discoveredAt: number;
+}
+
+export interface PennySessionState {
+  date: string;
+  wins: number;
+  losses: number;
+  consecutiveLosses: number;
+  totalTrades: number;
+  lastTradeWon: boolean | null;
+  dailyPnl: number;
+  peakDailyPnl: number;
+  done: boolean;
+  doneReason: string | null;
+}
+
+interface PennyEntrySignal {
+  ticker: string;
+  entryPrice: number;
+  stopLoss: number;
+  targetPrice: number;
+  riskReward: number;
+  pullbackNumber: number;
+  macdHistogram: number;
+  greenVolume: number;
+  redAvgVolume: number;
+}
+
+// ── Constants ────────────────────────────────────────────
+
+const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+const YAHOO_HEADERS = {
+  'User-Agent': 'Mozilla/5.0 (compatible; PortfolioAssistant/1.0)',
+  Accept: 'application/json',
+};
+const TIMEOUT_MS = 12_000;
+
+const PRICE_MIN = 2;
+const PRICE_MAX = 20;
+const MIN_CHANGE_PCT = 25;
+const MIN_VOLUME = 500_000;
+const MIN_RELATIVE_VOLUME = 5;
+const MAX_FLOAT_MILLIONS = 10;
+const MIN_RR = 2.0;
+const MAX_PULLBACKS = 2;
+
+// ── Rate-limited Finnhub fetch ───────────────────────────
+
+let _lastFinnhubCall = 0;
+const FINNHUB_GAP_MS = 900;
+
+async function fetchFinnhub<T>(url: string): Promise<T | null> {
+  const wait = FINNHUB_GAP_MS - (Date.now() - _lastFinnhubCall);
+  if (wait > 0) await new Promise(r => setTimeout(r, wait));
+  _lastFinnhubCall = Date.now();
+  try {
+    const res = await fetch(url, {
+      headers: YAHOO_HEADERS,
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    return await res.json() as T;
+  } catch {
+    return null;
+  }
+}
+
+// ── Session State ────────────────────────────────────────
+
+let _session: PennySessionState = makeEmptySession();
+
+function makeEmptySession(): PennySessionState {
+  return {
+    date: getETDateString(),
+    wins: 0,
+    losses: 0,
+    consecutiveLosses: 0,
+    totalTrades: 0,
+    lastTradeWon: null,
+    dailyPnl: 0,
+    peakDailyPnl: 0,
+    done: false,
+    doneReason: null,
+  };
+}
+
+function getETDateString(): string {
+  return new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+}
+
+export function getPennySessionState(): PennySessionState {
+  const today = getETDateString();
+  if (_session.date !== today) _session = makeEmptySession();
+  return _session;
+}
+
+export function resetPennySession(): void {
+  _session = makeEmptySession();
+}
+
+export function recordPennyTradeResult(pnl: number, config: AutoTraderConfig): void {
+  const session = getPennySessionState();
+  session.totalTrades++;
+  session.dailyPnl += pnl;
+  if (session.dailyPnl > session.peakDailyPnl) session.peakDailyPnl = session.dailyPnl;
+
+  if (pnl > 0) {
+    session.wins++;
+    session.consecutiveLosses = 0;
+    session.lastTradeWon = true;
+  } else {
+    session.losses++;
+    session.consecutiveLosses++;
+    session.lastTradeWon = false;
+  }
+
+  // Guard rails
+  if (session.consecutiveLosses >= 3) {
+    session.done = true;
+    session.doneReason = '3 consecutive losses';
+  }
+  if (session.dailyPnl <= -(config.pennyMaxDailyLoss || 200)) {
+    session.done = true;
+    session.doneReason = `max daily loss hit ($${config.pennyMaxDailyLoss || 200})`;
+  }
+  if (session.peakDailyPnl > 50 && session.dailyPnl < session.peakDailyPnl * 0.5) {
+    session.done = true;
+    session.doneReason = 'gave back 50% of daily profit';
+  }
+  if (session.totalTrades >= (config.pennyMaxDailyTrades || 10)) {
+    session.done = true;
+    session.doneReason = `max daily trades hit (${config.pennyMaxDailyTrades || 10})`;
+  }
+}
+
+// ── Position Sizing ──────────────────────────────────────
+
+export function pennyPositionSize(config: AutoTraderConfig): number {
+  const session = getPennySessionState();
+  const fullSize = config.pennyPositionSize || 200;
+  if (session.totalTrades === 0) return fullSize * 0.5;
+  if (session.lastTradeWon) return fullSize;
+  return fullSize * 0.5;
+}
+
+// ── Discovery: Yahoo Gainers + Finnhub Enrichment ────────
+
+interface YahooScreenerQuote {
+  symbol: string;
+  regularMarketPrice?: { raw?: number } | number;
+  regularMarketVolume?: { raw?: number } | number;
+  regularMarketChangePercent?: { raw?: number } | number;
+  averageDailyVolume10Day?: { raw?: number } | number;
+}
+
+function rawVal(v: unknown): number {
+  if (typeof v === 'number') return v;
+  if (v && typeof v === 'object' && 'raw' in v) return (v as { raw: number }).raw ?? 0;
+  return 0;
+}
+
+export async function runPennyDiscovery(): Promise<PennyCandidate[]> {
+  // Step 1: Yahoo day_gainers screener
+  const gainers = await fetchYahooGainers();
+  if (!gainers.length) return [];
+
+  // Step 2: Filter by Cameron's price + change + volume criteria
+  const filtered = gainers.filter(q => {
+    const price = rawVal(q.regularMarketPrice);
+    const vol = rawVal(q.regularMarketVolume);
+    const changePct = rawVal(q.regularMarketChangePercent);
+    return price >= PRICE_MIN && price <= PRICE_MAX
+      && changePct >= MIN_CHANGE_PCT
+      && vol >= MIN_VOLUME;
+  });
+
+  if (!filtered.length) return [];
+
+  // Step 3: Enrich with Finnhub (float, news, relative volume)
+  const candidates: PennyCandidate[] = [];
+  for (const q of filtered.slice(0, 10)) {
+    const ticker = q.symbol;
+    const price = rawVal(q.regularMarketPrice);
+    const volume = rawVal(q.regularMarketVolume);
+    const changePct = rawVal(q.regularMarketChangePercent);
+    const avgVolume = rawVal(q.averageDailyVolume10Day);
+    const relativeVolume = avgVolume > 0 ? volume / avgVolume : 0;
+
+    if (relativeVolume < MIN_RELATIVE_VOLUME) continue;
+
+    // Float check via Finnhub
+    const floatShares = await getFloat(ticker);
+    if (floatShares != null && floatShares > MAX_FLOAT_MILLIONS) continue;
+
+    // News catalyst check
+    const { hasCatalyst, headline } = await checkNewsCatalyst(ticker);
+
+    candidates.push({
+      ticker,
+      price,
+      changePct,
+      volume,
+      avgVolume,
+      relativeVolume,
+      float: floatShares,
+      hasCatalyst,
+      catalystHeadline: headline,
+      rank: 0,
+      discoveredAt: Date.now(),
+    });
+  }
+
+  // Rank by % change, take top 3
+  candidates.sort((a, b) => b.changePct - a.changePct);
+  candidates.forEach((c, i) => { c.rank = i + 1; });
+  return candidates.slice(0, 3);
+}
+
+async function fetchYahooGainers(): Promise<YahooScreenerQuote[]> {
+  try {
+    const url = new URL('https://query1.finance.yahoo.com/v1/finance/screener/predefined/saved');
+    url.searchParams.set('formatted', 'false');
+    url.searchParams.set('scrIds', 'day_gainers');
+    url.searchParams.set('start', '0');
+    url.searchParams.set('count', '25');
+    url.searchParams.set('lang', 'en-US');
+    url.searchParams.set('region', 'US');
+    const res = await fetch(url.toString(), {
+      headers: YAHOO_HEADERS,
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) return [];
+    const data = await res.json() as Record<string, unknown>;
+    const result = (data?.finance as Record<string, unknown>)?.result as Record<string, unknown>[] | undefined;
+    const quotes = result?.[0]?.quotes as YahooScreenerQuote[] | undefined;
+    return quotes ?? [];
+  } catch {
+    return [];
+  }
+}
+
+async function getFloat(ticker: string): Promise<number | null> {
+  if (!FINNHUB_KEY) return null;
+  const metric = await fetchFinnhub<{ metric?: { shareFloat?: number } }>(
+    `https://finnhub.io/api/v1/stock/metric?symbol=${ticker}&metric=all&token=${FINNHUB_KEY}`
+  );
+  if (metric?.metric?.shareFloat) return metric.metric.shareFloat;
+
+  const profile = await fetchFinnhub<{ shareOutstanding?: number }>(
+    `https://finnhub.io/api/v1/stock/profile2?symbol=${ticker}&token=${FINNHUB_KEY}`
+  );
+  return profile?.shareOutstanding ?? null;
+}
+
+async function checkNewsCatalyst(ticker: string): Promise<{ hasCatalyst: boolean; headline: string | null }> {
+  if (!FINNHUB_KEY) return { hasCatalyst: false, headline: null };
+  const today = getETDateString();
+  const news = await fetchFinnhub<Array<{ headline?: string; datetime?: number }>>(
+    `https://finnhub.io/api/v1/company-news?symbol=${ticker}&from=${today}&to=${today}&token=${FINNHUB_KEY}`
+  );
+  if (!news?.length) return { hasCatalyst: false, headline: null };
+
+  // Only count news from the last 2 hours
+  const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+  const recent = news.filter(n => (n.datetime ?? 0) * 1000 > twoHoursAgo);
+  return {
+    hasCatalyst: recent.length > 0,
+    headline: recent[0]?.headline ?? news[0]?.headline ?? null,
+  };
+}
+
+// ── Entry Signal: Pullback Pattern on 1-min Candles ──────
+
+interface IntradayBar {
+  t: number;
+  o: number;
+  h: number;
+  l: number;
+  c: number;
+  v: number;
+}
+
+async function fetch1mCandles(ticker: string): Promise<IntradayBar[]> {
+  try {
+    const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(ticker)}?range=1d&interval=1m&includePrePost=false`;
+    const res = await fetch(url, {
+      headers: YAHOO_HEADERS,
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) return [];
+    const data = await res.json() as Record<string, unknown>;
+    const result = (data?.chart as Record<string, unknown>)?.result as Record<string, unknown>[] | undefined;
+    if (!result?.[0]) return [];
+
+    const r = result[0];
+    const timestamps = r.timestamp as number[] | undefined;
+    if (!timestamps?.length) return [];
+
+    const q = ((r.indicators as Record<string, unknown>)?.quote as Record<string, unknown>[])?.[0] ?? {};
+    const opens   = (q.open   as (number | null)[]) ?? [];
+    const highs   = (q.high   as (number | null)[]) ?? [];
+    const lows    = (q.low    as (number | null)[]) ?? [];
+    const closes  = (q.close  as (number | null)[]) ?? [];
+    const volumes = (q.volume as (number | null)[]) ?? [];
+
+    const bars: IntradayBar[] = [];
+    for (let i = 0; i < timestamps.length; i++) {
+      const c = closes[i];
+      if (c == null) continue;
+      bars.push({
+        t: timestamps[i],
+        o: opens[i] ?? c,
+        h: highs[i] ?? c,
+        l: lows[i] ?? c,
+        c,
+        v: volumes[i] ?? 0,
+      });
+    }
+    return bars;
+  } catch {
+    return [];
+  }
+}
+
+function computeSimpleMACD(bars: IntradayBar[]): { histogram: number; signal: number } | null {
+  if (bars.length < 26) return null;
+  const closes = bars.map(b => b.c);
+  const ema12 = emaCalc(closes, 12);
+  const ema26 = emaCalc(closes, 26);
+  if (ema12 == null || ema26 == null) return null;
+
+  const macdLine = ema12 - ema26;
+  // Approximate signal line from recent MACD values
+  const recentMacd: number[] = [];
+  for (let i = Math.max(0, closes.length - 9); i < closes.length; i++) {
+    const e12 = emaCalc(closes.slice(0, i + 1), 12);
+    const e26 = emaCalc(closes.slice(0, i + 1), 26);
+    if (e12 != null && e26 != null) recentMacd.push(e12 - e26);
+  }
+  const signalLine = recentMacd.length >= 9 ? emaCalc(recentMacd, 9) ?? macdLine : macdLine;
+  return { histogram: macdLine - signalLine, signal: signalLine };
+}
+
+function emaCalc(data: number[], period: number): number | null {
+  if (data.length < period) return null;
+  const k = 2 / (period + 1);
+  let prev = 0;
+  for (let i = 0; i < period; i++) prev += data[i];
+  prev /= period;
+  for (let i = period; i < data.length; i++) {
+    prev = data[i] * k + prev * (1 - k);
+  }
+  return prev;
+}
+
+function ema9Value(bars: IntradayBar[]): number | null {
+  if (bars.length < 9) return null;
+  return emaCalc(bars.map(b => b.c), 9);
+}
+
+function computeVWAP(bars: IntradayBar[]): number | null {
+  if (!bars.length) return null;
+  let cumPV = 0;
+  let cumV = 0;
+  for (const b of bars) {
+    const typical = (b.h + b.l + b.c) / 3;
+    cumPV += typical * b.v;
+    cumV += b.v;
+  }
+  return cumV > 0 ? cumPV / cumV : null;
+}
+
+/**
+ * Detect pullback entry pattern on 1-min candles.
+ * Finds the Nth pullback (sequence of red candles → green candle making new high).
+ */
+function findPullbackEntries(bars: IntradayBar[]): PennyEntrySignal[] {
+  if (bars.length < 10) return [];
+
+  const entries: PennyEntrySignal[] = [];
+  let pullbackCount = 0;
+  let i = 5; // skip first few bars to let price establish
+
+  while (i < bars.length - 1) {
+    // Look for red candle(s) = pullback
+    const pullbackStart = i;
+    let redMaxVol = 0;
+    let pullbackLow = Infinity;
+
+    while (i < bars.length && bars[i].c < bars[i].o) {
+      redMaxVol = Math.max(redMaxVol, bars[i].v);
+      pullbackLow = Math.min(pullbackLow, bars[i].l);
+      i++;
+    }
+
+    // Need at least 1 red candle for a pullback
+    if (i === pullbackStart) { i++; continue; }
+    if (i >= bars.length) break;
+
+    // Current bar should be green: close > open
+    const greenBar = bars[i];
+    if (greenBar.c <= greenBar.o) { i++; continue; }
+
+    // Green candle must make new high vs prior candle's high
+    const priorHigh = bars[i - 1].h;
+    if (greenBar.h <= priorHigh) { i++; continue; }
+
+    // Volume confirmation: green candle volume > avg red candle volume
+    const redCount = i - pullbackStart;
+    const redAvgVol = redCount > 0 ? redMaxVol / redCount * redCount : 0;
+    // Simplified: green volume must exceed max red volume
+    if (greenBar.v <= redMaxVol * 0.8) { i++; continue; }
+
+    pullbackCount++;
+
+    // High of day up to this point
+    let hod = 0;
+    for (let j = 0; j <= i; j++) hod = Math.max(hod, bars[j].h);
+
+    const entry = greenBar.c;
+    const stop = pullbackLow;
+    const target = hod;
+    const risk = entry - stop;
+    const reward = target - entry;
+
+    if (risk > 0 && reward / risk >= MIN_RR) {
+      entries.push({
+        ticker: '',
+        entryPrice: entry,
+        stopLoss: stop,
+        targetPrice: target,
+        riskReward: reward / risk,
+        pullbackNumber: pullbackCount,
+        macdHistogram: 0,
+        greenVolume: greenBar.v,
+        redAvgVolume: redAvgVol,
+      });
+    }
+
+    i++;
+  }
+
+  return entries;
+}
+
+export async function checkPennyEntry(candidate: PennyCandidate): Promise<PennyEntrySignal | null> {
+  const bars = await fetch1mCandles(candidate.ticker);
+  if (bars.length < 30) return null;
+
+  // MACD must be positive
+  const macd = computeSimpleMACD(bars);
+  if (!macd || macd.histogram <= 0) return null;
+
+  // Find pullback entries
+  const entries = findPullbackEntries(bars);
+
+  // Only trade 1st and 2nd pullbacks
+  const eligible = entries.filter(e => e.pullbackNumber <= MAX_PULLBACKS);
+  if (!eligible.length) return null;
+
+  // Take the latest eligible entry
+  const signal = eligible[eligible.length - 1];
+  signal.ticker = candidate.ticker;
+  signal.macdHistogram = macd.histogram;
+  return signal;
+}
+
+// ── Exit Signal Monitoring ───────────────────────────────
+
+export interface PennyExitSignal {
+  ticker: string;
+  reasons: string[];
+}
+
+export async function checkPennyExit(ticker: string, entryPrice: number): Promise<PennyExitSignal | null> {
+  const bars = await fetch1mCandles(ticker);
+  if (bars.length < 10) return null;
+
+  const reasons: string[] = [];
+  const lastBar = bars[bars.length - 1];
+  const prevBar = bars.length >= 2 ? bars[bars.length - 2] : null;
+
+  // 1. MACD crossover to negative
+  const macd = computeSimpleMACD(bars);
+  if (macd && macd.histogram < 0) {
+    reasons.push('MACD crossed negative');
+  }
+
+  // 2. High-volume red candle
+  if (lastBar.c < lastBar.o) {
+    const avgVol = bars.slice(-10).reduce((s, b) => s + b.v, 0) / Math.min(bars.length, 10);
+    if (lastBar.v > avgVol * 2) {
+      reasons.push('High-volume red candle');
+    }
+  }
+
+  // 3. Price below 9 EMA
+  const ema9 = ema9Value(bars);
+  if (ema9 != null && lastBar.c < ema9) {
+    reasons.push('Below 9 EMA');
+  }
+
+  // 4. Price below VWAP
+  const vwap = computeVWAP(bars);
+  if (vwap != null && lastBar.c < vwap) {
+    reasons.push('Below VWAP');
+  }
+
+  // 5. Topping tail / doji
+  if (prevBar) {
+    const body = Math.abs(lastBar.c - lastBar.o);
+    const upperWick = lastBar.h - Math.max(lastBar.c, lastBar.o);
+    if (body > 0 && upperWick > body * 2) {
+      reasons.push('Topping tail');
+    }
+    if (body < (lastBar.h - lastBar.l) * 0.1 && (lastBar.h - lastBar.l) > 0) {
+      reasons.push('Doji candle');
+    }
+  }
+
+  return reasons.length > 0 ? { ticker, reasons } : null;
+}
+
+// ── Helpers for scheduler integration ────────────────────
+
+export function isPennySessionDone(): boolean {
+  return getPennySessionState().done;
+}
+
+export function getPennySessionSummary(): string {
+  const s = getPennySessionState();
+  const parts = [`W:${s.wins} L:${s.losses} PnL:$${s.dailyPnl.toFixed(0)}`];
+  if (s.done) parts.push(`(done: ${s.doneReason})`);
+  return parts.join(' ');
+}

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -105,6 +105,10 @@ export async function loadConfig(): Promise<AutoTraderConfig> {
     tradeSignalsEnabled: data.trade_signals_enabled ?? DEFAULT_CONFIG.tradeSignalsEnabled,
     suggestedFindsEnabled: data.suggested_finds_enabled ?? DEFAULT_CONFIG.suggestedFindsEnabled,
     optionsWheelEnabled: data.options_wheel_enabled ?? DEFAULT_CONFIG.optionsWheelEnabled,
+    pennyEnabled: data.penny_enabled ?? DEFAULT_CONFIG.pennyEnabled,
+    pennyPositionSize: Number(data.penny_position_size ?? DEFAULT_CONFIG.pennyPositionSize),
+    pennyMaxDailyLoss: Number(data.penny_max_daily_loss ?? DEFAULT_CONFIG.pennyMaxDailyLoss),
+    pennyMaxDailyTrades: Number(data.penny_max_daily_trades ?? DEFAULT_CONFIG.pennyMaxDailyTrades),
   };
 }
 
@@ -143,7 +147,7 @@ export interface ExternalStrategySignal {
   strategy_video_heading: string | null;
   ticker: string;
   signal: 'BUY' | 'SELL';
-  mode: 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL';
+  mode: 'DAY_TRADE' | 'DAY_PENNY' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL';
   confidence: number;
   entry_price: number | null;
   stop_loss: number | null;
@@ -327,7 +331,7 @@ export async function getTickerWinRate(
     .select('pnl')
     .eq('ticker', ticker)
     .eq('status', 'CLOSED')
-    .in('mode', ['DAY_TRADE', 'SWING_TRADE'])
+    .in('mode', ['DAY_TRADE', 'DAY_PENNY', 'SWING_TRADE'])
     .not('pnl', 'is', null)
     .neq('pnl', 0)
     .gte('closed_at', since);
@@ -436,7 +440,7 @@ export async function findExternalStrategySignal(params: {
   sourceName: string;
   ticker: string;
   signal: 'BUY' | 'SELL';
-  mode: 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL';
+  mode: 'DAY_TRADE' | 'DAY_PENNY' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL';
   executeOnDate: string;
   strategyVideoId?: string;
 }): Promise<ExternalStrategySignal | null> {
@@ -593,7 +597,7 @@ export async function getStrategySourcePerformance(): Promise<StrategySourcePerf
 
 export async function getRecentClosedStrategyOutcomes(params: {
   sourceName: string;
-  mode?: 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL';
+  mode?: 'DAY_TRADE' | 'DAY_PENNY' | 'SWING_TRADE' | 'LONG_TERM' | 'OPTIONS_PUT' | 'OPTIONS_CALL';
   strategyVideoId?: string | null;
   limit?: number;
 }): Promise<StrategyClosedTradeOutcome[]> {

--- a/auto-trader/src/lib/tradePerformanceLog.ts
+++ b/auto-trader/src/lib/tradePerformanceLog.ts
@@ -158,8 +158,8 @@ export async function logClosedTradePerformance(
   context?: LogContext
 ): Promise<void> {
   if (!closedTrade.closed_at) return;
-  const strategy = closedTrade.mode as 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM';
-  if (!['DAY_TRADE', 'SWING_TRADE', 'LONG_TERM'].includes(strategy)) return;
+  const strategy = closedTrade.mode as 'DAY_TRADE' | 'DAY_PENNY' | 'SWING_TRADE' | 'LONG_TERM';
+  if (!['DAY_TRADE', 'DAY_PENNY', 'SWING_TRADE', 'LONG_TERM'].includes(strategy)) return;
   if ((closedTrade.notes ?? '').startsWith('Dip buy')) return; // skip dip-buy add-ons
 
   const entryDatetime = closedTrade.filled_at ?? closedTrade.opened_at ?? closedTrade.created_at;
@@ -191,7 +191,7 @@ export async function logClosedTradePerformance(
 
   let maxRunupPct: number | null = null;
   let maxDrawdownPct: number | null = null;
-  if (entryPrice != null && entryPrice > 0 && strategy !== 'DAY_TRADE') {
+  if (entryPrice != null && entryPrice > 0 && strategy !== 'DAY_TRADE' && strategy !== 'DAY_PENNY') {
     try {
       const from = new Date(entryDatetime);
       const to = new Date(exitDatetime);

--- a/auto-trader/src/routes/strategies.ts
+++ b/auto-trader/src/routes/strategies.ts
@@ -17,7 +17,7 @@ import {
 const router = Router();
 
 const VALID_SIGNALS = new Set(['BUY', 'SELL']);
-const VALID_MODES = new Set(['DAY_TRADE', 'SWING_TRADE', 'LONG_TERM']);
+const VALID_MODES = new Set(['DAY_TRADE', 'DAY_PENNY', 'SWING_TRADE', 'LONG_TERM']);
 const VALID_STATUSES = new Set(['PENDING', 'EXECUTED', 'FAILED', 'SKIPPED', 'EXPIRED', 'CANCELLED']);
 
 function parseOptionalNumber(value: unknown): number | null {

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -91,6 +91,17 @@ import { getEconDayProfile } from './lib/econ-calendar.js';
 import { warmPositionPriceCache } from './routes/positions.js';
 import { generateMorningBrief } from './lib/morning-brief.js';
 import { validateOrder } from './lib/validateOrder.js';
+import {
+  runPennyDiscovery,
+  checkPennyEntry,
+  checkPennyExit,
+  getPennySessionState,
+  isPennySessionDone,
+  getPennySessionSummary,
+  recordPennyTradeResult,
+  pennyPositionSize,
+  type PennyCandidate,
+} from './lib/penny-scanner.js';
 
 // ── Types ────────────────────────────────────────────────
 
@@ -607,7 +618,7 @@ async function closeAllDayTrades(config: AutoTraderConfig): Promise<void> {
   // Include SUBMITTED + PARTIAL — IB fill confirmations sometimes don't write back before
   // the EOD sweep fires, leaving orders in SUBMITTED state. At 3:55 PM ET the position is
   // effectively closed by IB regardless; mark them closed in paper_trades too.
-  const dayTrades = activeTrades.filter(t => t.mode === 'DAY_TRADE' && ['FILLED', 'SUBMITTED', 'PARTIAL'].includes(t.status));
+  const dayTrades = activeTrades.filter(t => (t.mode === 'DAY_TRADE' || t.mode === 'DAY_PENNY') && ['FILLED', 'SUBMITTED', 'PARTIAL'].includes(t.status));
 
   if (dayTrades.length === 0) {
     log('EOD sweep: no open day trades');
@@ -715,7 +726,7 @@ async function closeAllDayTrades(config: AutoTraderConfig): Promise<void> {
 
 async function softCloseDayTrades(positions: EnrichedPosition[]): Promise<void> {
   const activeTrades = await getActiveTrades();
-  const dayTrades = activeTrades.filter(t => t.mode === 'DAY_TRADE' && ['FILLED', 'SUBMITTED', 'PARTIAL'].includes(t.status));
+  const dayTrades = activeTrades.filter(t => (t.mode === 'DAY_TRADE' || t.mode === 'DAY_PENNY') && ['FILLED', 'SUBMITTED', 'PARTIAL'].includes(t.status));
   if (dayTrades.length === 0) return;
 
   log(`[SoftClose] Checking ${dayTrades.length} open day trade(s) before power hour`);
@@ -2458,7 +2469,7 @@ function calculatePositionSize(
   config: AutoTraderConfig,
   params: {
     price: number;
-    mode: 'LONG_TERM' | 'DAY_TRADE' | 'SWING_TRADE' | 'OPTIONS_PUT' | 'OPTIONS_CALL';
+    mode: 'LONG_TERM' | 'DAY_TRADE' | 'DAY_PENNY' | 'SWING_TRADE' | 'OPTIONS_PUT' | 'OPTIONS_CALL';
     conviction?: number;
     suggestedFindTag?: 'Steady Compounder' | 'Gold Mine' | 'Dip Discovery';
     entryPrice?: number;
@@ -2478,7 +2489,9 @@ function calculatePositionSize(
   // sizing or risk-based formula. The risk-based formula can balloon when stops are tight
   // (e.g. $2 stop on a $200 stock → 2,750 shares), causing outsized day-trade losses.
   // Swing and long-term trades keep the larger allocation-based cap.
-  const modeMaxDollar = mode === 'DAY_TRADE' ? config.positionSize : hardMaxDollar;
+  const modeMaxDollar = mode === 'DAY_PENNY' ? config.pennyPositionSize
+    : mode === 'DAY_TRADE' ? config.positionSize
+    : hardMaxDollar;
 
   if (!config.useDynamicSizing || price <= 0) {
     const cappedSize = Math.min(config.positionSize, modeMaxDollar);
@@ -6094,6 +6107,150 @@ async function runSchedulerCycle(): Promise<void> {
       }
     } catch (err) {
       log(`[SpxScanner] Error: ${err instanceof Error ? err.message : 'unknown'}`);
+    }
+
+    // 12b. Penny stock momentum scanner (Ross Cameron's mechanical rules)
+    if (!config.pennyEnabled) {
+      // silent skip
+    } else {
+      try {
+        const etNow = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
+        const etMins = etNow.getHours() * 60 + etNow.getMinutes();
+        // Active window: 9:35 AM - 10:00 AM ET (regular hours only for now)
+        if (etMins >= 9 * 60 + 35 && etMins <= 10 * 60) {
+          if (isPennySessionDone()) {
+            log(`[PennyScanner] Session done: ${getPennySessionSummary()}`);
+          } else {
+            // Discovery: find candidates
+            const pennyCandidates = await runPennyDiscovery();
+            if (pennyCandidates.length > 0) {
+              log(`[PennyScanner] Found ${pennyCandidates.length} candidate(s): ${pennyCandidates.map(c => `${c.ticker}(+${c.changePct.toFixed(0)}%)`).join(', ')}`);
+
+              // Write to trade_scans for UI visibility
+              const sb = getSupabase();
+              const scanData = pennyCandidates.map(c => ({
+                ticker: c.ticker,
+                name: c.ticker,
+                price: c.price,
+                change: 0,
+                changePercent: c.changePct,
+                signal: 'BUY' as const,
+                confidence: 8,
+                reason: `Penny momentum: +${c.changePct.toFixed(0)}%, ${c.relativeVolume.toFixed(1)}x vol${c.hasCatalyst ? `, catalyst: ${c.catalystHeadline?.slice(0, 60)}` : ''}${c.float ? `, float ${c.float.toFixed(1)}M` : ''}`,
+                tags: ['penny_momentum'],
+                mode: 'DAY_PENNY' as const,
+              }));
+              await sb.from('trade_scans').upsert({
+                id: 'penny_trades',
+                data: scanData,
+                scanned_at: new Date().toISOString(),
+                expires_at: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+              });
+
+              // Check entry signals and execute
+              const pennySession = getPennySessionState();
+              const activeCount = await countActivePositions();
+              const slots = config.maxPositions - activeCount;
+
+              for (const candidate of pennyCandidates) {
+                if (slots <= 0) break;
+                if (pennySession.done) break;
+                if (await hasActiveTrade(candidate.ticker, { excludeOptions: true })) continue;
+
+                const entry = await checkPennyEntry(candidate);
+                if (!entry) continue;
+
+                const posSize = pennyPositionSize(config);
+                const qty = Math.max(1, Math.floor(posSize / entry.entryPrice));
+                if (qty <= 0) continue;
+
+                log(`[PennyScanner] Entry signal: ${candidate.ticker} @ $${entry.entryPrice.toFixed(2)}, stop $${entry.stopLoss.toFixed(2)}, target $${entry.targetPrice.toFixed(2)}, R:R ${entry.riskReward.toFixed(1)}`);
+
+                try {
+                  const orderResult = await placeBracketOrder({
+                    symbol: candidate.ticker,
+                    side: 'BUY',
+                    quantity: qty,
+                    entryPrice: entry.entryPrice,
+                    stopLoss: entry.stopLoss,
+                    takeProfit: entry.targetPrice,
+                    tif: 'DAY',
+                  });
+
+                  await createPaperTrade({
+                    ticker: candidate.ticker,
+                    mode: 'DAY_PENNY',
+                    signal: 'BUY',
+                    entry_price: entry.entryPrice,
+                    stop_loss: entry.stopLoss,
+                    target_price: entry.targetPrice,
+                    risk_reward: `${entry.riskReward.toFixed(1)}:1`,
+                    quantity: qty,
+                    position_size: qty * entry.entryPrice,
+                    status: 'SUBMITTED',
+                    ib_order_id: String(orderResult.parentOrderId),
+                    ib_parent_order_id: String(orderResult.parentOrderId),
+                    ib_tp_order_id: String(orderResult.takeProfitOrderId),
+                    ib_sl_order_id: String(orderResult.stopLossOrderId),
+                    scanner_reason: `Penny momentum: +${candidate.changePct.toFixed(0)}%, pullback #${entry.pullbackNumber}, MACD hist ${entry.macdHistogram.toFixed(4)}`,
+                    notes: `Penny trade #${pennySession.totalTrades + 1} of day. Session: ${getPennySessionSummary()}`,
+                    opened_at: new Date().toISOString(),
+                  });
+
+                  persistEvent(candidate.ticker, 'success',
+                    `Penny BUY: ${qty} shares @ $${entry.entryPrice.toFixed(2)}, R:R ${entry.riskReward.toFixed(1)}:1`, {
+                      source: 'penny_scanner',
+                      mode: 'DAY_PENNY',
+                    });
+
+                  log(`[PennyScanner] Executed: ${candidate.ticker} ${qty} shares @ $${entry.entryPrice.toFixed(2)}`);
+                } catch (err) {
+                  log(`[PennyScanner] Order failed for ${candidate.ticker}: ${err instanceof Error ? err.message : 'unknown'}`);
+                  persistEvent(candidate.ticker, 'error',
+                    `Penny order failed: ${err instanceof Error ? err.message : 'unknown'}`, {
+                      source: 'penny_scanner',
+                      mode: 'DAY_PENNY',
+                    });
+                }
+              }
+            } else {
+              log('[PennyScanner] No candidates found this cycle');
+            }
+
+            // Exit monitoring for open penny positions
+            const activeTrades = await getActiveTrades();
+            const pennyTrades = activeTrades.filter(t => t.mode === 'DAY_PENNY' && t.status === 'FILLED');
+            for (const trade of pennyTrades) {
+              const exitSignal = await checkPennyExit(trade.ticker, trade.entry_price ?? 0);
+              if (exitSignal) {
+                log(`[PennyScanner] Exit signal for ${trade.ticker}: ${exitSignal.reasons.join(', ')}`);
+                try {
+                  const closeSide = 'SELL';
+                  const qty = trade.quantity ?? 0;
+                  if (qty > 0) {
+                    await placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });
+                    await updatePaperTrade(trade.id, {
+                      status: 'CLOSED',
+                      close_reason: 'eod_close',
+                      closed_at: new Date().toISOString(),
+                      notes: `${trade.notes ?? ''} | Exit: ${exitSignal.reasons.join(', ')}`,
+                    });
+                    persistEvent(trade.ticker, 'success',
+                      `Penny exit: ${exitSignal.reasons.join(', ')}`, {
+                        source: 'penny_scanner',
+                        mode: 'DAY_PENNY',
+                      });
+                  }
+                } catch (err) {
+                  log(`[PennyScanner] Exit failed for ${trade.ticker}: ${err instanceof Error ? err.message : 'unknown'}`);
+                }
+              }
+            }
+          }
+        }
+      } catch (err) {
+        log(`[PennyScanner] Error: ${err instanceof Error ? err.message : 'unknown'}`);
+      }
     }
 
     // 13. Options wheel — manage open positions (every cycle, 30-min intervals)

--- a/docs/features/penny-stock-scanner.md
+++ b/docs/features/penny-stock-scanner.md
@@ -1,0 +1,267 @@
+# Penny Stock Momentum Scanner (DAY_PENNY)
+
+> Design doc — Ross Cameron's momentum strategy adapted for the auto-trader
+
+## Overview
+
+A dedicated penny stock momentum scanner that identifies low-float, high-momentum stocks using Ross Cameron's mechanical rules. Runs as a separate pipeline alongside the existing large-cap scanner, with its own discovery, entry confirmation, exit monitoring, position sizing, and P&L tracking.
+
+**Key principle:** This is a paper account experiment. Build with execution from day one, learn from real fills, tune from real data.
+
+## Strategy Rules (Source: Ross Cameron / Warrior Trading)
+
+### Stock Selection — "5 Pillars"
+
+| # | Criterion | Threshold | Automatable? |
+|---|-----------|-----------|:------------:|
+| 1 | Price range | $2–$20 (sweet spot $2–$10) | Yes |
+| 2 | Float | < 10M shares | Yes |
+| 3 | Daily gain | ≥ 25% | Yes |
+| 4 | News catalyst | Breaking news within 2 hours | Partial (AI) |
+| 5 | Relative volume | ≥ 5x vs 20-day average | Yes |
+| 6 | Visibility | Top 3 leading % gainers | Yes |
+
+### Entry Rules
+
+- Wait for first pullback after initial surge (1–2 red candles)
+- Entry: first green candle making new high vs prior candle high
+- Stop loss: low of the pullback
+- Target: retest of high of day (minimum 2:1 R:R)
+- **Both MACD and volume must confirm** — if either says no, skip
+- MACD must be positive (blue line above orange line)
+- Volume: green candle volume must exceed red candle volume
+- Trade only 1st and 2nd pullbacks, skip 3rd+
+
+### Exit Indicators (any one triggers exit)
+
+1. High volume red candle
+2. MACD crossover to negative
+3. Topping tail / doji candle
+4. Price breaks below VWAP
+5. Price breaks below 9 EMA
+6. Level 2: big seller / burst of red on time & sales (**human only — not automatable**)
+
+### Risk Management
+
+- First trade of day: half size
+- If first trade wins → full size on next trade
+- If first trade loses → stay at half size
+- 3 consecutive losses = done for the day
+- Give back half of daily profit = walk away
+- Max daily loss cap (configurable, default -$200)
+- Max daily trades cap (configurable, default 10)
+
+### Time Window
+
+- Active: 7:00–10:00 AM ET (pre-market + first 30 min of regular session)
+- Pre-market (7:00–9:30) has no circuit breaker halts — cleaner price action
+- Regular hours halts (LULD): 10% bands for stocks > $3, 20% bands for $0.75–$3
+
+### Moving Averages
+
+- 9 EMA (primary trend on 1-min chart)
+- 20 EMA (secondary)
+- 200 EMA (long-term context)
+- VWAP (intraday support/resistance)
+
+## Architecture
+
+### Where It Lives
+
+The penny scanner fits into the existing trade signals pipeline as a new category:
+
+```
+┌──────────────────── trade_scans table ────────────────────┐
+│                                                            │
+│  id: 'day_trades'    ← existing large-cap day trades       │
+│  id: 'swing_trades'  ← existing swing trades               │
+│  id: 'penny_trades'  ← NEW: penny momentum candidates      │
+│                                                            │
+└────────────────────────────────────────────────────────────┘
+         │                    │                    │
+         ▼                    ▼                    ▼
+┌─────────────── Trade Ideas UI (TradeIdeas.tsx) ───────────┐
+│                                                            │
+│  [Day Trades]  [Swing Trades]  [Key Levels]  [Penny ★]    │
+│   (amber)       (blue)          (violet)      (NEW tab)    │
+│                                                            │
+└────────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────── auto-trader (scheduler.ts) ────────────────┐
+│                                                            │
+│  subscribeToTradeScans() ← Realtime on trade_scans         │
+│       │                                                    │
+│       ├── executeScannerTrade()   ← existing (large-cap)   │
+│       └── executePennyTrade()    ← NEW (penny rules)       │
+│                                                            │
+└────────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────── paper_trades ──────────────────────────────┐
+│                                                            │
+│  mode: 'DAY_TRADE'   ← existing                           │
+│  mode: 'SWING_TRADE' ← existing                           │
+│  mode: 'DAY_PENNY'   ← NEW: separate P&L tracking         │
+│                                                            │
+└────────────────────────────────────────────────────────────┘
+```
+
+### Discovery Pipeline
+
+Two options (decide during implementation):
+
+**Option A: Edge function** — Add penny scan type to `trade-scanner`. Reuses Yahoo screener + Supabase cache. Simpler but limited to edge function's refresh cycle.
+
+**Option B: Local scanner** — New `auto-trader/src/lib/penny-scanner.ts` with `setInterval` polling every 30 seconds during 7–10 AM. Faster but bypasses the edge function pattern.
+
+**Recommendation:** Start with Option A (edge function) for discovery since it reuses existing Yahoo screener infra. Entry confirmation and exit monitoring run locally in the auto-trader regardless, since they need 1-min candle analysis and fast IB execution.
+
+### Execution Pipeline
+
+New `executePennyTrade()` in `scheduler.ts` — parallel to `executeScannerTrade()` with penny-specific gates:
+
+- **Skip:** FA alignment, ORB/VWAP reclaim, chop filter, ticker win-rate gate
+- **Keep:** duplicate entry prevention, max positions cap, daily loss gate
+- **Add:** MACD confirmation on 1-min candles, volume confirmation, pullback pattern detection, R:R validation (≥ 2:1)
+- **Position sizing:** fixed dollar amount (default $200/trade), half-size first trade, streak-based scaling
+
+### Exit Monitoring
+
+Runs alongside existing position management loop. For open `DAY_PENNY` positions:
+
+- Poll 1-min candles every 1–2 minutes
+- Check exit indicators: MACD crossover, 9 EMA break, VWAP break, volume spike, topping tail
+- Hard close all penny positions by 10:00 AM ET (or configurable end time)
+- Never hold penny positions overnight
+
+## Data Sources
+
+| Data | Source | Rate Limit |
+|------|--------|------------|
+| Gainers / price / volume | Yahoo Finance screener | No key required |
+| 1-min candles | Yahoo v8 chart API | No key required |
+| Float / shares outstanding | Finnhub `/stock/profile2` or `/stock/metric` | 60 calls/min |
+| News catalyst | Finnhub `/company-news` | 60 calls/min (shared) |
+| Relative volume | Yahoo daily bars (20-day avg) | No key required |
+
+**API budget per scan:** ~20 Finnhub calls at 900ms spacing = 18 seconds. Scanning every 3 min = ~7 calls/min, well within 60/min limit.
+
+## Full Change Map
+
+Complete audit of every file that needs updating for `DAY_PENNY`. Grouped by risk level.
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `auto-trader/src/lib/penny-scanner.ts` | Discovery, entry confirmation, exit monitoring |
+| New migration in `supabase/migrations/` | CHECK constraints + `penny_trades` seed row |
+| `docs/features/penny-stock-scanner.md` | This doc |
+
+### Layer 1 — Foundation (blocks everything else)
+
+| File | Change | Risk if missed |
+|------|--------|----------------|
+| `shared/trade-types.ts` | Add `'DAY_PENNY'` to `TradeMode` union | TS errors everywhere |
+| `shared/trade-status-sets.ts` | Add `'DAY_PENNY'` to `EQUITY_MODES` | Penny trades vanish from performance edge function |
+| Migration: `paper_trades` mode CHECK | Add `'DAY_PENNY'` (latest: `20260423000005`) | DB rejects inserts |
+| Migration: `auto_trade_events` mode CHECK | Add `'DAY_PENNY'` (latest: `20260214000006`) | Event logging fails |
+| Migration: `trade_performance_log` strategy CHECK | Add `'DAY_PENNY'` (`20260227000001`) | Performance log inserts fail |
+| Migration: `trade_scans` seed row | Add `penny_trades` row | No cache slot for penny ideas |
+
+### Layer 2 — Auto-Trader (execution pipeline)
+
+| File | Change | Include/Exclude |
+|------|--------|-----------------|
+| `auto-trader/src/scheduler.ts` | New `executePennyTrade()` function | New code |
+| `auto-trader/src/scheduler.ts` | Active day position filters (lines 610, 718) | INCLUDE — penny counts as active day position |
+| `auto-trader/src/scheduler.ts` | EOD soft/hard close queries (`.eq('mode', 'DAY_TRADE')`) | INCLUDE — penny must close EOD too |
+| `auto-trader/src/scheduler.ts` | Same-day cooldown queries (line 887, 1143, 1247) | EXCLUDE — penny has own cooldown logic |
+| `auto-trader/src/scheduler.ts` | TIF logic (`mode === 'DAY_TRADE' ? 'DAY' : 'GTC'`) (line 3964) | INCLUDE — penny uses DAY TIF |
+| `auto-trader/src/scheduler.ts` | Position sizing branches (line 2481, 3273) | EXCLUDE — penny has fixed $ sizing |
+| `auto-trader/src/scheduler.ts` | Scan evaluation maps (line 5745, 6005) | INCLUDE — penny ideas get Armed/Blocked badges |
+| `auto-trader/src/lib/tradePerformanceLog.ts` | Strategy allow-list (line 161–162) | INCLUDE — or penny P&L log inserts silently skipped |
+| `auto-trader/src/lib/supabase.ts` | Mode unions (line 146, 316–330, 439, 596) | INCLUDE where queries should see penny trades |
+| `auto-trader/src/routes/strategies.ts` | `VALID_MODES` Set (line 20) | INCLUDE — API accepts penny mode |
+| `auto-trader/src/lib/feedback.ts` | Mode check (line 78) | INCLUDE — penny uses same feedback rules |
+
+### Layer 3 — Edge Functions
+
+| File | Change | Include/Exclude |
+|------|--------|-----------------|
+| `supabase/functions/trade-scanner/index.ts` | Add penny scan type (discovery + write to `penny_trades`) | New code path |
+| `supabase/functions/paper-trading-performance/index.ts` | Uses `EQUITY_MODES` (line 198–200) | Automatic via Layer 1 |
+| `supabase/functions/trade-performance-log-close/index.ts` | Uses `EQUITY_MODES` + inserts strategy (line 71–98) | Automatic via Layer 1 + migration |
+| `supabase/functions/_shared/analysis.ts` | `Mode` union (line 27, 44) | INCLUDE — add `'DAY_PENNY'` to Mode union and interval maps |
+| `supabase/functions/trading-signals/index.ts` | `RequestMode` + prompt selection (line 409–440) | INCLUDE — map penny to day trade prompts |
+| `supabase/functions/auto-tune-strategy-config/index.ts` | Mode categorization (line 196–208) | New category — don't pollute existing day trade tuning |
+
+### Layer 4 — App UI
+
+| File | Change | Include/Exclude |
+|------|--------|-----------------|
+| `app/src/components/TradeIdeas.tsx` | New "Penny Stocks" tab + `relevantModes` set (line 144) | New tab |
+| `app/src/components/PaperTrading/tabs/TodayActivityTab.tsx` | Filter chip + mode filter (line 267–279) + badge (line 433–436) | New filter + label |
+| `app/src/components/PaperTrading/tabs/HistoryTab.tsx` | Mode label (line 188–189, uses `.replace('_', ' ')`) | Works automatically — shows "DAY PENNY" |
+| `app/src/components/PaperTrading/tabs/PerformanceTab.tsx` | Strategy breakdown row | Automatic via EQUITY_MODES |
+| `app/src/lib/paperTradesApi.ts` | `recalculatePerformanceByCategory` (line 831–881) | New `day_penny` category |
+| `app/src/lib/paperTradesApi.ts` | `getDayTradeValidationReport` (line 226) | EXCLUDE — penny gets own report or stays separate |
+| `app/src/lib/paperTradesApi.ts` | Influencer patterns (line 1597, 1619) | EXCLUDE — penny isn't influencer-driven |
+| `app/src/lib/autoTrader.ts` | Mode branches for TIF, sizing, stale logic (line 523, 630, 714) | INCLUDE — penny follows day trade lifecycle |
+| `app/src/lib/aiFeedback.ts` | Mode check (line 122) | INCLUDE |
+| `app/src/components/TradingSignals.tsx` | Mode options + throttle keys (line 408, 476, 614) | New mode option |
+| `app/src/lib/tradeScannerApi.ts` | Mode union (line 19) | Extend for penny |
+| `app/src/lib/tradingSignalsApi.ts` | `SignalsMode` union (line 9) | Extend for penny |
+| `app/src/components/PaperTrading/tabs/StrategyPerformanceTab.tsx` | Timeframe union (line 37, 1002) | EXCLUDE — penny isn't a video timeframe |
+| `app/src/components/PaperTrading/tabs/ValidationTab.tsx` | Diagnostics section | Optional — separate penny report later |
+
+### Layer 5 — Won't Break But Should Review
+
+| File | Notes |
+|------|-------|
+| `supabase/functions/extract-strategy-metadata-from-transcript/index.ts` | EXCLUDE — videos aren't tagged as penny timeframe |
+| `supabase/functions/import-strategy-signals/index.ts` | EXCLUDE — strategy imports don't target penny |
+| `auto-trader/src/lib/tradePerformanceMetrics.test.ts` | Update fixtures if testing penny metrics |
+| `.cursor/rules/auto-trader-conventions.mdc` | Document DAY_PENNY in "Trade Modes" section |
+| `supabase/functions/README.md` | Document penny scan type |
+
+## Safety Nets
+
+Even on a paper account, enforce these to keep the experiment clean:
+
+1. **`pennyMaxDailyLoss`** — default -$200/day from penny trades
+2. **`pennyMaxDailyTrades`** — default 10 trades/day
+3. **3 consecutive losses = done** — Cameron's rule, built into session state
+4. **Give back 50% of daily peak = done** — protects profitable days
+5. **Hard EOD close** — all penny positions closed by configured end time
+6. **Process-level circuit breaker** — if penny scanner throws 3 errors in a row, disable and alert
+
+## Success Criteria (30-Day Evaluation)
+
+After 30 days of paper trading:
+
+| Metric | Target | Kill if below |
+|--------|--------|---------------|
+| Win rate | > 50% | < 35% |
+| Avg winner / avg loser | > 1.5:1 | < 1.0:1 |
+| Expectancy per trade | > $0 | Negative after 50 trades |
+| Max drawdown | < $500 | > $1,000 |
+| Trades per day (avg) | 2–5 | 0 (scanner can't find setups) |
+
+## What We Can't Automate
+
+Three aspects of Cameron's strategy that require human discretion:
+
+1. **Level 2 / tape reading** — reading order flow, spotting iceberg orders, momentum shifts in time & sales. This is Cameron's primary edge.
+2. **News quality assessment** — distinguishing FDA approval from fluff PR. Gemini can approximate but adds latency.
+3. **"Feel" for extended moves** — knowing when a stock has run too far. We proxy with ATR distance thresholds.
+
+## Phase Plan
+
+| Phase | What Ships | Timeline |
+|-------|-----------|----------|
+| 1 | Types + migration + discovery + entry logic + bracket orders | Days 1–2 |
+| 2 | Exit monitoring (MACD/EMA/VWAP/volume exits) + session state (streak tracking) | Day 3 |
+| 3 | UI integration (Trade Ideas tab, Today's Activity, Performance category) | Day 4 |
+| 4 | Tuning from real paper data | Ongoing |

--- a/shared/config-defaults.ts
+++ b/shared/config-defaults.ts
@@ -55,6 +55,10 @@ export interface AutoTraderConfig {
   tradeSignalsEnabled: boolean;
   suggestedFindsEnabled: boolean;
   optionsWheelEnabled: boolean;
+  pennyEnabled: boolean;
+  pennyPositionSize: number;
+  pennyMaxDailyLoss: number;
+  pennyMaxDailyTrades: number;
 }
 
 export const DEFAULT_CONFIG: AutoTraderConfig = {
@@ -105,4 +109,8 @@ export const DEFAULT_CONFIG: AutoTraderConfig = {
   tradeSignalsEnabled: true,
   suggestedFindsEnabled: true,
   optionsWheelEnabled: true,
+  pennyEnabled: false,
+  pennyPositionSize: 200,
+  pennyMaxDailyLoss: 200,
+  pennyMaxDailyTrades: 10,
 };

--- a/shared/trade-status-sets.ts
+++ b/shared/trade-status-sets.ts
@@ -33,7 +33,7 @@ export const ALL_TERMINAL_STATUSES: readonly TradeStatus[] = [
 
 /** Equity trade modes (excludes options and earnings) */
 export const EQUITY_MODES: readonly TradeMode[] = [
-  'DAY_TRADE', 'SWING_TRADE', 'LONG_TERM',
+  'DAY_TRADE', 'DAY_PENNY', 'SWING_TRADE', 'LONG_TERM',
 ] as const;
 
 /** Options trade modes */

--- a/shared/trade-types.ts
+++ b/shared/trade-types.ts
@@ -8,6 +8,7 @@
 
 export type TradeMode =
   | 'DAY_TRADE'
+  | 'DAY_PENNY'
   | 'SWING_TRADE'
   | 'LONG_TERM'
   | 'OPTIONS_PUT'

--- a/supabase/functions/_shared/analysis.ts
+++ b/supabase/functions/_shared/analysis.ts
@@ -24,7 +24,7 @@ import {
 
 // ── Types ────────────────────────────────────────────────
 
-export type Mode = 'DAY_TRADE' | 'SWING_TRADE';
+export type Mode = 'DAY_TRADE' | 'DAY_PENNY' | 'SWING_TRADE';
 
 export interface AnalysisContext {
   indicators: IndicatorSummary;
@@ -42,6 +42,7 @@ export interface AnalysisContext {
 /** Candle timeframes per mode — same for scanner Pass 2 AND full analysis. */
 export const MODE_INTERVALS: Record<Mode, [string, string, string]> = {
   DAY_TRADE: ['1min', '15min', '1h'],
+  DAY_PENNY: ['1min', '15min', '1h'],
   SWING_TRADE: ['4h', '1day', '1week'],
 };
 
@@ -60,6 +61,7 @@ const CANDLE_SIZES_LITE: Record<string, number> = {
 /** Which timeframe to use for indicator computation. */
 const INDICATOR_INTERVAL: Record<Mode, string> = {
   DAY_TRADE: '15min',
+  DAY_PENNY: '15min',
   SWING_TRADE: '1day',
 };
 

--- a/supabase/functions/trading-signals/index.ts
+++ b/supabase/functions/trading-signals/index.ts
@@ -536,7 +536,7 @@ Deno.serve(async req => {
 
     const body: RequestPayload = await req.json();
     const ticker = (body?.ticker ?? '').toString().trim().toUpperCase();
-    const requestedMode: RequestMode = body?.mode === 'DAY_TRADE'
+    const requestedMode: RequestMode = (body?.mode === 'DAY_TRADE' || body?.mode === 'DAY_PENNY')
       ? 'DAY_TRADE'
       : body?.mode === 'AUTO'
         ? 'AUTO'

--- a/supabase/migrations/20260516000001_day_penny_mode.sql
+++ b/supabase/migrations/20260516000001_day_penny_mode.sql
@@ -1,0 +1,40 @@
+-- Add DAY_PENNY mode for the penny stock momentum scanner.
+-- Follows Ross Cameron's mechanical rules: $2-$20 price, float <10M,
+-- 25%+ daily gain, 5x relative volume, news catalyst.
+-- Separate pipeline from large-cap day trades with its own P&L tracking.
+
+-- 1. paper_trades: drop and re-add with DAY_PENNY
+ALTER TABLE paper_trades
+  DROP CONSTRAINT IF EXISTS paper_trades_mode_check;
+
+ALTER TABLE paper_trades
+  ADD CONSTRAINT paper_trades_mode_check
+    CHECK (mode IN (
+      'DAY_TRADE', 'SWING_TRADE', 'LONG_TERM',
+      'OPTIONS_PUT', 'OPTIONS_CALL',
+      'EARNINGS_CALENDAR', 'CALENDAR_SPREAD', 'CREDIT_SPREAD',
+      'DAY_PENNY'
+    ));
+
+-- 2. auto_trade_events: drop entirely (app code is the authority)
+--    Follows precedent of 20260514000001 which dropped action/source checks.
+ALTER TABLE auto_trade_events
+  DROP CONSTRAINT IF EXISTS auto_trade_events_mode_check;
+
+-- 3. trade_performance_log: extend strategy CHECK to include DAY_PENNY
+ALTER TABLE trade_performance_log
+  DROP CONSTRAINT IF EXISTS trade_performance_log_strategy_check;
+
+ALTER TABLE trade_performance_log
+  ADD CONSTRAINT trade_performance_log_strategy_check
+    CHECK (strategy IN ('DAY_TRADE', 'SWING_TRADE', 'LONG_TERM', 'DAY_PENNY'));
+
+-- 4. Seed penny_trades row in trade_scans (for scanner cache + UI)
+INSERT INTO trade_scans (id, data, scanned_at, expires_at)
+VALUES (
+  'penny_trades',
+  '[]'::jsonb,
+  NOW(),
+  NOW() + INTERVAL '30 minutes'
+)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary

- Adds a complete penny stock momentum scanner based on Ross Cameron's mechanical rules ($2-$20 price, float <10M, 25%+ daily gain, 5x relative volume, news catalyst)
- New `DAY_PENNY` trade mode across DB, shared types, auto-trader execution pipeline, edge functions, and all UI tabs
- Entry logic: first pullback with MACD + volume confirmation, 2:1 R:R minimum. Session state with guard rails (3 consecutive losses = done, max daily loss, 50% giveback rule, streak-based sizing)

## Changes

**Database**: Migration adds DAY_PENNY to paper_trades/trade_performance_log CHECK constraints, seeds penny_trades row in trade_scans

**Auto-Trader**: New `penny-scanner.ts` (discovery, entry, exit, session state), scheduler wiring (9:35-10:00 AM ET window), EOD close, config knobs (`pennyEnabled`, `pennyPositionSize`, `pennyMaxDailyLoss`, `pennyMaxDailyTrades`)

**Edge Functions**: analysis.ts Mode union, trading-signals DAY_PENNY mapping

**App UI**: Penny tab in Trade Ideas (green), Penny filter/badge in Today's Activity, day_penny performance category, DAY_PENNY in autoTrader TIF/sizing/stale-trade logic

## Test plan

- [ ] Verify Penny tab appears in Trade Ideas (empty until scanner runs during market hours)
- [ ] Verify Penny filter chip in Today's Activity tab
- [ ] Verify auto-trader starts cleanly with new penny-scanner import
- [ ] Enable `pennyEnabled: true` in config and verify scanner runs during 9:35-10:00 AM ET window


Made with [Cursor](https://cursor.com)