### PR TITLE
fix: comprehensive DAY_PENNY audit — settings, performance, scheduler

### DIFF
--- a/app/src/components/PaperTrading/shared/SignalScorecard.tsx
+++ b/app/src/components/PaperTrading/shared/SignalScorecard.tsx
@@ -6,7 +6,7 @@ export interface SignalScorecardProps {
   title: string;
   subtitle: string;
   data: CategoryPerformance | undefined;
-  color: 'indigo' | 'blue' | 'emerald' | 'violet';
+  color: 'indigo' | 'blue' | 'emerald' | 'violet' | 'green';
 }
 
 const colorClasses = {
@@ -14,6 +14,7 @@ const colorClasses = {
   blue: 'border-blue-200 bg-blue-50',
   emerald: 'border-emerald-200 bg-emerald-50',
   violet: 'border-violet-200 bg-violet-50',
+  green: 'border-green-200 bg-green-50',
 };
 
 const textColors = {
@@ -21,6 +22,7 @@ const textColors = {
   blue: 'text-blue-700',
   emerald: 'text-emerald-700',
   violet: 'text-violet-700',
+  green: 'text-green-700',
 };
 
 export function SignalScorecard({ title, subtitle, data, color }: SignalScorecardProps) {

--- a/app/src/components/PaperTrading/tabs/PerformanceTab.tsx
+++ b/app/src/components/PaperTrading/tabs/PerformanceTab.tsx
@@ -41,6 +41,7 @@ export function PerformanceTab({
   const sf = categories.find(c => c.category === 'suggested_finds');
   const scannerDt = categories.find(c => c.category === 'scanner_day_trade');
   const influencerDt = categories.find(c => c.category === 'influencer_day_trade');
+  const pennyDt = categories.find(c => c.category === 'day_penny');
   const sw = categories.find(c => c.category === 'swing_trade');
   const dipBuy = categories.find(c => c.category === 'dip_buy');
   const profitTake = categories.find(c => c.category === 'profit_take');
@@ -102,6 +103,7 @@ export function PerformanceTab({
           <SignalScorecard title="Suggested Finds" subtitle="Long-term picks" data={sf} color="indigo" />
           <SignalScorecard title="Scanner Day Trades" subtitle="Trade signals only" data={scannerDt} color="blue" />
           <SignalScorecard title="Influencer Day Trades" subtitle="Strategy video signals" data={influencerDt} color="emerald" />
+          <SignalScorecard title="Penny Day Trades" subtitle="Momentum scanner" data={pennyDt} color="green" />
           <SignalScorecard title="Swing Trades" subtitle="Scanner signals" data={sw} color="violet" />
         </div>
 

--- a/app/src/components/PaperTrading/tabs/SettingsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/SettingsTab.tsx
@@ -162,6 +162,44 @@ export function SettingsTab({ config, onUpdate }: SettingsTabProps) {
         </div>
       </div>
 
+      {config.pennyEnabled && (
+        <div className="rounded-lg border border-green-200 bg-green-50/50 p-4 space-y-3">
+          <h4 className="text-sm font-semibold text-[hsl(var(--foreground))]">Penny Scanner Settings</h4>
+          <p className="text-xs text-[hsl(var(--muted-foreground))] -mt-1">
+            Ross Cameron's rules: first pullback entry, MACD + volume confirmation, streak-based sizing
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <label className="block text-xs font-medium text-[hsl(var(--foreground))] mb-1">Position Size ($)</label>
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-[hsl(var(--muted-foreground))]">$</span>
+                <NumInput value={config.pennyPositionSize} onCommit={v => onUpdate({ pennyPositionSize: v })}
+                  className="w-full px-2 py-1.5 border border-[hsl(var(--border))] rounded-lg text-xs"
+                  min={50} max={2000} step={50} />
+              </div>
+              <p className="text-[10px] text-[hsl(var(--muted-foreground))] mt-0.5">Full size after a winner; half after a loss or first trade of day</p>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-[hsl(var(--foreground))] mb-1">Max Daily Loss ($)</label>
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-[hsl(var(--muted-foreground))]">$</span>
+                <NumInput value={config.pennyMaxDailyLoss} onCommit={v => onUpdate({ pennyMaxDailyLoss: v })}
+                  className="w-full px-2 py-1.5 border border-[hsl(var(--border))] rounded-lg text-xs"
+                  min={50} max={1000} step={50} />
+              </div>
+              <p className="text-[10px] text-[hsl(var(--muted-foreground))] mt-0.5">Stop penny trading for the day if losses exceed this</p>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-[hsl(var(--foreground))] mb-1">Max Daily Trades</label>
+              <NumInput value={config.pennyMaxDailyTrades} onCommit={v => onUpdate({ pennyMaxDailyTrades: v })}
+                className="w-full px-2 py-1.5 border border-[hsl(var(--border))] rounded-lg text-xs"
+                min={1} max={30} step={1} />
+              <p className="text-[10px] text-[hsl(var(--muted-foreground))] mt-0.5">Max penny trades per day (also stops after 3 consecutive losses)</p>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <label className="block text-sm font-medium text-[hsl(var(--foreground))] mb-1.5">

--- a/app/src/components/PaperTrading/tabs/SettingsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/SettingsTab.tsx
@@ -151,6 +151,15 @@ export function SettingsTab({ config, onUpdate }: SettingsTabProps) {
             <p className="text-xs text-[hsl(var(--muted-foreground))]">Sell cash-secured puts & covered calls for premium income</p>
           </div>
         </div>
+
+        <div className="flex items-center gap-3">
+          <SettingsToggle enabled={config.pennyEnabled}
+            onToggle={() => onUpdate({ pennyEnabled: !config.pennyEnabled })} />
+          <div>
+            <p className="text-sm font-medium text-[hsl(var(--foreground))]">Penny Scanner</p>
+            <p className="text-xs text-[hsl(var(--muted-foreground))]">Momentum penny stocks ($2-$20) — mechanical rules, 9:35-10:00 AM ET</p>
+          </div>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -809,7 +809,7 @@ async function checkStaleDayTrades(positions: EnrichedPosition[]): Promise<void>
   const todayEt = getETDateString();
 
   const stale = activeTrades.filter(t => {
-    if (t.mode !== 'DAY_TRADE' || t.status !== 'FILLED') return false;
+    if ((t.mode !== 'DAY_TRADE' && t.mode !== 'DAY_PENNY') || t.status !== 'FILLED') return false;
     const tradeDate = t.filled_at
       ? new Date(t.filled_at).toLocaleDateString('en-CA', { timeZone: 'America/New_York' })
       : null;
@@ -4492,7 +4492,7 @@ async function syncPositions(
       // or after 24h as a safety net for any that slip through.
       const tradeDateET = new Date(trade.created_at).toLocaleDateString('en-US', { timeZone: 'America/New_York' });
       const todayET = new Date().toLocaleDateString('en-US', { timeZone: 'America/New_York' });
-      const dayOrderExpired = trade.mode === 'DAY_TRADE' && (
+      const dayOrderExpired = (trade.mode === 'DAY_TRADE' || trade.mode === 'DAY_PENNY') && (
         (tradeDateET === todayET && isPastMarketCloseET()) || tradeAge > 86400000
       );
       if (dayOrderExpired) {
@@ -5299,7 +5299,7 @@ async function checkDayTradeTrailingStops(
 ): Promise<void> {
   const activeTrades = await getActiveTrades();
   const dayTrades = activeTrades.filter(
-    t => t.mode === 'DAY_TRADE' && (t.status === 'FILLED' || t.status === 'PARTIAL'),
+    t => (t.mode === 'DAY_TRADE' || t.mode === 'DAY_PENNY') && (t.status === 'FILLED' || t.status === 'PARTIAL'),
   );
   if (dayTrades.length === 0) return;
 


### PR DESCRIPTION
## Summary

- Full audit of every `DAY_TRADE` literal across the codebase, fixed all missing `DAY_PENNY` spots
- Added Penny Scanner settings section (position size, max daily loss, max daily trades) to Settings page
- Added Penny Day Trades scorecard to Performance tab with green color support
- Fixed 3 scheduler gaps: stale day trade detector, trailing stop monitor, day order expiry

## Test plan

- [ ] Settings page: toggle Penny Scanner on, verify config fields appear
- [ ] Performance tab: "Penny Day Trades" card renders (empty until trades execute)
- [ ] Auto-trader restarts cleanly


Made with [Cursor](https://cursor.com)