### PR TITLE
fix: comprehensive DAY_PENNY audit round 2 — scheduler, app, edge functions

### DIFF
--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -742,11 +742,13 @@ export function calculatePositionSize(
   // sizing or risk-based formula. The risk-based formula can balloon when stops are tight
   // (e.g. $2 stop on a $200 stock → 2,750 shares), causing outsized day-trade losses.
   // Swing and long-term trades keep the larger allocation-based cap.
-  const modeMaxDollar = (mode === 'DAY_TRADE' || mode === 'DAY_PENNY') ? config.positionSize : hardMaxDollar;
+  const modeMaxDollar = mode === 'DAY_PENNY' ? config.pennyPositionSize
+    : mode === 'DAY_TRADE' ? config.positionSize
+    : hardMaxDollar;
 
   if (!config.useDynamicSizing || price <= 0) {
-    // Fallback: flat position sizing, but STILL capped by mode
-    const cappedSize = Math.min(config.positionSize, modeMaxDollar);
+    const flatSize = mode === 'DAY_PENNY' ? config.pennyPositionSize : config.positionSize;
+    const cappedSize = Math.min(flatSize, modeMaxDollar);
     const qty = Math.max(1, Math.floor(cappedSize / price));
     return { quantity: qty, dollarSize: qty * price };
   }

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -223,7 +223,7 @@ export async function getDayTradeValidationReport(): Promise<DayTradeValidationR
   const { data, error } = await supabase
     .from('paper_trades')
     .select('*')
-    .eq('mode', 'DAY_TRADE')
+    .in('mode', ['DAY_TRADE', 'DAY_PENNY'])
     .not('closed_at', 'is', null)
     .order('opened_at', { ascending: false })
     .limit(100);

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -895,7 +895,7 @@ async function promoteDayTradeGainersToWatchlist(): Promise<void> {
   const { data: closedToday } = await sb
     .from('paper_trades')
     .select('ticker, pnl, strategy_source')
-    .eq('mode', 'DAY_TRADE')
+    .in('mode', ['DAY_TRADE', 'DAY_PENNY'])
     .in('status', [...CLOSED_STATUSES])
     .not('pnl', 'is', null)
     .gte('opened_at', `${todayEt}T00:00:00Z`);
@@ -1151,7 +1151,7 @@ export async function reconcileIBLongs(): Promise<{ closed: string[]; errors: st
     .from('paper_trades')
     .select('ticker')
     .eq('signal', 'BUY')
-    .eq('mode', 'DAY_TRADE')
+    .in('mode', ['DAY_TRADE', 'DAY_PENNY'])
     .is('fill_price', null)
     .in('status', ['CLOSED', 'CANCELLED'])
     .gte('opened_at', `${todayEt}T00:00:00Z`);
@@ -1255,7 +1255,7 @@ async function isDayTradeLossGateActive(config: AutoTraderConfig): Promise<boole
   const { data } = await sb
     .from('paper_trades')
     .select('pnl')
-    .eq('mode', 'DAY_TRADE')
+    .in('mode', ['DAY_TRADE', 'DAY_PENNY'])
     .eq('status', 'CLOSED')
     .gte('closed_at', `${todayEt}T00:00:00Z`);
 
@@ -2677,12 +2677,12 @@ async function calculateKellyMultiplier(config: AutoTraderConfig): Promise<numbe
 
   try {
     const sb = getSupabase();
-    // Use last 30 closed DAY_TRADE + SWING_TRADE results (exclude LONG_TERM — different risk profile)
+    // Use last 30 closed short-term results (exclude LONG_TERM — different risk profile)
     const { data, error } = await sb
       .from('paper_trades')
       .select('pnl_percent, fill_price, mode')
       .in('status', [...CLOSED_STATUSES])
-      .in('mode', ['DAY_TRADE', 'SWING_TRADE'])
+      .in('mode', ['DAY_TRADE', 'DAY_PENNY', 'SWING_TRADE'])
       .not('pnl_percent', 'is', null)
       .not('fill_price', 'is', null)
       .order('closed_at', { ascending: false })
@@ -2922,7 +2922,7 @@ async function executeScannerTrade(
   // they are different instruments and managed by a separate pipeline.
   if (await hasActiveTrade(ticker, { excludeOptions: true })) return 'skipped:duplicate';
 
-  // ── Same-day re-entry cooldown (DAY_TRADE only) ───────────────────────
+  // ── Same-day re-entry cooldown (DAY_TRADE only — penny has its own session state) ──
   // hasActiveTrade only checks SUBMITTED/FILLED/PARTIAL — once a day trade hits
   // its target or stop (TARGET_HIT / STOPPED / CLOSED) the ticker is "free" again
   // and the scanner will re-enter it the same afternoon. This creates ghost BUY
@@ -2936,7 +2936,7 @@ async function executeScannerTrade(
       .from('paper_trades')
       .select('id', { count: 'exact', head: true })
       .eq('ticker', ticker)
-      .eq('mode', 'DAY_TRADE')
+      .in('mode', ['DAY_TRADE', 'DAY_PENNY'])
       .not('mode', 'in', '(OPTIONS_PUT,OPTIONS_CALL)')
       .in('status', ['TARGET_HIT', 'STOPPED', 'CLOSED'])
       .gte('opened_at', `${todayEt}T00:00:00Z`);

--- a/supabase/functions/auto-tune-strategy-config/index.ts
+++ b/supabase/functions/auto-tune-strategy-config/index.ts
@@ -196,13 +196,15 @@ Deno.serve(async (req) => {
     const influencerDay = cleanTrades.filter(t => t.mode === 'DAY_TRADE' && t.strategy_video_id != null);
     // Scanner day trades = DAY_TRADE without a strategy_video_id
     const scannerDay = cleanTrades.filter(t => t.mode === 'DAY_TRADE' && t.strategy_video_id == null);
+    const pennyDay = cleanTrades.filter(t => t.mode === 'DAY_PENNY');
     const swingTrades = cleanTrades.filter(t => t.mode === 'SWING_TRADE');
     const longTerm = cleanTrades.filter(t => t.mode === 'LONG_TERM');
-    const allDayTrade = cleanTrades.filter(t => t.mode === 'DAY_TRADE');
+    const allDayTrade = cleanTrades.filter(t => t.mode === 'DAY_TRADE' || t.mode === 'DAY_PENNY');
 
     const categoryStats: CategoryStats[] = [
       computeStats(influencerDay, 'influencer_day'),
       computeStats(scannerDay, 'scanner_day'),
+      computeStats(pennyDay, 'DAY_PENNY'),
       computeStats(swingTrades, 'SWING_TRADE'),
       computeStats(longTerm, 'LONG_TERM'),
       computeStats(allDayTrade, 'DAY_TRADE'),


### PR DESCRIPTION
## Summary

Deep audit found 7 additional DAY_PENNY gaps beyond the first PR:

**Scheduler (5 fixes):**
- IB ghost day-trade query now includes DAY_PENNY
- Watchlist promotion includes penny winners
- Kelly adaptive sizing includes penny outcomes
- Same-day re-entry cooldown DB query covers both modes
- Daily loss gate aggregates penny + scanner losses together

**App (2 fixes):**
- `calculatePositionSize` uses `pennyPositionSize` for DAY_PENNY (was incorrectly using regular `positionSize`)
- Validation report includes DAY_PENNY trades

**Edge function (1 fix):**
- auto-tune-strategy-config: separate DAY_PENNY stats + include in all-day-trade aggregate

## Test plan

- [ ] Auto-trader restarts cleanly
- [ ] App builds without errors
- [ ] auto-tune-strategy-config edge function deployed


Made with [Cursor](https://cursor.com)