### PR TITLE
fix: dynamic P&L by filter in Today's Activity

### DIFF
--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -218,11 +218,11 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
     );
   }
 
-  const eventBasedPnl = (() => {
+  const computeEventPnl = (evList: typeof events) => {
     const countedTradeIds = new Set<string>();
     const AUTO_CLOSE = new Set(['system', 'lt_auto_sell', 'swing_expiry', 'capital_pressure']);
     let sum = 0;
-    for (const ev of events) {
+    for (const ev of evList) {
       const matched = tradesByTicker.get(ev.ticker)?.find(t =>
         (t.pnl != null || ['FILLED', 'TARGET_HIT', 'STOPPED', 'CLOSED'].includes(t.status))
         && !countedTradeIds.has(t.id)
@@ -240,10 +240,10 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
       }
     }
     return sum;
-  })();
+  };
 
-  const todayPnl = ibRealizedPnl ?? eventBasedPnl;
-  const pnlSource = ibRealizedPnl != null ? 'ib' : 'events';
+  const allEventPnl = useMemo(() => computeEventPnl(events), [events, tradesByTicker]);
+  const todayPnlAll = ibRealizedPnl ?? allEventPnl;
 
   function handleSort(key: SortKey) {
     if (sortKey === key) {
@@ -308,18 +308,28 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
     });
   }, [events, filterMode, sortKey, sortDir, tradesByTicker]);
 
+  const filteredPnl = useMemo(() => computeEventPnl(filteredSortedEvents), [filteredSortedEvents, tradesByTicker]);
+  const useIbPnl = filterMode === 'all' && ibRealizedPnl != null;
+  const displayPnl = useIbPnl ? ibRealizedPnl : filterMode === 'all' ? todayPnlAll : filteredPnl;
+  const pnlLabel = filterMode === 'all' ? "Today's Realized P&L"
+    : filterMode === 'day' ? 'Day Trade P&L'
+    : filterMode === 'penny' ? 'Penny P&L'
+    : filterMode === 'long_term' ? 'LT / Swing P&L'
+    : filterMode === 'gainers' ? 'Gainers P&L'
+    : 'Losers P&L';
+
   return (
     <div className="space-y-3">
-      {todayPnl !== 0 && (
+      {displayPnl !== 0 && (
         <div className="flex items-center justify-between rounded-lg bg-[hsl(var(--secondary))] px-4 py-2.5">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-[hsl(var(--muted-foreground))]">Today&apos;s Realized P&L</span>
-            {pnlSource === 'ib' && (
+            <span className="text-sm font-medium text-[hsl(var(--muted-foreground))]">{pnlLabel}</span>
+            {useIbPnl && (
               <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 font-semibold">IB</span>
             )}
           </div>
-          <span className={cn('text-sm font-bold tabular-nums', todayPnl > 0 ? 'text-emerald-600' : todayPnl < 0 ? 'text-red-600' : '')}>
-            {fmtUsd(todayPnl, 2, true)}
+          <span className={cn('text-sm font-bold tabular-nums', displayPnl > 0 ? 'text-emerald-600' : displayPnl < 0 ? 'text-red-600' : '')}>
+            {fmtUsd(displayPnl, 2, true)}
           </span>
         </div>
       )}


### PR DESCRIPTION
P&L header now updates when switching filters. IB source for All, event-based for filtered views. Label changes too (e.g. 'Day Trade P&L', 'Penny P&L').

Made with [Cursor](https://cursor.com)