### PR TITLE
feat: cold streak detector — auto-halve sizing when a strategy goes cold

### DIFF
--- a/auto-trader/src/lib/streak-tracker.ts
+++ b/auto-trader/src/lib/streak-tracker.ts
@@ -1,0 +1,141 @@
+/**
+ * Strategy-level cold streak detector.
+ *
+ * Inspired by James Rich Young: track each strategy's recent performance
+ * independently. When a strategy goes cold (rolling win rate drops below
+ * threshold), halve position size. Don't restore until win rate convincingly
+ * recovers (hysteresis band prevents flip-flopping).
+ *
+ * This is a position sizing MULTIPLIER, not a gate. The strategy keeps
+ * trading at reduced size so we can detect recovery.
+ *
+ * Composes multiplicatively with Kelly and market regime:
+ *   base × Kelly × regime × streak = final size
+ */
+
+import { getSupabase } from './supabase.js';
+import { CLOSED_STATUSES } from '../../../shared/trade-status-sets.js';
+
+const log = (msg: string) => console.log(`[StreakTracker] ${msg}`);
+
+interface StreakConfig {
+  windowSize: number;
+  coldThreshold: number;
+  recoveryThreshold: number;
+}
+
+const STREAK_CONFIGS: Record<string, StreakConfig> = {
+  DAY_TRADE:  { windowSize: 10, coldThreshold: 0.35, recoveryThreshold: 0.50 },
+  DAY_PENNY:  { windowSize: 10, coldThreshold: 0.25, recoveryThreshold: 0.40 },
+  SWING_TRADE: { windowSize: 5, coldThreshold: 0.30, recoveryThreshold: 0.45 },
+};
+
+const COLD_MULTIPLIER = 0.5;
+
+interface StreakState {
+  mode: string;
+  is_cold: boolean;
+  entered_cold_at: string | null;
+  rolling_win_rate: number | null;
+}
+
+/**
+ * Returns a position sizing multiplier for the given trade mode.
+ * 1.0 = normal, 0.5 = cold streak active.
+ *
+ * Non-blocking: returns 1.0 on any error (never silently kills sizing).
+ */
+export async function getStreakMultiplier(mode: string): Promise<number> {
+  const config = STREAK_CONFIGS[mode];
+  if (!config) return 1.0;
+
+  try {
+    const sb = getSupabase();
+
+    // Fetch last N completed trades for this mode
+    const { data: trades, error: tradeErr } = await sb
+      .from('paper_trades')
+      .select('pnl')
+      .eq('mode', mode)
+      .in('status', [...CLOSED_STATUSES])
+      .not('pnl', 'is', null)
+      .not('fill_price', 'is', null)
+      .order('closed_at', { ascending: false })
+      .limit(config.windowSize);
+
+    if (tradeErr || !trades || trades.length < config.windowSize) {
+      // Not enough trades to judge — don't apply cold streak
+      return 1.0;
+    }
+
+    const wins = trades.filter(t => (t.pnl ?? 0) > 0).length;
+    const winRate = wins / trades.length;
+
+    // Fetch current state
+    const { data: stateRow } = await sb
+      .from('strategy_streak_state')
+      .select('is_cold, entered_cold_at, rolling_win_rate')
+      .eq('mode', mode)
+      .single();
+
+    const wasCold = stateRow?.is_cold ?? false;
+    let isCold: boolean;
+
+    if (wasCold) {
+      // Currently cold — only recover if win rate exceeds recovery threshold
+      isCold = winRate < config.recoveryThreshold;
+    } else {
+      // Currently normal — enter cold if win rate drops below cold threshold
+      isCold = winRate < config.coldThreshold;
+    }
+
+    // Persist state change
+    const stateChanged = isCold !== wasCold;
+    if (stateChanged || !stateRow) {
+      await sb
+        .from('strategy_streak_state')
+        .upsert({
+          mode,
+          is_cold: isCold,
+          entered_cold_at: isCold && !wasCold ? new Date().toISOString() : (stateRow?.entered_cold_at ?? null),
+          last_checked_at: new Date().toISOString(),
+          rolling_win_rate: winRate,
+          window_size: config.windowSize,
+        });
+
+      if (isCold && !wasCold) {
+        log(`⚠️ ${mode} entered cold streak — win rate ${(winRate * 100).toFixed(0)}% (last ${config.windowSize} trades) < ${(config.coldThreshold * 100).toFixed(0)}% threshold → position size ×${COLD_MULTIPLIER}`);
+      } else if (!isCold && wasCold) {
+        log(`✅ ${mode} recovered from cold streak — win rate ${(winRate * 100).toFixed(0)}% > ${(config.recoveryThreshold * 100).toFixed(0)}% recovery threshold → full size restored`);
+      }
+    } else {
+      // Update rolling stats even if state didn't change
+      await sb
+        .from('strategy_streak_state')
+        .update({
+          last_checked_at: new Date().toISOString(),
+          rolling_win_rate: winRate,
+        })
+        .eq('mode', mode);
+    }
+
+    return isCold ? COLD_MULTIPLIER : 1.0;
+  } catch (err) {
+    log(`Error checking streak for ${mode}: ${err instanceof Error ? err.message : 'unknown'} — returning 1.0`);
+    return 1.0;
+  }
+}
+
+/** Check if a mode is currently in a cold streak (read-only, for UI). */
+export async function getStreakStates(): Promise<StreakState[]> {
+  try {
+    const sb = getSupabase();
+    const { data } = await sb
+      .from('strategy_streak_state')
+      .select('mode, is_cold, entered_cold_at, rolling_win_rate')
+      .order('mode');
+    return (data ?? []) as StreakState[];
+  } catch {
+    return [];
+  }
+}

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -88,6 +88,7 @@ import { checkSpxLevelSetups } from './lib/spx-level-scanner.js';
 import { isInsideOrb } from './lib/orb.js';
 import { evaluateVwapAlignment, detectVwapReclaim } from './lib/vwap.js';
 import { checkTrendFilter } from './lib/trend-filter.js';
+import { getStreakMultiplier } from './lib/streak-tracker.js';
 import { getEconDayProfile } from './lib/econ-calendar.js';
 import { warmPositionPriceCache } from './routes/positions.js';
 import { generateMorningBrief } from './lib/morning-brief.js';
@@ -2477,11 +2478,12 @@ function calculatePositionSize(
     stopLoss?: number;
     regimeMultiplier?: number;
     drawdownMultiplier?: number;
+    streakMultiplier?: number;
   }
 ): { quantity: number; dollarSize: number } {
   const {
     price, mode, conviction, suggestedFindTag, entryPrice, stopLoss,
-    regimeMultiplier = 1.0, drawdownMultiplier = 1.0,
+    regimeMultiplier = 1.0, drawdownMultiplier = 1.0, streakMultiplier = 1.0,
   } = params;
   const alloc = config.maxTotalAllocation;
   const hardMaxDollar = alloc * 0.10;
@@ -2523,7 +2525,7 @@ function calculatePositionSize(
     dollarSize = alloc * (config.baseAllocationPct / 100);
   }
 
-  dollarSize = dollarSize * regimeMultiplier * drawdownMultiplier;
+  dollarSize = dollarSize * regimeMultiplier * drawdownMultiplier * streakMultiplier;
   dollarSize = Math.min(dollarSize, maxDollar);
   dollarSize = Math.max(dollarSize, 100);
   const quantity = Math.max(1, Math.floor(dollarSize / price));
@@ -3215,9 +3217,13 @@ async function executeScannerTrade(
     log(`${ticker}: high-impact econ day — position size ×${econMult} (${econProfile.events.map(e => e.event).join(', ')})`);
   }
 
+  const streakMult = await getStreakMultiplier(mode);
+  if (streakMult < 1.0) log(`${ticker}: cold streak active for ${mode} — sizing ×${streakMult}`);
+
   const sizingRaw = calculatePositionSize(config, {
     price: entryPrice, mode, entryPrice, stopLoss,
     drawdownMultiplier: dd.multiplier * kellyMult * vixMult * econMult,
+    streakMultiplier: streakMult,
   });
   // Scanner trades (AI-generated, not expert-vetted) must be capped at positionSize.
   // Dynamic sizing can produce 200-400 share positions when the stop is very tight —
@@ -3860,11 +3866,14 @@ async function executeExternalStrategySignal(
   // Don't let Kelly/drawdown from unrelated scanner trades shrink their position size.
   const isInfluencerSignalForSizing = signal.strategy_video_id != null;
 
+  const extStreakMult = await getStreakMultiplier(signal.mode);
+  if (extStreakMult < 1.0) log(`${ticker}: cold streak active for ${signal.mode} — sizing ×${extStreakMult}`);
+
   const baseSizing = flatDollarSize
     ? (() => {
       const adjusted = isInfluencerSignalForSizing
         ? flatDollarSize
-        : flatDollarSize * sizingMultiplier;
+        : flatDollarSize * sizingMultiplier * extStreakMult;
       const quantity = Math.max(1, Math.floor(adjusted / referencePrice));
       return { quantity, dollarSize: quantity * referencePrice };
     })()
@@ -3874,9 +3883,8 @@ async function executeExternalStrategySignal(
       conviction: signal.confidence,
       entryPrice: effectiveEntryPrice ?? undefined,
       stopLoss: effectiveStopLoss ?? undefined,
-      // Influencer signals skip Kelly/drawdown dampening even in the dynamic path —
-      // consistent with the flat-dollar path above.
       drawdownMultiplier: isInfluencerSignalForSizing ? 1.0 : sizingMultiplier,
+      streakMultiplier: extStreakMult,
     });
 
   const splitDollarSize = baseSizing.dollarSize / allocationSplit;

--- a/supabase/migrations/20260516000002_strategy_streak_state.sql
+++ b/supabase/migrations/20260516000002_strategy_streak_state.sql
@@ -1,0 +1,25 @@
+-- Strategy-level cold streak state tracking
+-- Inspired by James Rich Young's approach: track per-strategy performance
+-- and automatically halve position size during cold streaks.
+
+CREATE TABLE IF NOT EXISTS strategy_streak_state (
+  mode TEXT PRIMARY KEY,
+  is_cold BOOLEAN NOT NULL DEFAULT false,
+  entered_cold_at TIMESTAMPTZ,
+  last_checked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  rolling_win_rate NUMERIC,
+  window_size INT NOT NULL DEFAULT 10
+);
+
+ALTER TABLE strategy_streak_state ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read strategy_streak_state" ON strategy_streak_state FOR SELECT USING (true);
+CREATE POLICY "Anyone can insert strategy_streak_state" ON strategy_streak_state FOR INSERT WITH CHECK (true);
+CREATE POLICY "Anyone can update strategy_streak_state" ON strategy_streak_state FOR UPDATE USING (true);
+
+-- Seed rows for active modes
+INSERT INTO strategy_streak_state (mode, is_cold, window_size)
+VALUES
+  ('DAY_TRADE', false, 10),
+  ('DAY_PENNY', false, 10),
+  ('SWING_TRADE', false, 5)
+ON CONFLICT (mode) DO NOTHING;


### PR DESCRIPTION
## Summary

Adds per-strategy cold streak detection that automatically halves position size when a strategy's recent performance drops below threshold, inspired by James Rich Young's manual approach.

**How it works:**
- Rolling window of last N trades per mode (10 for day trades, 5 for swing)
- Cold threshold: DAY_TRADE <35% WR, DAY_PENNY <25%, SWING <30%
- Recovery threshold: DAY_TRADE >50%, DAY_PENNY >40%, SWING >45%
- Hysteresis band prevents flip-flopping
- Multiplies into existing sizing: base × Kelly × regime × streak

**New files:**
- `auto-trader/src/lib/streak-tracker.ts` (~120 lines)
- `supabase/migrations/20260516000002_strategy_streak_state.sql`

## Test plan

- [ ] Auto-trader restarts cleanly
- [ ] `strategy_streak_state` table created with 3 seed rows
- [ ] Monitor logs for streak multiplier messages


Made with [Cursor](https://cursor.com)