### PR TITLE
refactor: move streak board to Performance tab

### DIFF
--- a/app/src/components/PaperTrading/tabs/PerformanceTab.tsx
+++ b/app/src/components/PaperTrading/tabs/PerformanceTab.tsx
@@ -20,6 +20,7 @@ import { SignalScorecard } from '../shared';
 import { MetricsTable } from '../shared/MetricsTable';
 import { formatRegimeLabel } from '../utils';
 import { Spinner } from '../../Spinner';
+import { StreakBoard } from '../shared';
 
 export interface PerformanceTabProps {
   categories: CategoryPerformance[];
@@ -76,6 +77,8 @@ export function PerformanceTab({
 
   return (
     <div className="space-y-4">
+      <StreakBoard />
+
       <div className="space-y-3">
         <div className="rounded-xl border border-[hsl(var(--border))] bg-white p-4">
           <div className="flex items-center justify-between mb-2">

--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -5,7 +5,6 @@ import type { AutoTradeEventRecord, PaperTrade, PendingStrategySignal } from '..
 import { executeSignal } from '../../../lib/paperTradesApi';
 import { fmtUsd } from '../utils';
 import { CLOSED_STATUSES, EXCLUDED_STATUSES } from '../../../../../shared/trade-status-sets.ts';
-import { StreakBoard } from '../shared';
 
 /** Convert raw failure_reason codes into human-readable labels. */
 function formatSkipReason(reason: string | null | undefined): string | null {
@@ -321,8 +320,6 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
 
   return (
     <div className="space-y-3">
-      <StreakBoard />
-
       {displayPnl !== 0 && (
         <div className="flex items-center justify-between rounded-lg bg-[hsl(var(--secondary))] px-4 py-2.5">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
Moves the 10-day streak grid from Today's Activity to the top of Performance where it belongs contextually.

Made with [Cursor](https://cursor.com)