### PR TITLE
fix: options orders now require IB fill confirmation

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -760,7 +760,11 @@ export interface OptionsOrderParams {
 
 export interface OptionsOrderResult {
   orderId: number;
+  avgFillPrice: number;
+  filledQty: number;
 }
+
+const OPT_ORDER_TIMEOUT_MS = 120_000; // 2 min — limit orders need more time than market orders
 
 export function placeOptionsOrder(params: OptionsOrderParams): Promise<OptionsOrderResult> {
   return new Promise((resolve, reject) => {
@@ -769,8 +773,6 @@ export function placeOptionsOrder(params: OptionsOrderParams): Promise<OptionsOr
     }
 
     const { symbol, right, strike, expiry, contracts, account } = params;
-    // IB requires limit prices to conform to minimum tick increments.
-    // Options ≥ $3.00 use $0.05 ticks; options < $3.00 use $0.01 ticks.
     const tick = params.limitPrice >= 3.0 ? 0.05 : 0.01;
     const limitPrice = Math.round(params.limitPrice / tick) * tick;
 
@@ -797,11 +799,21 @@ export function placeOptionsOrder(params: OptionsOrderParams): Promise<OptionsOr
       ...(account ? { account } : {}),
     };
 
+    const timer = setTimeout(() => {
+      _pendingOrderCallbacks.delete(orderId);
+      const msg = `IB options order ${orderId} (${symbol} $${strike}${right}) timed out after ${OPT_ORDER_TIMEOUT_MS / 1000}s — no fill/reject received`;
+      console.error(`[IB] ${msg}`);
+      reject(new Error(msg));
+    }, OPT_ORDER_TIMEOUT_MS);
+
+    _pendingOrderCallbacks.set(orderId, { resolve, reject, timer, symbol });
+
     try {
       ib.placeOrder(orderId, contract, order);
-      console.log(`[IB] Options order placed: SELL ${contracts}x ${symbol} $${strike}${right} ${expiry} @ $${limitPrice} (orderId=${orderId})`);
-      resolve({ orderId });
+      console.log(`[IB] Options order dispatched: SELL ${contracts}x ${symbol} $${strike}${right} ${expiry} @ $${limitPrice} (orderId=${orderId}) — awaiting fill...`);
     } catch (err) {
+      clearTimeout(timer);
+      _pendingOrderCallbacks.delete(orderId);
       reject(err);
     }
   });

--- a/auto-trader/src/lib/options-manager.ts
+++ b/auto-trader/src/lib/options-manager.ts
@@ -13,7 +13,7 @@ import { getSupabase, createAutoTradeEvent } from './supabase.js';
 import { ACTIVE_STATUSES, CLOSED_STATUSES, OPTIONS_MODES } from '../../../shared/trade-status-sets.js';
 import { getOptionsAutoTradeConfig, autoTradeOption, type OptionsTradeTicket } from './options-scanner.js';
 import { getOptionsChain } from './options-chain.js';
-import { isConnected, requestOpenOrders, placeOptionsOrder, getDefaultAccount } from '../ib-connection.js';
+import { isConnected, placeOptionsOrder, getDefaultAccount } from '../ib-connection.js';
 
 import type { AutoTradeEventType } from '../../../shared/auto-trade-events.js';
 
@@ -345,34 +345,33 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
   result.stopLossMultiplier = stopLossMultiplier;
   result.profitClosePct = profitClosePct;
 
-  // ── Check SUBMITTED orders for IB fills ──────────────────
-  if (isConnected()) {
-    const { data: submitted } = await sb
+  // ── Clean up stale SUBMITTED options orders ──────────────
+  // With the fix to placeOptionsOrder (now awaits fill/reject), SUBMITTED
+  // orders should not persist. Any still SUBMITTED after 5 minutes are stale
+  // (order timed out, process restarted, etc.) — mark them CANCELLED.
+  {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    const { data: stale } = await sb
       .from('paper_trades')
-      .select('id, ticker, option_strike, option_premium, ib_order_id')
+      .select('id, ticker, option_strike, ib_order_id')
       .in('mode', [...OPTIONS_MODES])
       .eq('status', 'SUBMITTED')
-      .not('ib_order_id', 'is', null);
+      .lt('opened_at', fiveMinAgo);
 
-    if (submitted?.length) {
-      const openOrders = await requestOpenOrders().catch(() => []);
-      const openOrderIds = new Set(openOrders.map(o => o.orderId));
+    if (stale?.length) {
+      for (const row of stale as Array<{ id: string; ticker: string; option_strike: number; ib_order_id: number | null }>) {
+        await sb.from('paper_trades').update({
+          status: 'CANCELLED',
+          close_reason: 'expired',
+          closed_at: new Date().toISOString(),
+          notes: `[AUTO] Stale SUBMITTED order — no IB fill confirmation received`,
+        }).eq('id', row.id);
 
-      for (const row of submitted as Array<{ id: string; ticker: string; option_strike: number; option_premium: number; ib_order_id: number }>) {
-        if (!openOrderIds.has(row.ib_order_id)) {
-          // Order no longer open → it filled (or was cancelled; treat as filled for options sells)
-          await sb.from('paper_trades').update({
-            status: 'FILLED',
-            filled_at: new Date().toISOString(),
-            fill_price: row.option_premium,
-          }).eq('id', row.id);
-
-          console.log(`[Options Manager] Order ${row.ib_order_id} for ${row.ticker} $${row.option_strike}P confirmed filled`);
-          persistEvent(row.ticker, 'success',
-            `✅ ${row.ticker} $${row.option_strike} put order filled — premium $${(row.option_premium * 100).toFixed(0)} collected`,
-            { action: 'filled', source: 'options', metadata: { ibOrderId: row.ib_order_id } }
-          );
-        }
+        console.log(`[Options Manager] Cancelled stale SUBMITTED order for ${row.ticker} $${row.option_strike}P (ib_order=${row.ib_order_id})`);
+        persistEvent(row.ticker, 'warning',
+          `⚠️ ${row.ticker} $${row.option_strike}P order expired — no IB fill confirmation`,
+          { action: 'skipped', source: 'scanner', mode: 'OPTIONS_PUT', metadata: { ibOrderId: row.ib_order_id } }
+        );
       }
     }
   }

--- a/auto-trader/src/lib/options-scanner.ts
+++ b/auto-trader/src/lib/options-scanner.ts
@@ -1179,7 +1179,7 @@ export async function autoTradeOption(ticket: OptionsTradeTicket): Promise<{ tra
   }
 
   try {
-    const { orderId } = await placeOptionsOrder({
+    const { orderId, avgFillPrice, filledQty } = await placeOptionsOrder({
       symbol: ticket.ticker,
       right: 'P',
       strike: ticket.strike,
@@ -1189,32 +1189,45 @@ export async function autoTradeOption(ticket: OptionsTradeTicket): Promise<{ tra
       account: getDefaultAccount() ?? undefined,
     });
 
-    console.log(`[Options Auto-Trade] Placed IB order ${orderId} for ${ticket.ticker} $${ticket.strike}P`);
-    const tradeId = await paperTradeOption(ticket, orderId);
+    console.log(`[Options Auto-Trade] IB order ${orderId} FILLED for ${ticket.ticker} $${ticket.strike}P @ $${avgFillPrice.toFixed(2)} (${filledQty} contracts)`);
+
+    // Record with real IB fill price — no SUBMITTED state needed since we awaited confirmation
+    const realPremium = avgFillPrice;
+    const tradeId = await paperTradeOption({ ...ticket, premium: realPremium }, orderId);
+
+    // Immediately mark as FILLED with real fill price (paperTradeOption sets SUBMITTED for live orders)
+    if (tradeId) {
+      const sb = getSupabase();
+      await sb.from('paper_trades').update({
+        status: 'FILLED',
+        fill_price: realPremium,
+        filled_at: new Date().toISOString(),
+      }).eq('id', tradeId);
+    }
+
     createAutoTradeEvent({
       ticker: ticket.ticker,
       event_type: 'success',
       action: 'executed',
       source: 'scanner',
       mode: 'OPTIONS_PUT',
-      message: `Live order placed #${orderId} — Sold ${ticket.contracts ?? 1}x $${ticket.strike}P exp ${ticket.expiry}, limit $${ticket.premium.toFixed(2)}/contract`,
-      metadata: { ibOrderId: orderId, strike: ticket.strike, expiry: ticket.expiry, premium: ticket.premium, contracts: ticket.contracts ?? 1 },
+      message: `IB order filled #${orderId} — Sold ${filledQty}x $${ticket.strike}P exp ${ticket.expiry} @ $${realPremium.toFixed(2)}/contract`,
+      metadata: { ibOrderId: orderId, strike: ticket.strike, expiry: ticket.expiry, premium: realPremium, contracts: filledQty },
     }).catch(() => {});
     return { tradeId, ibOrderId: orderId, isLive: true };
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
-    console.error('[Options Auto-Trade] IB order failed, falling back to paper:', err);
-    const tradeId = await paperTradeOption(ticket);
+    console.error('[Options Auto-Trade] IB order rejected/timed out:', errMsg);
     createAutoTradeEvent({
       ticker: ticket.ticker,
       event_type: 'error',
       action: 'failed',
       source: 'scanner',
       mode: 'OPTIONS_PUT',
-      message: `IB order failed — paper fallback. $${ticket.strike}P exp ${ticket.expiry}. Error: ${errMsg}`,
+      message: `IB options order rejected — ${ticket.ticker} $${ticket.strike}P exp ${ticket.expiry}. ${errMsg}`,
       metadata: { strike: ticket.strike, expiry: ticket.expiry, premium: ticket.premium, error: errMsg } as Record<string, unknown>,
     }).catch(() => {});
-    return { tradeId, ibOrderId: null, isLive: false };
+    return { tradeId: null, ibOrderId: null, isLive: false };
   }
 }
 


### PR DESCRIPTION
## Summary

Critical bug fix: options orders were being recorded as FILLED with fake
prices even when IB rejected/cancelled them.

- `placeOptionsOrder()` now awaits real IB fill/reject (like market orders do)
- `autoTradeOption()` uses IB's `avgFillPrice`, not scanner math
- Removed dangerous "not in open orders = filled" inference
- Cleaned up 12 ghost records in DB

## Test plan

- [ ] Auto-trader restarts cleanly
- [ ] Next options scan attempts real IB order placement
- [ ] Rejected orders log error, don't create DB records
- [ ] Successful fills show real IB prices (nickel increments)
- [ ] Ghost records no longer appear in UI


Made with [Cursor](https://cursor.com)