### PR TITLE
fix: stale weekend P&L display + orphan alert spam

### DIFF
--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -541,7 +541,7 @@ export function PaperTrading() {
           icon={<TrendingUp className="w-4 h-4" />}
           label="Unrealized P&L"
           value={connected && totalMktValue > 0 ? fmtUsd(totalUnrealizedPnl, 0, true) : '—'}
-          subtitle={ibAccountPnl?.realizedPnL != null
+          subtitle={ibAccountPnl?.realizedPnL != null && new Date().getDay() !== 0 && new Date().getDay() !== 6
             ? `Today Realized: ${fmtUsd(ibAccountPnl.realizedPnL, 0, true)}`
             : `All-Time: ${fmtUsd(performance?.total_pnl ?? 0, 0, true)}`}
           color={totalUnrealizedPnl >= 0 ? 'green' : 'red'}

--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -42,6 +42,12 @@ type FilterMode = 'all' | 'day' | 'penny' | 'long_term' | 'gainers' | 'losers';
 type SortKey = 'ticker' | 'pnl' | 'time' | null;
 type SortDir = 'asc' | 'desc';
 
+function isTradingDay(): boolean {
+  const now = new Date();
+  const day = now.getDay();
+  return day !== 0 && day !== 6; // 0=Sun, 6=Sat
+}
+
 export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], onExecuteSignal, ibRealizedPnl }: TodayActivityTabProps) {
   const [executingId, setExecutingId] = useState<string | null>(null);
   const [executingAll, setExecutingAll] = useState(false);
@@ -243,7 +249,8 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
   };
 
   const allEventPnl = useMemo(() => computeEventPnl(events), [events, tradesByTicker]);
-  const todayPnlAll = ibRealizedPnl ?? allEventPnl;
+  const effectiveIbPnl = isTradingDay() ? ibRealizedPnl : null;
+  const todayPnlAll = effectiveIbPnl ?? allEventPnl;
 
   function handleSort(key: SortKey) {
     if (sortKey === key) {
@@ -309,8 +316,8 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
   }, [events, filterMode, sortKey, sortDir, tradesByTicker]);
 
   const filteredPnl = useMemo(() => computeEventPnl(filteredSortedEvents), [filteredSortedEvents, tradesByTicker]);
-  const useIbPnl = filterMode === 'all' && ibRealizedPnl != null;
-  const displayPnl = useIbPnl ? ibRealizedPnl : filterMode === 'all' ? todayPnlAll : filteredPnl;
+  const useIbPnl = filterMode === 'all' && effectiveIbPnl != null;
+  const displayPnl = useIbPnl ? effectiveIbPnl : filterMode === 'all' ? todayPnlAll : filteredPnl;
   const pnlLabel = filterMode === 'all' ? "Today's Realized P&L"
     : filterMode === 'day' ? 'Day Trade P&L'
     : filterMode === 'penny' ? 'Penny P&L'

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -541,11 +541,13 @@ Action needed: Check the auto-trader service and restart if necessary.`,
       const deferred = shortResult.errors.length > 0 && shortResult.closed.length === 0
         || longResult.errors.length > 0 && longResult.closed.length === 0;
       if (deferred) {
-        // Deferred (market closed) — schedule retry at 9:31 AM ET if we're before open
+        // Deferred (market closed) — schedule retry at 9:31 AM ET on next weekday
         const etNow = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
+        const etDay = etNow.getDay();
         const etMins = etNow.getHours() * 60 + etNow.getMinutes();
         const marketOpenMin = 9 * 60 + 31; // 9:31 AM ET
-        if (etMins < marketOpenMin) {
+        const isWeekday = etDay >= 1 && etDay <= 5;
+        if (isWeekday && etMins < marketOpenMin) {
           const delayMs = (marketOpenMin - etMins) * 60_000;
           log(`[IBReconcile] Scheduling retry in ${Math.round(delayMs / 60_000)} min (at 9:31 AM ET)`);
           setTimeout(() => {
@@ -558,6 +560,8 @@ Action needed: Check the auto-trader service and restart if necessary.`,
               }),
             ]);
           }, delayMs);
+        } else if (!isWeekday) {
+          log('[IBReconcile] Weekend — deferring reconciliation until Monday market open');
         }
       }
     } catch (err) {
@@ -1018,17 +1022,30 @@ export async function reconcileIBShorts(): Promise<{ closed: string[]; errors: s
     const tickers = shorts.map(p => `${p.symbol}(${Math.abs(p.position)})`).join(', ');
     const alertMsg = `[IBReconcile] ⚠️ CRITICAL: ${shorts.length} orphaned short position(s) detected AFTER HOURS: ${tickers}. Cannot place cover orders — market is closed. Will retry at next startup during market hours.`;
     log(alertMsg);
-    await createAutoTradeEvent({
-      ticker: 'SYSTEM',
-      event_type: 'error',
-      action: 'failed',
-      source: 'system',
-      message: alertMsg,
-      metadata: {
-        reconcile_type: 'ib_short_reconcile_deferred',
-        shorts: shorts.map(p => ({ symbol: p.symbol, qty: Math.abs(p.position), avgCost: p.avgCost })),
-      },
-    });
+
+    // Only create one deferred alert per calendar day to avoid spamming on every restart
+    const todayStr = etNow.toISOString().slice(0, 10);
+    const { data: existing } = await getSupabase()
+      .from('auto_trade_events')
+      .select('id')
+      .eq('ticker', 'SYSTEM')
+      .gte('created_at', `${todayStr}T00:00:00Z`)
+      .ilike('message', '%orphaned short%AFTER HOURS%')
+      .limit(1);
+
+    if (!existing?.length) {
+      await createAutoTradeEvent({
+        ticker: 'SYSTEM',
+        event_type: 'error',
+        action: 'failed',
+        source: 'system',
+        message: alertMsg,
+        metadata: {
+          reconcile_type: 'ib_short_reconcile_deferred',
+          shorts: shorts.map(p => ({ symbol: p.symbol, qty: Math.abs(p.position), avgCost: p.avgCost })),
+        },
+      });
+    }
     return { closed: [], errors: [`Market closed — ${shorts.length} short(s) deferred: ${tickers}`] };
   }
 


### PR DESCRIPTION
## Summary

- Don't show IB's stale Friday P&L as "Today's Realized P&L" on weekends
- Dedupe orphan short reconciliation alerts (one per day, not per restart)
- Skip 9:31 retry scheduling on weekends

## Test plan

- [ ] Reload app on Sunday — P&L bar should show $0 or be hidden
- [ ] Auto-trader restart on weekend should NOT create duplicate SYSTEM events
- [ ] Monday morning: reconciler retries ENPH short cover at market open


Made with [Cursor](https://cursor.com)