### PR TITLE
feat: dual-account architecture for paper + live trading

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -13,6 +13,7 @@ import { generateAIInsights } from './lib/aiInsights';
 import { getRiskProfile, setRiskProfile } from './lib/settingsStorage';
 import { cn } from './lib/utils';
 import { AuthProvider, useAuth } from './lib/auth';
+import { AccountProvider } from './contexts/AccountContext';
 import { useAutoTradeScheduler } from './hooks/useAutoTradeScheduler';
 
 // Components
@@ -994,9 +995,11 @@ function AppContent() {
 function App() {
   return (
     <AuthProvider>
-      <BrowserRouter>
-        <AppContent />
-      </BrowserRouter>
+      <AccountProvider>
+        <BrowserRouter>
+          <AppContent />
+        </BrowserRouter>
+      </AccountProvider>
     </AuthProvider>
   );
 }

--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -66,6 +66,7 @@ import {
   clearSharedTradesCache,
 } from '../../lib/paperTradesApi';
 import { getTotalDeployed, getMarketRegime, calculateKellyMultiplier, type MarketRegime } from '../../lib/autoTrader';
+import { useAccountView, type AccountView } from '../../contexts/AccountContext';
 import { Spinner } from '../Spinner';
 import { fmtUsd } from './utils';
 import { StatCard } from './shared';
@@ -81,6 +82,31 @@ import {
 } from './tabs';
 
 export type Tab = 'portfolio' | 'today' | 'smart' | 'strategies' | 'validation' | 'history' | 'performance' | 'settings';
+
+function AccountPill({ value, onChange }: { value: AccountView; onChange: (v: AccountView) => void }) {
+  const pills: Array<{ id: AccountView; label: string; activeClass: string }> = [
+    { id: 'live',  label: '🟢 Live',  activeClass: 'bg-emerald-600 text-white shadow-md shadow-emerald-500/25' },
+    { id: 'paper', label: 'Paper',    activeClass: 'bg-slate-700 text-white shadow-md' },
+    { id: 'all',   label: 'All',      activeClass: 'bg-blue-600 text-white shadow-md shadow-blue-500/25' },
+  ];
+
+  return (
+    <div className="flex items-center gap-0.5 bg-slate-100 p-0.5 rounded-lg">
+      {pills.map(p => (
+        <button
+          key={p.id}
+          onClick={() => onChange(p.id)}
+          className={cn(
+            'px-3 py-1.5 text-xs font-semibold rounded-md transition-all',
+            value === p.id ? p.activeClass : 'text-slate-500 hover:text-slate-700'
+          )}
+        >
+          {p.label}
+        </button>
+      ))}
+    </div>
+  );
+}
 
 // Module-level cache: survives unmount so navigating back is instant
 const PAGE_CACHE_TTL = 2 * 60 * 1000; // 2 minutes
@@ -110,6 +136,7 @@ interface PageCache {
 let _pageCache: PageCache | null = null;
 
 export function PaperTrading() {
+  const { accountView, setAccountView } = useAccountView();
   const cached = _pageCache && Date.now() - _pageCache.ts < PAGE_CACHE_TTL ? _pageCache : null;
 
   const [config, setConfig] = useState<AutoTraderConfig>(getAutoTraderConfig);
@@ -171,8 +198,8 @@ export function PaperTrading() {
   const loadCoreData = useCallback(async () => {
     const [perf, savedEvents, todayEvents] = await Promise.all([
       getPerformance(),
-      getAutoTradeEvents(100),
-      getTodaysExecutedEvents(),
+      getAutoTradeEvents(100, accountView),
+      getTodaysExecutedEvents(accountView),
     ]);
     setPerformance(perf);
     setPersistedEvents(savedEvents);
@@ -223,7 +250,7 @@ export function PaperTrading() {
       for (const group of needed) {
         switch (group) {
           case 'allTrades':
-            promises.push(getAllTrades(500).then(d => { setAllTrades(d); }));
+            promises.push(getAllTrades(500, accountView).then(d => { setAllTrades(d); }));
             break;
           case 'pendingSignals':
             promises.push(getPendingStrategySignals(300).then(d => { setPendingSignals(d); }));
@@ -232,15 +259,15 @@ export function PaperTrading() {
             promises.push(getTodaySignalsForManualExecute().then(d => { setTodaySignalsForExecute(d); }));
             break;
           case 'categoryPerf':
-            promises.push(recalculatePerformanceByCategory().then(d => { setCategoryPerf(d); }));
+            promises.push(recalculatePerformanceByCategory(accountView).then(d => { setCategoryPerf(d); }));
             break;
           case 'totalDeployed':
             promises.push(getTotalDeployed().then(d => { setTotalDeployed(d); }));
             break;
           case 'strategyPerf':
             promises.push(Promise.all([
-              recalculatePerformanceByStrategySource().then(d => { setSourcePerf(d); }),
-              recalculatePerformanceByStrategyVideo().then(d => { setVideoPerf(d); }),
+              recalculatePerformanceByStrategySource(accountView).then(d => { setSourcePerf(d); }),
+              recalculatePerformanceByStrategyVideo(accountView).then(d => { setVideoPerf(d); }),
               getStrategySignalStatusSummaries().then(d => { setStrategyStatuses(d); }),
             ]).then(() => {}));
             break;
@@ -285,6 +312,21 @@ export function PaperTrading() {
   // Re-load IB data when connection or account changes
   useEffect(() => { loadIBData(); }, [loadIBData]);
 
+  // Re-fetch all data when account view switches
+  useEffect(() => {
+    fetchedRef.current.clear();
+    clearSharedTradesCache();
+    _pageCache = null;
+    (async () => {
+      setLoading(true);
+      try {
+        await Promise.all([loadCoreData(), loadIBData(), loadTabData(tab, true)]);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [accountView]); // eslint-disable-line react-hooks/exhaustive-deps
+
   useEffect(() => { loadAutoTraderConfig().then(setConfig); }, []);
 
   // Load tab data lazily when the user switches tabs.
@@ -295,7 +337,7 @@ export function PaperTrading() {
     const forceRefresh = tab === 'today';
     loadTabData(tab, forceRefresh);
     if (forceRefresh) {
-      getTodaysExecutedEvents().then(setTodaysExecuted).catch(() => {});
+      getTodaysExecutedEvents(accountView).then(setTodaysExecuted).catch(() => {});
       loadIBData();
     }
   }, [tab]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -436,12 +478,19 @@ export function PaperTrading() {
       <div>
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-[hsl(var(--foreground))]">Paper Trading</h1>
+            <h1 className="text-2xl font-bold text-[hsl(var(--foreground))]">
+              {accountView === 'live' ? 'Live Trading' : accountView === 'all' ? 'All Accounts' : 'Paper Trading'}
+            </h1>
             <p className="text-sm text-[hsl(var(--muted-foreground))] mt-1">
-              Auto-execute scanner signals on IB paper account
+              {accountView === 'live'
+                ? 'Live account — real money positions'
+                : accountView === 'all'
+                  ? 'Combined view of paper + live accounts'
+                  : 'Auto-execute scanner signals on IB paper account'}
             </p>
           </div>
           <div className="flex items-center gap-3">
+            <AccountPill value={accountView} onChange={setAccountView} />
             <button
               onClick={handleSync}
               disabled={syncing || !connected}
@@ -611,6 +660,7 @@ export function PaperTrading() {
               pendingSignals={pendingSignals}
               connected={connected}
               onRefresh={loadIBData}
+              accountView={accountView}
             />
           )}
           {tab === 'today' && (
@@ -620,6 +670,7 @@ export function PaperTrading() {
               todaySignalsForExecute={todaySignalsForExecute}
               onExecuteSignal={refreshAfterAction}
               ibRealizedPnl={ibAccountPnl?.realizedPnL ?? null}
+              accountView={accountView}
             />
           )}
           {tab === 'smart' && (
@@ -644,13 +695,14 @@ export function PaperTrading() {
             />
           )}
           {tab === 'history' && (
-            <HistoryTab trades={allTrades} pendingSignals={pendingSignals} />
+            <HistoryTab trades={allTrades} pendingSignals={pendingSignals} accountView={accountView} />
           )}
           {tab === 'performance' && (
             <PerformanceTab
               categories={categoryPerf}
               totalDeployed={totalDeployed}
               maxAllocation={config.maxTotalAllocation}
+              accountView={accountView}
             />
           )}
           {tab === 'settings' && (

--- a/app/src/components/PaperTrading/tabs/HistoryTab.tsx
+++ b/app/src/components/PaperTrading/tabs/HistoryTab.tsx
@@ -1,17 +1,29 @@
 import { useState } from 'react';
 import { Clock } from 'lucide-react';
-import type { PaperTrade, PendingStrategySignal } from '../../../lib/paperTradesApi';
+import type { PaperTrade, PendingStrategySignal, PaperTradeWithAccount } from '../../../lib/paperTradesApi';
+import type { AccountView } from '../../../contexts/AccountContext';
 import { fmtUsd } from '../utils';
 import { StatusBadge } from '../shared';
 
 type HistorySortKey = 'date' | 'ticker' | 'pnl' | 'signal' | 'status';
 
+function AccountDot({ type }: { type?: 'paper' | 'live' }) {
+  if (!type) return null;
+  return (
+    <span
+      className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${type === 'live' ? 'bg-emerald-500' : 'bg-slate-400'}`}
+      title={type === 'live' ? 'Live trade' : 'Paper trade'}
+    />
+  );
+}
+
 export interface HistoryTabProps {
   trades: PaperTrade[];
   pendingSignals: PendingStrategySignal[];
+  accountView?: AccountView;
 }
 
-export function HistoryTab({ trades, pendingSignals }: HistoryTabProps) {
+export function HistoryTab({ trades, pendingSignals, accountView }: HistoryTabProps) {
   const [sortKey, setSortKey] = useState<HistorySortKey>('date');
   const [sortAsc, setSortAsc] = useState(false);
 
@@ -164,7 +176,12 @@ export function HistoryTab({ trades, pendingSignals }: HistoryTabProps) {
               const isActive = ['SUBMITTED', 'FILLED', 'PARTIAL', 'PENDING'].includes(trade.status);
               return (
                 <tr key={trade.id} className={`hover:bg-[hsl(var(--secondary))]/50 ${isActive ? 'bg-blue-50/30' : ''}`}>
-                  <td className="px-4 py-3 font-bold">{trade.ticker}</td>
+                  <td className="px-4 py-3 font-bold">
+                    <span className="inline-flex items-center gap-1.5">
+                      {accountView === 'all' && <AccountDot type={(trade as PaperTradeWithAccount)._accountType} />}
+                      {trade.ticker}
+                    </span>
+                  </td>
                   <td className="px-4 py-3">
                     <span className={`inline-flex px-2 py-0.5 rounded text-[10px] font-bold ${trade.signal === 'BUY' ? 'bg-emerald-100 text-emerald-700' : 'bg-red-100 text-red-700'}`}>
                       {trade.signal}

--- a/app/src/components/PaperTrading/tabs/PerformanceTab.tsx
+++ b/app/src/components/PaperTrading/tabs/PerformanceTab.tsx
@@ -22,16 +22,20 @@ import { formatRegimeLabel } from '../utils';
 import { Spinner } from '../../Spinner';
 import { StreakBoard } from '../shared';
 
+import type { AccountView } from '../../../contexts/AccountContext';
+
 export interface PerformanceTabProps {
   categories: CategoryPerformance[];
   totalDeployed: number;
   maxAllocation: number;
+  accountView?: AccountView;
 }
 
 export function PerformanceTab({
   categories,
   totalDeployed,
   maxAllocation,
+  accountView: _accountView,
 }: PerformanceTabProps) {
   const [window, setWindow] = useState<'7d' | '30d' | '90d'>('30d');
   const [data, setData] = useState<PerformanceResponse | null>(null);

--- a/app/src/components/PaperTrading/tabs/PortfolioTab.tsx
+++ b/app/src/components/PaperTrading/tabs/PortfolioTab.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import type { IBPosition, IBLiveOrder } from '../../../lib/ibClient';
 import type { PendingStrategySignal } from '../../../lib/paperTradesApi';
+import type { AccountView } from '../../../contexts/AccountContext';
 import { fmtUsd } from '../utils';
 import { StatusBadge } from '../shared';
 
@@ -40,9 +41,10 @@ export interface PortfolioTabProps {
   pendingSignals: PendingStrategySignal[];
   connected: boolean;
   onRefresh: () => void;
+  accountView?: AccountView;
 }
 
-export function PortfolioTab({ positions, orders, pendingSignals, connected, onRefresh }: PortfolioTabProps) {
+export function PortfolioTab({ positions, orders, pendingSignals, connected, onRefresh, accountView: _accountView }: PortfolioTabProps) {
   const [sortKey, setSortKey] = useState<PortfolioSortKey>('costBasis');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
 

--- a/app/src/components/PaperTrading/tabs/SettingsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/SettingsTab.tsx
@@ -620,6 +620,127 @@ export function SettingsTab({ config, onUpdate }: SettingsTabProps) {
           </p>
         </div>
       </div>
+
+      {/* ── Live Trading Section ── */}
+      <div className="border-t border-[hsl(var(--border))] pt-6 mt-6">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h4 className="text-sm font-semibold text-[hsl(var(--foreground))]">🟢 Live Trading</h4>
+            <p className="text-xs text-[hsl(var(--muted-foreground))] mt-0.5">Real money — IB live account settings</p>
+          </div>
+        </div>
+
+        {/* Kill switch */}
+        <div className="rounded-lg border-2 border-red-300 bg-red-50/50 p-4 mb-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <AlertTriangle className="w-5 h-5 text-red-600 flex-shrink-0" />
+              <div>
+                <p className="text-sm font-bold text-red-800">Live Kill Switch</p>
+                <p className="text-xs text-red-600">
+                  {config.liveKillSwitch
+                    ? 'ON — All live trading is BLOCKED. Only paper trades will execute.'
+                    : 'OFF — Live-routed modes will trade with real money.'}
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={() => onUpdate({ liveKillSwitch: !config.liveKillSwitch })}
+              className={cn(
+                'relative inline-flex h-7 w-14 items-center rounded-full transition-colors flex-shrink-0',
+                config.liveKillSwitch ? 'bg-red-600' : 'bg-emerald-600'
+              )}
+            >
+              <span className={cn(
+                'inline-block h-5 w-5 rounded-full bg-white transition-transform',
+                config.liveKillSwitch ? 'translate-x-8' : 'translate-x-1'
+              )} />
+            </button>
+          </div>
+        </div>
+
+        {/* Mode routing */}
+        <div className="rounded-lg border border-[hsl(var(--border))] bg-slate-50 p-4 mb-4">
+          <h5 className="text-xs font-semibold text-[hsl(var(--foreground))] mb-2">Mode Routing</h5>
+          <p className="text-[10px] text-[hsl(var(--muted-foreground))] mb-3">
+            Which account receives orders for each trade mode. Changes apply on next auto-trader cycle.
+          </p>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+            {Object.entries(config.modeRouting ?? {}).map(([mode, target]) => (
+              <div key={mode} className="flex items-center justify-between bg-white rounded-md border border-[hsl(var(--border))] px-3 py-1.5">
+                <span className="text-xs font-medium text-[hsl(var(--foreground))]">
+                  {mode.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, c => c.toUpperCase())}
+                </span>
+                <button
+                  onClick={() => {
+                    const updated = { ...config.modeRouting, [mode]: target === 'paper' ? 'live' as const : 'paper' as const };
+                    onUpdate({ modeRouting: updated });
+                  }}
+                  className={cn(
+                    'px-2 py-0.5 rounded text-[10px] font-bold transition-colors',
+                    target === 'live'
+                      ? 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200'
+                      : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                  )}
+                >
+                  {target.toUpperCase()}
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Live sizing parameters */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label className="block text-xs font-medium text-[hsl(var(--foreground))] mb-1">Portfolio Value ($)</label>
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs text-[hsl(var(--muted-foreground))]">$</span>
+              <NumInput value={config.livePortfolioValue} onCommit={v => onUpdate({ livePortfolioValue: v })}
+                className="w-full px-2 py-1.5 border border-[hsl(var(--border))] rounded-lg text-xs"
+                min={1000} step={1000} />
+            </div>
+            <p className="text-[10px] text-[hsl(var(--muted-foreground))] mt-0.5">Total value of live IB account</p>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-[hsl(var(--foreground))] mb-1">Position Size ($)</label>
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs text-[hsl(var(--muted-foreground))]">$</span>
+              <NumInput value={config.livePositionSize} onCommit={v => onUpdate({ livePositionSize: v })}
+                className="w-full px-2 py-1.5 border border-[hsl(var(--border))] rounded-lg text-xs"
+                min={100} step={100} />
+            </div>
+            <p className="text-[10px] text-[hsl(var(--muted-foreground))] mt-0.5">Max $ per live trade</p>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-[hsl(var(--foreground))] mb-1">Max Positions</label>
+            <NumInput value={config.liveMaxPositions} onCommit={v => onUpdate({ liveMaxPositions: v })}
+              className="w-full px-2 py-1.5 border border-[hsl(var(--border))] rounded-lg text-xs"
+              min={1} max={10} />
+            <p className="text-[10px] text-[hsl(var(--muted-foreground))] mt-0.5">Max concurrent live positions</p>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-[hsl(var(--foreground))] mb-1">Daily Loss Limit ($)</label>
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs text-[hsl(var(--muted-foreground))]">$</span>
+              <NumInput value={config.liveDailyLossLimit} onCommit={v => onUpdate({ liveDailyLossLimit: v })}
+                className="w-full px-2 py-1.5 border border-[hsl(var(--border))] rounded-lg text-xs"
+                min={-10000} max={0} step={100} />
+            </div>
+            <p className="text-[10px] text-[hsl(var(--muted-foreground))] mt-0.5">Stop live trading if daily losses exceed this (negative number)</p>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-[hsl(var(--foreground))] mb-1">Daily Deployment Limit ($)</label>
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs text-[hsl(var(--muted-foreground))]">$</span>
+              <NumInput value={config.liveMaxDailyDeployment} onCommit={v => onUpdate({ liveMaxDailyDeployment: v })}
+                className="w-full px-2 py-1.5 border border-[hsl(var(--border))] rounded-lg text-xs"
+                min={500} step={500} />
+            </div>
+            <p className="text-[10px] text-[hsl(var(--muted-foreground))] mt-0.5">Max new capital deployed per day on live account</p>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -30,12 +30,26 @@ function formatSkipReason(reason: string | null | undefined): string | null {
   return reason;
 }
 
+import type { AccountView } from '../../../contexts/AccountContext';
+import type { AutoTradeEventWithAccount } from '../../../lib/paperTradesApi';
+
+function AccountDot({ type }: { type?: 'paper' | 'live' }) {
+  if (!type) return null;
+  return (
+    <span
+      className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${type === 'live' ? 'bg-emerald-500' : 'bg-slate-400'}`}
+      title={type === 'live' ? 'Live trade' : 'Paper trade'}
+    />
+  );
+}
+
 export interface TodayActivityTabProps {
   events: AutoTradeEventRecord[];
   trades: PaperTrade[];
   todaySignalsForExecute?: PendingStrategySignal[];
   onExecuteSignal?: () => void;
   ibRealizedPnl?: number | null;
+  accountView?: AccountView;
 }
 
 type FilterMode = 'all' | 'day' | 'penny' | 'long_term' | 'gainers' | 'losers';
@@ -48,7 +62,7 @@ function isTradingDay(): boolean {
   return day !== 0 && day !== 6; // 0=Sun, 6=Sat
 }
 
-export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], onExecuteSignal, ibRealizedPnl }: TodayActivityTabProps) {
+export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], onExecuteSignal, ibRealizedPnl, accountView }: TodayActivityTabProps) {
   const [executingId, setExecutingId] = useState<string | null>(null);
   const [executingAll, setExecutingAll] = useState(false);
   const [filterMode, setFilterMode] = useState<FilterMode>('all');
@@ -467,7 +481,12 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
 
               return (
                 <tr key={event.id} className={cn('hover:bg-[hsl(var(--secondary))]/50', (isPositionSync || isAutoClose) && 'bg-slate-50/50')}>
-                  <td className="px-4 py-3 font-bold">{event.ticker}</td>
+                  <td className="px-4 py-3 font-bold">
+                    <span className="inline-flex items-center gap-1.5">
+                      {accountView === 'all' && <AccountDot type={(event as AutoTradeEventWithAccount)._accountType} />}
+                      {event.ticker}
+                    </span>
+                  </td>
                   <td className="px-4 py-3">
                     <span className={cn('inline-flex px-1.5 py-0.5 rounded text-[10px] font-bold', signalColor)}>
                       {signalLabel}

--- a/app/src/contexts/AccountContext.tsx
+++ b/app/src/contexts/AccountContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+export type AccountView = 'live' | 'paper' | 'all';
+
+interface AccountContextValue {
+  accountView: AccountView;
+  setAccountView: (view: AccountView) => void;
+  tradesTable: (view?: AccountView) => 'paper_trades' | 'live_trades';
+  eventsTable: (view?: AccountView) => 'auto_trade_events' | 'live_trade_events';
+}
+
+function resolveTradesTable(view: AccountView): 'paper_trades' | 'live_trades' {
+  return view === 'live' ? 'live_trades' : 'paper_trades';
+}
+
+function resolveEventsTable(view: AccountView): 'auto_trade_events' | 'live_trade_events' {
+  return view === 'live' ? 'live_trade_events' : 'auto_trade_events';
+}
+
+const AccountContext = createContext<AccountContextValue>({
+  accountView: 'paper',
+  setAccountView: () => {},
+  tradesTable: () => 'paper_trades',
+  eventsTable: () => 'auto_trade_events',
+});
+
+export function AccountProvider({ children }: { children: ReactNode }) {
+  const [accountView, setAccountView] = useState<AccountView>('paper');
+
+  const value: AccountContextValue = {
+    accountView,
+    setAccountView,
+    tradesTable: (view?: AccountView) => resolveTradesTable(view ?? accountView),
+    eventsTable: (view?: AccountView) => resolveEventsTable(view ?? accountView),
+  };
+
+  return <AccountContext.Provider value={value}>{children}</AccountContext.Provider>;
+}
+
+export function useAccountView() {
+  return useContext(AccountContext);
+}

--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -218,6 +218,14 @@ export async function loadAutoTraderConfig(): Promise<AutoTraderConfig> {
         pennyMaxDailyLoss: Number(data.penny_max_daily_loss ?? DEFAULT_CONFIG.pennyMaxDailyLoss),
         pennyMaxDailyTrades: Number(data.penny_max_daily_trades ?? DEFAULT_CONFIG.pennyMaxDailyTrades),
         trendFilterEnabled: data.trend_filter_enabled ?? DEFAULT_CONFIG.trendFilterEnabled,
+        // Dual-account routing
+        modeRouting: data.mode_routing ?? DEFAULT_CONFIG.modeRouting,
+        liveKillSwitch: data.live_kill_switch ?? DEFAULT_CONFIG.liveKillSwitch,
+        liveDailyLossLimit: Number(data.live_daily_loss_limit ?? DEFAULT_CONFIG.liveDailyLossLimit),
+        livePortfolioValue: Number(data.live_portfolio_value ?? DEFAULT_CONFIG.livePortfolioValue),
+        livePositionSize: Number(data.live_position_size ?? DEFAULT_CONFIG.livePositionSize),
+        liveMaxPositions: Number(data.live_max_positions ?? DEFAULT_CONFIG.liveMaxPositions),
+        liveMaxDailyDeployment: Number(data.live_max_daily_deployment ?? DEFAULT_CONFIG.liveMaxDailyDeployment),
       };
       localStorage.setItem(CONFIG_KEY, JSON.stringify(config));
       return config;
@@ -311,6 +319,14 @@ export async function saveAutoTraderConfig(config: Partial<AutoTraderConfig>): P
         penny_max_daily_loss: updated.pennyMaxDailyLoss,
         penny_max_daily_trades: updated.pennyMaxDailyTrades,
         trend_filter_enabled: updated.trendFilterEnabled,
+        // Dual-account routing
+        mode_routing: updated.modeRouting,
+        live_kill_switch: updated.liveKillSwitch,
+        live_daily_loss_limit: updated.liveDailyLossLimit,
+        live_portfolio_value: updated.livePortfolioValue,
+        live_position_size: updated.livePositionSize,
+        live_max_positions: updated.liveMaxPositions,
+        live_max_daily_deployment: updated.liveMaxDailyDeployment,
         updated_at: new Date().toISOString(),
       });
   } catch (err) {

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -6,8 +6,11 @@
 import { supabase } from './supabaseClient';
 import { getExemptFromAutoDeactivationSources } from './strategyVideosApi';
 
-import type { PaperTrade, TradeStatus, CloseReason, TradeMode } from '../../../shared/trade-types.ts';
-export type { PaperTrade, TradeStatus, CloseReason, TradeMode };
+import type { PaperTrade, TradeStatus, CloseReason, TradeMode, AccountType } from '../../../shared/trade-types.ts';
+export type { PaperTrade, TradeStatus, CloseReason, TradeMode, AccountType };
+
+import type { AccountView } from '../contexts/AccountContext';
+export type { AccountView };
 
 import type { AutoTradeEventRecord, AutoTradeAction, AutoTradeSource } from '../../../shared/auto-trade-events.ts';
 export type { AutoTradeEventRecord, AutoTradeAction, AutoTradeSource };
@@ -18,6 +21,19 @@ import {
   EXCLUDED_STATUSES,
   ALL_TERMINAL_STATUSES,
 } from '../../../shared/trade-status-sets.ts';
+
+// ── Account-aware table resolvers ────────────────────────
+
+function tradesTableName(view: AccountView): 'paper_trades' | 'live_trades' {
+  return view === 'live' ? 'live_trades' : 'paper_trades';
+}
+
+function eventsTableName(view: AccountView): 'auto_trade_events' | 'live_trade_events' {
+  return view === 'live' ? 'live_trade_events' : 'auto_trade_events';
+}
+
+// Extended trade type with optional account indicator (used in 'all' view)
+export type PaperTradeWithAccount = PaperTrade & { _accountType?: AccountType };
 
 // ── Shared cache: dedup parallel paper_trades fetches ────
 // The recalculate*() functions all query paper_trades independently.
@@ -31,7 +47,25 @@ let _exemptCache: { data: Set<string>; ts: number } | null = null;
 
 const SHARED_CACHE_TTL = 30_000;
 
-async function getSharedTrades(): Promise<PaperTrade[]> {
+async function getSharedTrades(accountView: AccountView = 'paper'): Promise<PaperTradeWithAccount[]> {
+  if (accountView === 'all') {
+    const [paperResult, liveResult] = await Promise.all([
+      supabase.from('paper_trades').select('*').limit(2000),
+      supabase.from('live_trades').select('*').limit(2000),
+    ]);
+    return [
+      ...(paperResult.data ?? []).map(t => ({ ...t, _accountType: 'paper' as const })),
+      ...(liveResult.data ?? []).map(t => ({ ...t, _accountType: 'live' as const })),
+    ].sort((a, b) => new Date(b.opened_at).getTime() - new Date(a.opened_at).getTime()) as PaperTradeWithAccount[];
+  }
+
+  if (accountView === 'live') {
+    const { data, error } = await supabase.from('live_trades').select('*').limit(2000);
+    if (error) throw new Error(`Failed to fetch live trades: ${error.message}`);
+    return (data ?? []) as PaperTradeWithAccount[];
+  }
+
+  // Paper (default) — use the cache
   if (_sharedTradesCache && Date.now() - _sharedTradesCache.ts < SHARED_CACHE_TTL) {
     return _sharedTradesCache.data;
   }
@@ -169,15 +203,28 @@ export async function getActiveTrades(): Promise<PaperTrade[]> {
 }
 
 /** Get all trades (most recent first) */
-export async function getAllTrades(limit = 50): Promise<PaperTrade[]> {
+export async function getAllTrades(limit = 50, accountView: AccountView = 'paper'): Promise<PaperTradeWithAccount[]> {
+  if (accountView === 'all') {
+    const [paperResult, liveResult] = await Promise.all([
+      supabase.from('paper_trades').select('*').order('opened_at', { ascending: false }).limit(limit),
+      supabase.from('live_trades').select('*').order('opened_at', { ascending: false }).limit(limit),
+    ]);
+    return [
+      ...(paperResult.data ?? []).map(t => ({ ...t, _accountType: 'paper' as const })),
+      ...(liveResult.data ?? []).map(t => ({ ...t, _accountType: 'live' as const })),
+    ].sort((a, b) => new Date(b.opened_at).getTime() - new Date(a.opened_at).getTime())
+      .slice(0, limit) as PaperTradeWithAccount[];
+  }
+
+  const table = tradesTableName(accountView);
   const { data, error } = await supabase
-    .from('paper_trades')
+    .from(table)
     .select('*')
     .order('opened_at', { ascending: false })
     .limit(limit);
 
   if (error) throw new Error(`Failed to fetch trades: ${error.message}`);
-  return (data ?? []) as PaperTrade[];
+  return (data ?? []) as PaperTradeWithAccount[];
 }
 
 /** Day trade validation report — answers: trend vs chop? confidence ≥7 predictive? */
@@ -540,72 +587,106 @@ export async function createAutoTradeEvent(
 }
 
 /** Get recent auto-trade events (most recent first) */
-export async function getAutoTradeEvents(limit = 100): Promise<AutoTradeEventRecord[]> {
+export type AutoTradeEventWithAccount = AutoTradeEventRecord & { _accountType?: AccountType };
+
+export async function getAutoTradeEvents(limit = 100, accountView: AccountView = 'paper'): Promise<AutoTradeEventWithAccount[]> {
+  if (accountView === 'all') {
+    const [paperRes, liveRes] = await Promise.all([
+      supabase.from('auto_trade_events').select('*').order('created_at', { ascending: false }).limit(limit),
+      supabase.from('live_trade_events').select('*').order('created_at', { ascending: false }).limit(limit),
+    ]);
+    return [
+      ...(paperRes.data ?? []).map(e => ({ ...e, _accountType: 'paper' as const })),
+      ...(liveRes.data ?? []).map(e => ({ ...e, _accountType: 'live' as const })),
+    ].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      .slice(0, limit) as AutoTradeEventWithAccount[];
+  }
+
+  const table = eventsTableName(accountView);
   const { data, error } = await supabase
-    .from('auto_trade_events')
+    .from(table)
     .select('*')
     .order('created_at', { ascending: false })
     .limit(limit);
 
   if (error) return [];
-  return (data ?? []) as AutoTradeEventRecord[];
+  return (data ?? []) as AutoTradeEventWithAccount[];
 }
 
 /** Get today's executed events (all modes — day, swing, long-term, system closes) */
-export async function getTodaysExecutedEvents(): Promise<AutoTradeEventRecord[]> {
+export async function getTodaysExecutedEvents(accountView: AccountView = 'paper'): Promise<AutoTradeEventWithAccount[]> {
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
   const todayISO = todayStart.toISOString();
 
-  const [eventsRes, tradesRes] = await Promise.all([
-    supabase
-      .from('auto_trade_events')
-      .select('*')
-      .in('action', ['executed', 'failed', 'closed'])
-      .gte('created_at', todayISO)
-      .order('created_at', { ascending: false }),
-    supabase
-      .from('paper_trades')
-      .select('id, ticker, mode, signal, scanner_confidence, fa_confidence, fa_recommendation, strategy_source, strategy_source_url, strategy_video_id, strategy_video_heading, quantity, fill_price, status, opened_at, filled_at, scanner_signal')
-      .in('status', ['FILLED', 'TARGET_HIT', 'STOPPED', 'CLOSED', 'PARTIAL'])
-      .gte('opened_at', todayISO)
-      .order('opened_at', { ascending: false }),
-  ]);
+  async function fetchForTable(
+    evTable: 'auto_trade_events' | 'live_trade_events',
+    trTable: 'paper_trades' | 'live_trades',
+    acct?: AccountType,
+  ): Promise<AutoTradeEventWithAccount[]> {
+    const [eventsRes, tradesRes] = await Promise.all([
+      supabase.from(evTable).select('*')
+        .in('action', ['executed', 'failed', 'closed'])
+        .gte('created_at', todayISO)
+        .order('created_at', { ascending: false }),
+      supabase.from(trTable)
+        .select('id, ticker, mode, signal, scanner_confidence, fa_confidence, fa_recommendation, strategy_source, strategy_source_url, strategy_video_id, strategy_video_heading, quantity, fill_price, status, opened_at, filled_at, scanner_signal')
+        .in('status', ['FILLED', 'TARGET_HIT', 'STOPPED', 'CLOSED', 'PARTIAL'])
+        .gte('opened_at', todayISO)
+        .order('opened_at', { ascending: false }),
+    ]);
 
-  const events = ((eventsRes.data ?? []) as AutoTradeEventRecord[]).filter(
-    e => e.action === 'executed' || e.action === 'closed' || e.source === 'system'
-  );
+    const events = ((eventsRes.data ?? []) as AutoTradeEventRecord[]).filter(
+      e => e.action === 'executed' || e.action === 'closed' || e.source === 'system'
+    );
 
-  const eventTickers = new Set(
-    events.filter(e => e.action === 'executed').map(e => e.ticker.toUpperCase())
-  );
+    const eventTickers = new Set(
+      events.filter(e => e.action === 'executed').map(e => e.ticker.toUpperCase())
+    );
 
-  const fallbackTrades = (tradesRes.data ?? []).filter(
-    t => !eventTickers.has(t.ticker.toUpperCase())
-  );
+    const fallbackTrades = (tradesRes.data ?? []).filter(
+      t => !eventTickers.has(t.ticker.toUpperCase())
+    );
 
-  const synthetic: AutoTradeEventRecord[] = fallbackTrades.map(t => ({
-    id: `synth-${t.id}`,
-    ticker: t.ticker,
-    event_type: 'success' as const,
-    action: 'executed' as const,
-    source: 'scanner' as const,
-    mode: t.mode as AutoTradeEventRecord['mode'],
-    message: `${t.signal} ${t.quantity ?? '?'} @ $${(t.fill_price ?? 0).toFixed(2)}`,
-    strategy_source: t.strategy_source ?? null,
-    strategy_source_url: t.strategy_source_url ?? null,
-    strategy_video_id: t.strategy_video_id ?? null,
-    strategy_video_heading: t.strategy_video_heading ?? null,
-    scanner_signal: t.scanner_signal ?? t.signal,
-    scanner_confidence: t.scanner_confidence ?? null,
-    fa_recommendation: t.fa_recommendation ?? null,
-    fa_confidence: t.fa_confidence ?? null,
-    skip_reason: null,
-    metadata: { synthetic: true },
-    created_at: t.filled_at ?? t.opened_at,
-  }));
+    const synthetic: AutoTradeEventRecord[] = fallbackTrades.map(t => ({
+      id: `synth-${t.id}`,
+      ticker: t.ticker,
+      event_type: 'success' as const,
+      action: 'executed' as const,
+      source: 'scanner' as const,
+      mode: t.mode as AutoTradeEventRecord['mode'],
+      message: `${t.signal} ${t.quantity ?? '?'} @ $${(t.fill_price ?? 0).toFixed(2)}`,
+      strategy_source: t.strategy_source ?? null,
+      strategy_source_url: t.strategy_source_url ?? null,
+      strategy_video_id: t.strategy_video_id ?? null,
+      strategy_video_heading: t.strategy_video_heading ?? null,
+      scanner_signal: t.scanner_signal ?? t.signal,
+      scanner_confidence: t.scanner_confidence ?? null,
+      fa_recommendation: t.fa_recommendation ?? null,
+      fa_confidence: t.fa_confidence ?? null,
+      skip_reason: null,
+      metadata: { synthetic: true },
+      created_at: t.filled_at ?? t.opened_at,
+    }));
 
-  return [...events, ...synthetic].sort(
+    const result = [...events, ...synthetic];
+    if (acct) return result.map(e => ({ ...e, _accountType: acct }));
+    return result;
+  }
+
+  if (accountView === 'all') {
+    const [paper, live] = await Promise.all([
+      fetchForTable('auto_trade_events', 'paper_trades', 'paper'),
+      fetchForTable('live_trade_events', 'live_trades', 'live'),
+    ]);
+    return [...paper, ...live].sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+  }
+
+  const evTable = eventsTableName(accountView);
+  const trTable = tradesTableName(accountView);
+  return (await fetchForTable(evTable, trTable)).sort(
     (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
   );
 }
@@ -613,17 +694,31 @@ export async function getTodaysExecutedEvents(): Promise<AutoTradeEventRecord[]>
 /** Get auto-trade events for a specific ticker */
 export async function getAutoTradeEventsByTicker(
   ticker: string,
-  limit = 50
-): Promise<AutoTradeEventRecord[]> {
+  limit = 50,
+  accountView: AccountView = 'paper',
+): Promise<AutoTradeEventWithAccount[]> {
+  if (accountView === 'all') {
+    const [paperRes, liveRes] = await Promise.all([
+      supabase.from('auto_trade_events').select('*').eq('ticker', ticker).order('created_at', { ascending: false }).limit(limit),
+      supabase.from('live_trade_events').select('*').eq('ticker', ticker).order('created_at', { ascending: false }).limit(limit),
+    ]);
+    return [
+      ...(paperRes.data ?? []).map(e => ({ ...e, _accountType: 'paper' as const })),
+      ...(liveRes.data ?? []).map(e => ({ ...e, _accountType: 'live' as const })),
+    ].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      .slice(0, limit) as AutoTradeEventWithAccount[];
+  }
+
+  const table = eventsTableName(accountView);
   const { data, error } = await supabase
-    .from('auto_trade_events')
+    .from(table)
     .select('*')
     .eq('ticker', ticker)
     .order('created_at', { ascending: false })
     .limit(limit);
 
   if (error) return [];
-  return (data ?? []) as AutoTradeEventRecord[];
+  return (data ?? []) as AutoTradeEventWithAccount[];
 }
 
 /** Get event stats for analysis — counts by action type */
@@ -685,9 +780,10 @@ export async function getPerformance(): Promise<TradePerformance | null> {
 }
 
 /** Update aggregate performance (recalculate from all trades) */
-export async function recalculatePerformance(): Promise<TradePerformance | null> {
+export async function recalculatePerformance(accountView: AccountView = 'paper'): Promise<TradePerformance | null> {
+  const table = tradesTableName(accountView === 'all' ? 'paper' : accountView);
   const { data: trades, error } = await supabase
-    .from('paper_trades')
+    .from(table)
     .select('*')
     .in('status', [...CLOSED_STATUSES]);
 
@@ -836,10 +932,10 @@ export interface PendingStrategySignal {
  * - dip_buy: dip buy add-ons (portfolio management)
  * - profit_take: profit take trims (portfolio management)
  */
-export async function recalculatePerformanceByCategory(): Promise<CategoryPerformance[]> {
+export async function recalculatePerformanceByCategory(accountView: AccountView = 'paper'): Promise<CategoryPerformance[]> {
   let trades: PaperTrade[];
   try {
-    trades = await getSharedTrades();
+    trades = await getSharedTrades(accountView === 'all' ? 'paper' : accountView);
   } catch {
     return [];
   }
@@ -941,11 +1037,11 @@ export async function recalculatePerformanceByCategory(): Promise<CategoryPerfor
   return results;
 }
 
-export async function recalculatePerformanceByStrategySource(): Promise<StrategySourcePerformance[]> {
+export async function recalculatePerformanceByStrategySource(accountView: AccountView = 'paper'): Promise<StrategySourcePerformance[]> {
   let allTrades: PaperTrade[];
   let exemptSources: Set<string>;
   try {
-    [allTrades, exemptSources] = await Promise.all([getSharedTrades(), getCachedExemptSources()]);
+    [allTrades, exemptSources] = await Promise.all([getSharedTrades(accountView === 'all' ? 'paper' : accountView), getCachedExemptSources()]);
   } catch {
     return [];
   }
@@ -1045,11 +1141,11 @@ export async function recalculatePerformanceByStrategySource(): Promise<Strategy
     .sort((a, b) => b.totalPnl - a.totalPnl);
 }
 
-export async function recalculatePerformanceByStrategyVideo(): Promise<StrategyVideoPerformance[]> {
+export async function recalculatePerformanceByStrategyVideo(accountView: AccountView = 'paper'): Promise<StrategyVideoPerformance[]> {
   let allTrades: PaperTrade[];
   let exemptSources: Set<string>;
   try {
-    [allTrades, exemptSources] = await Promise.all([getSharedTrades(), getCachedExemptSources()]);
+    [allTrades, exemptSources] = await Promise.all([getSharedTrades(accountView === 'all' ? 'paper' : accountView), getCachedExemptSources()]);
   } catch {
     return [];
   }

--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -1,387 +1,35 @@
 /**
  * IB Gateway connection manager using @stoqey/ib (TWS API).
  *
- * - Auto-connects to IB Gateway on port 4002 (paper trading)
- * - Auto-reconnects on disconnect with exponential backoff
- * - Exposes connection state + account info to REST routes
+ * Dual-account architecture:
+ *   - paperConn: port 4002, clientId=1 (paper trading — existing)
+ *   - liveConn:  port 4001, clientId=2 (live trading — new)
+ *
+ * All existing module-level exports (isConnected, placeMarketOrder, etc.)
+ * are backward-compatible thin wrappers delegating to paperConn.
+ * New dual-account code uses the IBConnection class API directly.
  */
 
 import { IBApi, EventName, Contract, Order, OrderAction, OrderType, SecType, TimeInForce, OptionType } from '@stoqey/ib';
-import { insertIbFill, updateIbFillCommission, getTodayFillPrices } from './lib/supabase.js';
+import { insertIbFill, updateIbFillCommission, getTodayFillPrices, getFillPriceByOrderId, saveConfigPartial, createAutoTradeEvent } from './lib/supabase.js';
+import type { AccountType } from '../../shared/trade-types.js';
 
-// ── Configuration ────────────────────────────────────────
+// ── Constants ────────────────────────────────────────────
 
 const IB_HOST = process.env.IB_HOST ?? '127.0.0.1';
-const IB_PORT = parseInt(process.env.IB_PORT ?? '4002', 10);
-const IB_CLIENT_ID = parseInt(process.env.IB_CLIENT_ID ?? '1', 10);
-
 const RECONNECT_BASE_MS = 2_000;
 const RECONNECT_MAX_MS = 60_000;
 const MAX_CONCURRENT_REQUESTS = 8;
+const MKT_ORDER_TIMEOUT_MS = 30_000;
+const OPT_ORDER_TIMEOUT_MS = 120_000;
 
-// ── State ────────────────────────────────────────────────
-
-let ib: IBApi | null = null;
-let connected = false;
-let reconnectAttempts = 0;
-let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-let accounts: string[] = [];
-let nextOrderId = 0;
-let connectionListeners: Array<(state: boolean) => void> = [];
-
-// ── Account-level daily P&L (via reqPnL subscription) ───
-let _pnlReqId = 0;
-let _dailyPnL: number | null = null;
-let _unrealizedPnL: number | null = null;
-let _realizedPnL: number | null = null;
-
-// ── Order fill prices (from orderStatus events) ─────────
-// Maps orderId → avgFillPrice. Populated when IB reports a Filled status.
-const _orderFillPrices = new Map<number, number>();
-
-// Per-request error routing: when IB sends error code 200 for a specific reqId,
-// resolve the pending promise immediately instead of waiting for timeout.
-const _pendingReqCallbacks = new Map<number, (code: number, msg: string) => void>();
-
-// Pending order callbacks: resolves/rejects order promises when IB sends
-// fill confirmation (orderStatus Filled) or rejection (error/Cancelled/Inactive).
-// Prevents the fire-and-forget bug where callers assumed success without confirmation.
-interface PendingOrder {
-  resolve: (result: { orderId: number; avgFillPrice: number; filledQty: number }) => void;
-  reject: (err: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
-  symbol: string;
-}
-const _pendingOrderCallbacks = new Map<number, PendingOrder>();
-
-// Semaphore to limit concurrent IB API requests and prevent flooding
-let _activeRequests = 0;
-const _requestQueue: Array<() => void> = [];
-
-export async function acquireRequestSlot(): Promise<void> {
-  if (_activeRequests < MAX_CONCURRENT_REQUESTS) {
-    _activeRequests++;
-    return;
-  }
-  return new Promise<void>(resolve => {
-    _requestQueue.push(() => { _activeRequests++; resolve(); });
-  });
-}
-
-export function releaseRequestSlot(): void {
-  _activeRequests--;
-  const next = _requestQueue.shift();
-  if (next) next();
-}
-
-export function registerReqErrorCallback(reqId: number, cb: (code: number, msg: string) => void): void {
-  _pendingReqCallbacks.set(reqId, cb);
-}
-
-export function unregisterReqErrorCallback(reqId: number): void {
-  _pendingReqCallbacks.delete(reqId);
-}
-
-// ── Public API ───────────────────────────────────────────
-
-export function isConnected(): boolean {
-  return connected;
-}
-
-export function getAccounts(): string[] {
-  return accounts;
-}
-
-export function getDefaultAccount(): string | null {
-  return accounts[0] ?? null;
-}
-
-export function getIBApi(): IBApi | null {
-  return ib;
-}
-
-export function getNextOrderId(): number {
-  return nextOrderId++;
-}
-
-export function onConnectionChange(fn: (state: boolean) => void): () => void {
-  connectionListeners.push(fn);
-  return () => {
-    connectionListeners = connectionListeners.filter(l => l !== fn);
-  };
-}
+// ── Interfaces (unchanged from original, re-exported) ────
 
 export interface AccountPnL {
   dailyPnL: number | null;
   unrealizedPnL: number | null;
   realizedPnL: number | null;
 }
-
-export function getDailyPnL(): AccountPnL {
-  return { dailyPnL: _dailyPnL, unrealizedPnL: _unrealizedPnL, realizedPnL: _realizedPnL };
-}
-
-/**
- * Get the actual IB fill price for an order from the in-memory cache.
- * For a DB fallback when the cache misses, use getOrderFillPriceWithFallback().
- */
-export function getOrderFillPrice(orderId: number): number | undefined {
-  return _orderFillPrices.get(orderId);
-}
-
-/**
- * Get fill price with DB fallback. Use this in non-hot paths where an async
- * call is acceptable (e.g. syncPositions closure logic).
- */
-export async function getOrderFillPriceWithFallback(orderId: number): Promise<number | undefined> {
-  const cached = _orderFillPrices.get(orderId);
-  if (cached !== undefined) return cached;
-  const { getFillPriceByOrderId } = await import('./lib/supabase.js');
-  const dbPrice = await getFillPriceByOrderId(orderId);
-  if (dbPrice !== undefined) {
-    _orderFillPrices.set(orderId, dbPrice);
-  }
-  return dbPrice;
-}
-
-/**
- * Hydrate the in-memory fill price cache from the ib_fills DB table.
- * Called on startup to survive restarts.
- */
-async function hydrateOrderFillPrices(): Promise<void> {
-  try {
-    const fills = await getTodayFillPrices();
-    let count = 0;
-    for (const [orderId, price] of fills) {
-      if (!_orderFillPrices.has(orderId)) {
-        _orderFillPrices.set(orderId, price);
-        count++;
-      }
-    }
-    if (count > 0) {
-      console.log(`[IB] Hydrated ${count} fill prices from DB`);
-    }
-  } catch (err) {
-    console.warn('[IB] Failed to hydrate fill prices from DB:', err instanceof Error ? err.message : err);
-  }
-}
-
-// ── Connect ──────────────────────────────────────────────
-
-export function connect(): void {
-  if (ib) {
-    try { ib.disconnect(); } catch { /* ignore */ }
-  }
-
-  ib = new IBApi({ host: IB_HOST, port: IB_PORT, clientId: IB_CLIENT_ID });
-
-  // ── Event handlers ──
-
-  ib.on(EventName.connected, () => {
-    console.log(`[IB] Connected to IB Gateway at ${IB_HOST}:${IB_PORT}`);
-    connected = true;
-    reconnectAttempts = 0;
-    connectionListeners.forEach(fn => fn(true));
-
-    // Request managed accounts
-    ib!.reqManagedAccts();
-    // Request next valid order ID
-    ib!.reqIds();
-  });
-
-  ib.on(EventName.disconnected, () => {
-    console.log('[IB] Disconnected from IB Gateway');
-    connected = false;
-    connectionListeners.forEach(fn => fn(false));
-    scheduleReconnect();
-  });
-
-  ib.on(EventName.error, (err: Error, code?: number, reqId?: number) => {
-    // Code 1100 = connectivity lost, 1102 = connectivity restored
-    // Code 2104/2106/2158 = market data farm messages (informational)
-    const infoOnly = code && [2104, 2106, 2108, 2158].includes(code);
-    if (infoOnly) {
-      console.log(`[IB] Info (${code}): ${err.message}`);
-      return;
-    }
-
-    // Route per-request errors (e.g. code 200 "No security definition") to the
-    // waiting promise so it resolves immediately instead of waiting for timeout.
-    if (reqId != null && code != null && _pendingReqCallbacks.has(reqId)) {
-      const cb = _pendingReqCallbacks.get(reqId)!;
-      _pendingReqCallbacks.delete(reqId);
-      cb(code, err.message);
-      return;
-    }
-
-    // Route order-level errors (code 200 = no security def, 201 = rejected,
-    // 202 = cancelled, 110 = price cap, etc.) to the pending order promise.
-    if (reqId != null && _pendingOrderCallbacks.has(reqId)) {
-      const pending = _pendingOrderCallbacks.get(reqId)!;
-      clearTimeout(pending.timer);
-      _pendingOrderCallbacks.delete(reqId);
-      const msg = `IB order ${reqId} (${pending.symbol}) rejected: code=${code} ${err.message}`;
-      console.error(`[IB] ${msg}`);
-      pending.reject(new Error(msg));
-      return;
-    }
-
-    console.error(`[IB] Error (code=${code}, reqId=${reqId}): ${err.message}`);
-
-    if (code === 1100) {
-      connected = false;
-      connectionListeners.forEach(fn => fn(false));
-    }
-  });
-
-  ib.on(EventName.managedAccounts, (accountsList: string) => {
-    accounts = accountsList.split(',').map(a => a.trim()).filter(Boolean);
-    console.log(`[IB] Managed accounts: ${accounts.join(', ')}`);
-
-    // Subscribe to account-level daily P&L once we have the account ID
-    if (accounts[0] && ib) {
-      _pnlReqId = getNextOrderId();
-      _dailyPnL = null;
-      _unrealizedPnL = null;
-      _realizedPnL = null;
-      try {
-        ib.reqPnL(_pnlReqId, accounts[0], '');
-        console.log(`[IB] Subscribed to account PnL (reqId=${_pnlReqId}, account=${accounts[0]})`);
-      } catch (err) {
-        console.warn(`[IB] reqPnL failed:`, err instanceof Error ? err.message : err);
-      }
-    }
-  });
-
-  ib.on(EventName.nextValidId, (orderId: number) => {
-    nextOrderId = orderId;
-    console.log(`[IB] Next valid order ID: ${nextOrderId}`);
-  });
-
-  ib.on(EventName.pnl, (reqId: number, dailyPnL: number, unrealizedPnL?: number, realizedPnL?: number) => {
-    if (reqId !== _pnlReqId) return;
-    _dailyPnL = dailyPnL;
-    _unrealizedPnL = unrealizedPnL ?? null;
-    _realizedPnL = realizedPnL ?? null;
-  });
-
-  ib.on(EventName.orderStatus, (
-    orderId: number, status: string, filled: number,
-    _remaining: number, avgFillPrice: number,
-  ) => {
-    if (status === 'Filled' && avgFillPrice > 0) {
-      _orderFillPrices.set(orderId, avgFillPrice);
-      console.log(`[IB] Order ${orderId} filled @ $${avgFillPrice.toFixed(4)}`);
-
-      // Resolve the pending order promise with fill confirmation
-      if (_pendingOrderCallbacks.has(orderId)) {
-        const pending = _pendingOrderCallbacks.get(orderId)!;
-        clearTimeout(pending.timer);
-        _pendingOrderCallbacks.delete(orderId);
-        pending.resolve({ orderId, avgFillPrice, filledQty: filled });
-      }
-
-      insertIbFill({
-        order_id: orderId,
-        ticker: '',  // orderStatus doesn't include contract info; execDetails will fill this
-        side: '',
-        quantity: filled,
-        fill_price: avgFillPrice,
-        filled_at: new Date().toISOString(),
-      }).catch(err => console.warn(`[IB] Failed to persist orderStatus fill: ${err instanceof Error ? err.message : err}`));
-    }
-
-    // Reject on terminal non-fill statuses
-    if ((status === 'Cancelled' || status === 'Inactive') && _pendingOrderCallbacks.has(orderId)) {
-      const pending = _pendingOrderCallbacks.get(orderId)!;
-      clearTimeout(pending.timer);
-      _pendingOrderCallbacks.delete(orderId);
-      console.error(`[IB] Order ${orderId} (${pending.symbol}) ${status}`);
-      pending.reject(new Error(`IB order ${orderId} (${pending.symbol}) ${status}`));
-    }
-  });
-
-  // execDetails gives us the definitive per-fill record with contract info
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (ib as any).on(EventName.execDetails, (_reqId: number, contract: any, execution: any) => {
-    const orderId = execution?.orderId ?? execution?.order?.orderId;
-    const price = execution?.price ?? execution?.avgPrice;
-    const qty = execution?.shares ?? execution?.cumQty ?? 0;
-    const execId = execution?.execId ?? null;
-    const side = execution?.side ?? '';
-    const ticker = contract?.symbol ?? '';
-
-    if (orderId && price > 0) {
-      _orderFillPrices.set(orderId, price);
-      console.log(`[IB] ExecDetails: order ${orderId} ${side} ${qty}x ${ticker} @ $${price.toFixed(4)} (execId=${execId})`);
-      insertIbFill({
-        order_id: orderId,
-        exec_id: execId,
-        ticker,
-        side,
-        quantity: qty,
-        fill_price: price,
-        filled_at: new Date().toISOString(),
-      }).catch(err => console.warn(`[IB] Failed to persist execDetails fill: ${err instanceof Error ? err.message : err}`));
-    }
-  });
-
-  // commissionReport arrives after execDetails — update the matching fill row with
-  // commission AND IB's realizedPNL. realizedPNL uses IB's FIFO cost basis, so it's
-  // the authoritative P&L when orphaned prior-day lots exist (TSLA/AAPL-style issues).
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (ib as any).on(EventName.commissionReport, (report: any) => {
-    const execId = report?.execId;
-    const commission = report?.commission;
-    const realizedPnl: number | undefined = report?.realizedPNL ?? report?.realizedPnl;
-    if (execId && commission != null && commission < 1e6) {
-      const rpnlStr = realizedPnl != null && isFinite(realizedPnl) && Math.abs(realizedPnl) < 1e6
-        ? ` realizedPnl=$${realizedPnl.toFixed(2)}` : '';
-      console.log(`[IB] Commission: execId=${execId} commission=$${commission.toFixed(4)}${rpnlStr}`);
-      updateIbFillCommission(execId, commission, realizedPnl != null && isFinite(realizedPnl) && Math.abs(realizedPnl) < 1e6 ? realizedPnl : null)
-        .catch(err => console.warn(`[IB] Failed to update commission: ${err instanceof Error ? err.message : err}`));
-    }
-  });
-
-  // Hydrate fill price cache from DB on connect so we survive restarts
-  hydrateOrderFillPrices().catch(() => {});
-
-  // Connect
-  console.log(`[IB] Connecting to ${IB_HOST}:${IB_PORT} (clientId=${IB_CLIENT_ID})...`);
-  ib.connect();
-}
-
-// ── Reconnect ────────────────────────────────────────────
-
-function scheduleReconnect(): void {
-  if (reconnectTimer) return;
-
-  const delay = Math.min(
-    RECONNECT_BASE_MS * Math.pow(2, reconnectAttempts),
-    RECONNECT_MAX_MS
-  );
-  reconnectAttempts++;
-
-  console.log(`[IB] Reconnecting in ${delay / 1000}s (attempt ${reconnectAttempts})...`);
-
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = null;
-    connect();
-  }, delay);
-}
-
-// ── Contract Helper ──────────────────────────────────────
-
-export function createStockContract(symbol: string): Contract {
-  return {
-    symbol: symbol.toUpperCase(),
-    secType: SecType.STK,
-    exchange: 'SMART',
-    currency: 'USD',
-  };
-}
-
-// ── Contract Search ──────────────────────────────────────
 
 export interface ContractSearchResult {
   conId: number;
@@ -391,80 +39,6 @@ export interface ContractSearchResult {
   currency: string;
   description: string;
 }
-
-export async function searchContract(symbol: string): Promise<ContractSearchResult | null> {
-  if (!ib || !connected) {
-    throw new Error('Not connected to IB Gateway');
-  }
-
-  await acquireRequestSlot();
-  try {
-    return await new Promise<ContractSearchResult | null>((resolve) => {
-      const reqId = getNextOrderId();
-      // Use empty exchange for contract detail lookups — SMART is a routing strategy
-      // and reqContractDetails can return empty results when exchange is set to SMART.
-      const contract: Contract = {
-        symbol: symbol.toUpperCase(),
-        secType: SecType.STK,
-        currency: 'USD',
-      };
-      let resolved = false;
-
-      const cleanup = () => {
-        unregisterReqErrorCallback(reqId);
-      };
-
-      const timeout = setTimeout(() => {
-        if (!resolved) {
-          resolved = true;
-          cleanup();
-          resolve(null);
-        }
-      }, 10_000);
-
-      // Register per-request error handler (e.g. code 200 = no security definition)
-      registerReqErrorCallback(reqId, (_code: number, _msg: string) => {
-        if (resolved) return;
-        resolved = true;
-        clearTimeout(timeout);
-        resolve(null);
-      });
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const emitter = ib as any;
-
-      emitter.on(EventName.contractDetails, (rId: number, details: { contract: { conId?: number; symbol?: string; secType?: string; primaryExch?: string; currency?: string }; longName?: string }) => {
-        if (rId !== reqId || resolved) return;
-        resolved = true;
-        clearTimeout(timeout);
-        cleanup();
-
-        resolve({
-          conId: details.contract.conId ?? 0,
-          symbol: details.contract.symbol ?? symbol,
-          secType: details.contract.secType ?? 'STK',
-          primaryExch: details.contract.primaryExch ?? '',
-          currency: details.contract.currency ?? 'USD',
-          description: details.longName ?? '',
-        });
-      });
-
-      emitter.on(EventName.contractDetailsEnd, (rId: number) => {
-        if (rId !== reqId || resolved) return;
-        resolved = true;
-        clearTimeout(timeout);
-        cleanup();
-        resolve(null);
-      });
-
-      ib!.reqContractDetails(reqId, contract);
-    });
-  } finally {
-    releaseRequestSlot();
-  }
-}
-
-// ── Place Bracket Order ──────────────────────────────────
 
 export interface BracketOrderParams {
   symbol: string;
@@ -482,89 +56,6 @@ export interface BracketOrderResult {
   stopLossOrderId: number;
 }
 
-export function placeBracketOrder(params: BracketOrderParams): Promise<BracketOrderResult> {
-  return new Promise((resolve, reject) => {
-    if (!ib || !connected) {
-      return reject(new Error('Not connected to IB Gateway'));
-    }
-
-    const { symbol, side, quantity, entryPrice, stopLoss, takeProfit, tif = 'GTC' } = params;
-
-    // Hard gate: DAY orders must not be placed before 9:30 AM ET.
-    // This is the lowest-level defense — even if application logic fails to check market hours,
-    // the IB client will refuse to send the order. DAY orders expire at market close anyway,
-    // so placing them pre-market means they'd be sent to IB before liquidity exists.
-    if (tif === 'DAY') {
-      const etNow = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
-      const etDay = etNow.getDay();
-      const etMins = etNow.getHours() * 60 + etNow.getMinutes();
-      const marketOpen = 9 * 60 + 30; // 9:30 AM ET
-      if (etDay !== 0 && etDay !== 6 && etMins < marketOpen) {
-        const etStr = `${String(etNow.getHours()).padStart(2, '0')}:${String(etNow.getMinutes()).padStart(2, '0')} ET`;
-        console.error(`[IB] ❌ DAY bracket order for ${symbol} rejected — market not open yet (${etStr})`);
-        return reject(new Error(`DAY order rejected: market not open (${etStr}) — order would be invalid before 9:30 AM ET`));
-      }
-    }
-    const contract = createStockContract(symbol);
-
-    const parentId = getNextOrderId();
-    const tpId = getNextOrderId();
-    const slId = getNextOrderId();
-
-    const closeSide = side === 'BUY' ? OrderAction.SELL : OrderAction.BUY;
-    const ibTif = tif === 'DAY' ? TimeInForce.DAY : TimeInForce.GTC;
-
-    // Parent: limit entry
-    const parentOrder: Order = {
-      action: side === 'BUY' ? OrderAction.BUY : OrderAction.SELL,
-      orderType: OrderType.LMT,
-      totalQuantity: quantity,
-      lmtPrice: entryPrice,
-      tif: ibTif,
-      transmit: false, // don't transmit yet — children first
-    };
-
-    // Take profit: limit close
-    const takeProfitOrder: Order = {
-      action: closeSide,
-      orderType: OrderType.LMT,
-      totalQuantity: quantity,
-      lmtPrice: takeProfit,
-      parentId,
-      tif: ibTif,
-      transmit: false,
-    };
-
-    // Stop loss: stop close
-    const stopLossOrder: Order = {
-      action: closeSide,
-      orderType: OrderType.STP,
-      totalQuantity: quantity,
-      auxPrice: stopLoss,
-      parentId,
-      tif: ibTif,
-      transmit: true, // transmit the whole bracket
-    };
-
-    // Place all three
-    try {
-      ib.placeOrder(parentId, contract, parentOrder);
-      ib.placeOrder(tpId, contract, takeProfitOrder);
-      ib.placeOrder(slId, contract, stopLossOrder);
-
-      resolve({
-        parentOrderId: parentId,
-        takeProfitOrderId: tpId,
-        stopLossOrderId: slId,
-      });
-    } catch (err) {
-      reject(err);
-    }
-  });
-}
-
-// ── Place Market Order (no bracket — simple buy/sell at market) ──
-
 export interface MarketOrderParams {
   symbol: string;
   side: 'BUY' | 'SELL';
@@ -577,57 +68,6 @@ export interface MarketOrderResult {
   filledQty: number;
 }
 
-const MKT_ORDER_TIMEOUT_MS = 30_000;
-
-export function placeMarketOrder(params: MarketOrderParams): Promise<MarketOrderResult> {
-  return new Promise((resolve, reject) => {
-    if (!ib || !connected) {
-      return reject(new Error('Not connected to IB Gateway'));
-    }
-
-    const { symbol, side, quantity } = params;
-    const contract = createStockContract(symbol);
-    const orderId = getNextOrderId();
-
-    const order: Order = {
-      action: side === 'BUY' ? OrderAction.BUY : OrderAction.SELL,
-      orderType: OrderType.MKT,
-      totalQuantity: quantity,
-      tif: TimeInForce.DAY,
-      transmit: true,
-    };
-
-    const timer = setTimeout(() => {
-      _pendingOrderCallbacks.delete(orderId);
-      const msg = `IB order ${orderId} (${symbol} ${side} ${quantity}) timed out after ${MKT_ORDER_TIMEOUT_MS / 1000}s — no fill/error received`;
-      console.error(`[IB] ${msg}`);
-      reject(new Error(msg));
-    }, MKT_ORDER_TIMEOUT_MS);
-
-    _pendingOrderCallbacks.set(orderId, { resolve, reject, timer, symbol });
-
-    try {
-      ib.placeOrder(orderId, contract, order);
-      console.log(`[IB] Market order dispatched: ${side} ${quantity}x ${symbol} (orderId=${orderId}) — awaiting fill...`);
-    } catch (err) {
-      clearTimeout(timer);
-      _pendingOrderCallbacks.delete(orderId);
-      reject(err);
-    }
-  });
-}
-
-// ── Cancel Order ─────────────────────────────────────────
-
-export function cancelOrder(orderId: number): void {
-  if (!ib || !connected) {
-    throw new Error('Not connected to IB Gateway');
-  }
-  ib.cancelOrder(orderId);
-}
-
-// ── Positions ────────────────────────────────────────────
-
 export interface PositionData {
   account: string;
   symbol: string;
@@ -636,54 +76,6 @@ export interface PositionData {
   avgCost: number;
   conId: number;
 }
-
-export function requestPositions(): Promise<PositionData[]> {
-  return new Promise((resolve, reject) => {
-    if (!ib || !connected) {
-      return reject(new Error('Not connected to IB Gateway'));
-    }
-
-    const positions: PositionData[] = [];
-    let resolved = false;
-
-    const timeout = setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        resolve(positions);
-      }
-    }, 10_000);
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const emitter = ib as any;
-
-    const posHandler = (account: string, contract: Contract, pos: number, avgCost: number) => {
-      if (resolved) return;
-      positions.push({
-        account,
-        symbol: contract.symbol ?? '',
-        secType: contract.secType ?? '',
-        position: pos,
-        avgCost,
-        conId: contract.conId ?? 0,
-      });
-    };
-
-    const endHandler = () => {
-      if (resolved) return;
-      resolved = true;
-      clearTimeout(timeout);
-      emitter.off(EventName.position, posHandler);
-      emitter.off(EventName.positionEnd, endHandler);
-      resolve(positions);
-    };
-
-    emitter.on(EventName.position, posHandler);
-    emitter.on(EventName.positionEnd, endHandler);
-    ib.reqPositions();
-  });
-}
-
-// ── Open Orders ──────────────────────────────────────────
 
 export interface OpenOrderData {
   orderId: number;
@@ -697,64 +89,13 @@ export interface OpenOrderData {
   parentId: number;
 }
 
-export function requestOpenOrders(): Promise<OpenOrderData[]> {
-  return new Promise((resolve, reject) => {
-    if (!ib || !connected) {
-      return reject(new Error('Not connected to IB Gateway'));
-    }
-
-    const orders: OpenOrderData[] = [];
-    let resolved = false;
-
-    const timeout = setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        resolve(orders);
-      }
-    }, 10_000);
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const emitter = ib as any;
-
-    const orderHandler = (orderId: number, contract: Contract, order: Order, orderState: { status?: string }) => {
-      if (resolved) return;
-      orders.push({
-        orderId,
-        symbol: contract.symbol ?? '',
-        action: String(order.action ?? ''),
-        orderType: String(order.orderType ?? ''),
-        totalQuantity: Number(order.totalQuantity ?? 0),
-        lmtPrice: Number(order.lmtPrice ?? 0),
-        auxPrice: Number(order.auxPrice ?? 0),
-        status: orderState.status ?? '',
-        parentId: Number(order.parentId ?? 0),
-      });
-    };
-
-    const endHandler = () => {
-      if (resolved) return;
-      resolved = true;
-      clearTimeout(timeout);
-      emitter.off(EventName.openOrder, orderHandler);
-      emitter.off(EventName.openOrderEnd, endHandler);
-      resolve(orders);
-    };
-
-    emitter.on(EventName.openOrder, orderHandler);
-    emitter.on(EventName.openOrderEnd, endHandler);
-    ib.reqAllOpenOrders();
-  });
-}
-
-// ── Place Options Order (sell put / sell call) ────────────
-
 export interface OptionsOrderParams {
   symbol: string;
-  right: 'P' | 'C';   // Put or Call
+  right: 'P' | 'C';
   strike: number;
-  expiry: string;      // YYYYMMDD
-  contracts: number;   // number of contracts (each = 100 shares)
-  limitPrice: number;  // premium per share (e.g. 2.50)
+  expiry: string;
+  contracts: number;
+  limitPrice: number;
   account?: string;
 }
 
@@ -764,30 +105,842 @@ export interface OptionsOrderResult {
   filledQty: number;
 }
 
-const OPT_ORDER_TIMEOUT_MS = 120_000; // 2 min — limit orders need more time than market orders
+export interface CalendarSpreadOrderParams {
+  symbol: string;
+  right: 'P' | 'C';
+  strike: number;
+  frontExpiry: string;
+  backExpiry: string;
+  contracts: number;
+  limitPrice: number;
+  account?: string;
+}
 
-export function placeOptionsOrder(params: OptionsOrderParams): Promise<OptionsOrderResult> {
-  return new Promise((resolve, reject) => {
-    if (!ib || !connected) {
-      return reject(new Error('Not connected to IB Gateway'));
+export interface CalendarSpreadOrderResult {
+  orderId: number;
+}
+
+export interface VerticalSpreadOrderParams {
+  symbol: string;
+  right: 'P' | 'C';
+  sellStrike: number;
+  buyStrike: number;
+  expiry: string;
+  contracts: number;
+  limitPrice: number;
+  account?: string;
+}
+
+export interface VerticalSpreadOrderResult {
+  orderId: number;
+}
+
+interface PendingOrder {
+  resolve: (result: { orderId: number; avgFillPrice: number; filledQty: number }) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+  symbol: string;
+}
+
+// ── IBConnection Class ───────────────────────────────────
+
+export class IBConnection {
+  readonly label: AccountType;
+  readonly port: number;
+  readonly clientId: number;
+
+  private ib: IBApi | null = null;
+  private _connected = false;
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private _accounts: string[] = [];
+  private _nextOrderId = 0;
+  private connectionListeners: Array<(state: boolean) => void> = [];
+
+  private _pnlReqId = 0;
+  private _dailyPnL: number | null = null;
+  private _unrealizedPnL: number | null = null;
+  private _realizedPnL: number | null = null;
+
+  private _orderFillPrices = new Map<number, number>();
+  private _pendingReqCallbacks = new Map<number, (code: number, msg: string) => void>();
+  private _pendingOrderCallbacks = new Map<number, PendingOrder>();
+
+  private _activeRequests = 0;
+  private _requestQueue: Array<() => void> = [];
+
+  private get tag(): string { return `[IB:${this.label}]`; }
+
+  constructor(label: AccountType, port: number, clientId: number) {
+    this.label = label;
+    this.port = port;
+    this.clientId = clientId;
+  }
+
+  // ── Semaphore ────────────────────────────────────────
+
+  async acquireRequestSlot(): Promise<void> {
+    if (this._activeRequests < MAX_CONCURRENT_REQUESTS) {
+      this._activeRequests++;
+      return;
+    }
+    return new Promise<void>(resolve => {
+      this._requestQueue.push(() => { this._activeRequests++; resolve(); });
+    });
+  }
+
+  releaseRequestSlot(): void {
+    this._activeRequests--;
+    const next = this._requestQueue.shift();
+    if (next) next();
+  }
+
+  registerReqErrorCallback(reqId: number, cb: (code: number, msg: string) => void): void {
+    this._pendingReqCallbacks.set(reqId, cb);
+  }
+
+  unregisterReqErrorCallback(reqId: number): void {
+    this._pendingReqCallbacks.delete(reqId);
+  }
+
+  // ── Public API ───────────────────────────────────────
+
+  isConnected(): boolean { return this._connected; }
+  getAccounts(): string[] { return this._accounts; }
+  getDefaultAccount(): string | null { return this._accounts[0] ?? null; }
+  getIBApi(): IBApi | null { return this.ib; }
+
+  getNextOrderId(): number { return this._nextOrderId++; }
+
+  onConnectionChange(fn: (state: boolean) => void): () => void {
+    this.connectionListeners.push(fn);
+    return () => {
+      this.connectionListeners = this.connectionListeners.filter(l => l !== fn);
+    };
+  }
+
+  getDailyPnL(): AccountPnL {
+    return { dailyPnL: this._dailyPnL, unrealizedPnL: this._unrealizedPnL, realizedPnL: this._realizedPnL };
+  }
+
+  getOrderFillPrice(orderId: number): number | undefined {
+    return this._orderFillPrices.get(orderId);
+  }
+
+  async getOrderFillPriceWithFallback(orderId: number): Promise<number | undefined> {
+    const cached = this._orderFillPrices.get(orderId);
+    if (cached !== undefined) return cached;
+    const dbPrice = await getFillPriceByOrderId(orderId, this.label);
+    if (dbPrice !== undefined) {
+      this._orderFillPrices.set(orderId, dbPrice);
+    }
+    return dbPrice;
+  }
+
+  // ── Connect ──────────────────────────────────────────
+
+  connect(): void {
+    if (this.ib) {
+      try { this.ib.disconnect(); } catch { /* ignore */ }
     }
 
-    const { symbol, right, strike, expiry, contracts, account } = params;
+    this.ib = new IBApi({ host: IB_HOST, port: this.port, clientId: this.clientId });
+    const ib = this.ib;
+
+    ib.on(EventName.connected, () => {
+      console.log(`${this.tag} Connected to IB Gateway at ${IB_HOST}:${this.port}`);
+      this._connected = true;
+      this.reconnectAttempts = 0;
+      this.connectionListeners.forEach(fn => fn(true));
+      ib.reqManagedAccts();
+      ib.reqIds();
+    });
+
+    ib.on(EventName.disconnected, () => {
+      console.log(`${this.tag} Disconnected from IB Gateway`);
+      this._connected = false;
+      this.connectionListeners.forEach(fn => fn(false));
+
+      if (this.label === 'live') {
+        console.log(`${this.tag} Live connection lost — auto-engaging kill switch`);
+        saveConfigPartial({ liveKillSwitch: true }).catch(err => {
+          console.error(`${this.tag} Failed to auto-engage kill switch: ${err}`);
+        });
+        createAutoTradeEvent({
+          ticker: 'SYSTEM',
+          event_type: 'error',
+          action: 'failed',
+          source: 'system',
+          message: `[IB:live] Connection lost — kill switch auto-engaged`,
+        }, 'live').catch(() => {});
+      }
+
+      this.scheduleReconnect();
+    });
+
+    ib.on(EventName.error, (err: Error, code?: number, reqId?: number) => {
+      const infoOnly = code && [2104, 2106, 2108, 2158].includes(code);
+      if (infoOnly) {
+        console.log(`${this.tag} Info (${code}): ${err.message}`);
+        return;
+      }
+
+      if (reqId != null && code != null && this._pendingReqCallbacks.has(reqId)) {
+        const cb = this._pendingReqCallbacks.get(reqId)!;
+        this._pendingReqCallbacks.delete(reqId);
+        cb(code, err.message);
+        return;
+      }
+
+      if (reqId != null && this._pendingOrderCallbacks.has(reqId)) {
+        const pending = this._pendingOrderCallbacks.get(reqId)!;
+        clearTimeout(pending.timer);
+        this._pendingOrderCallbacks.delete(reqId);
+        const msg = `IB order ${reqId} (${pending.symbol}) rejected: code=${code} ${err.message}`;
+        console.error(`${this.tag} ${msg}`);
+        pending.reject(new Error(msg));
+        return;
+      }
+
+      console.error(`${this.tag} Error (code=${code}, reqId=${reqId}): ${err.message}`);
+
+      if (code === 1100) {
+        this._connected = false;
+        this.connectionListeners.forEach(fn => fn(false));
+      }
+    });
+
+    ib.on(EventName.managedAccounts, (accountsList: string) => {
+      this._accounts = accountsList.split(',').map(a => a.trim()).filter(Boolean);
+      console.log(`${this.tag} Managed accounts: ${this._accounts.join(', ')}`);
+
+      if (this._accounts[0] && this.ib) {
+        this._pnlReqId = this.getNextOrderId();
+        this._dailyPnL = null;
+        this._unrealizedPnL = null;
+        this._realizedPnL = null;
+        try {
+          this.ib.reqPnL(this._pnlReqId, this._accounts[0], '');
+          console.log(`${this.tag} Subscribed to account PnL (reqId=${this._pnlReqId}, account=${this._accounts[0]})`);
+        } catch (pnlErr) {
+          console.warn(`${this.tag} reqPnL failed:`, pnlErr instanceof Error ? pnlErr.message : pnlErr);
+        }
+      }
+    });
+
+    ib.on(EventName.nextValidId, (orderId: number) => {
+      this._nextOrderId = orderId;
+      console.log(`${this.tag} Next valid order ID: ${this._nextOrderId}`);
+    });
+
+    ib.on(EventName.pnl, (reqId: number, dailyPnL: number, unrealizedPnL?: number, realizedPnL?: number) => {
+      if (reqId !== this._pnlReqId) return;
+      this._dailyPnL = dailyPnL;
+      this._unrealizedPnL = unrealizedPnL ?? null;
+      this._realizedPnL = realizedPnL ?? null;
+    });
+
+    ib.on(EventName.orderStatus, (
+      orderId: number, status: string, filled: number,
+      _remaining: number, avgFillPrice: number,
+    ) => {
+      if (status === 'Filled' && avgFillPrice > 0) {
+        this._orderFillPrices.set(orderId, avgFillPrice);
+        console.log(`${this.tag} Order ${orderId} filled @ $${avgFillPrice.toFixed(4)}`);
+
+        if (this._pendingOrderCallbacks.has(orderId)) {
+          const pending = this._pendingOrderCallbacks.get(orderId)!;
+          clearTimeout(pending.timer);
+          this._pendingOrderCallbacks.delete(orderId);
+          pending.resolve({ orderId, avgFillPrice, filledQty: filled });
+        }
+
+        insertIbFill({
+          order_id: orderId,
+          ticker: '',
+          side: '',
+          quantity: filled,
+          fill_price: avgFillPrice,
+          filled_at: new Date().toISOString(),
+        }, this.label).catch(fillErr => console.warn(`${this.tag} Failed to persist orderStatus fill: ${fillErr instanceof Error ? fillErr.message : fillErr}`));
+      }
+
+      if ((status === 'Cancelled' || status === 'Inactive') && this._pendingOrderCallbacks.has(orderId)) {
+        const pending = this._pendingOrderCallbacks.get(orderId)!;
+        clearTimeout(pending.timer);
+        this._pendingOrderCallbacks.delete(orderId);
+        console.error(`${this.tag} Order ${orderId} (${pending.symbol}) ${status}`);
+        pending.reject(new Error(`IB order ${orderId} (${pending.symbol}) ${status}`));
+      }
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (ib as any).on(EventName.execDetails, (_reqId: number, contract: any, execution: any) => {
+      const orderId = execution?.orderId ?? execution?.order?.orderId;
+      const price = execution?.price ?? execution?.avgPrice;
+      const qty = execution?.shares ?? execution?.cumQty ?? 0;
+      const execId = execution?.execId ?? null;
+      const side = execution?.side ?? '';
+      const ticker = contract?.symbol ?? '';
+
+      if (orderId && price > 0) {
+        this._orderFillPrices.set(orderId, price);
+        console.log(`${this.tag} ExecDetails: order ${orderId} ${side} ${qty}x ${ticker} @ $${price.toFixed(4)} (execId=${execId})`);
+        insertIbFill({
+          order_id: orderId,
+          exec_id: execId,
+          ticker,
+          side,
+          quantity: qty,
+          fill_price: price,
+          filled_at: new Date().toISOString(),
+        }, this.label).catch(fillErr => console.warn(`${this.tag} Failed to persist execDetails fill: ${fillErr instanceof Error ? fillErr.message : fillErr}`));
+      }
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (ib as any).on(EventName.commissionReport, (report: any) => {
+      const execId = report?.execId;
+      const commission = report?.commission;
+      const realizedPnl: number | undefined = report?.realizedPNL ?? report?.realizedPnl;
+      if (execId && commission != null && commission < 1e6) {
+        const rpnlStr = realizedPnl != null && isFinite(realizedPnl) && Math.abs(realizedPnl) < 1e6
+          ? ` realizedPnl=$${realizedPnl.toFixed(2)}` : '';
+        console.log(`${this.tag} Commission: execId=${execId} commission=$${commission.toFixed(4)}${rpnlStr}`);
+        updateIbFillCommission(execId, commission, realizedPnl != null && isFinite(realizedPnl) && Math.abs(realizedPnl) < 1e6 ? realizedPnl : null, this.label)
+          .catch(commErr => console.warn(`${this.tag} Failed to update commission: ${commErr instanceof Error ? commErr.message : commErr}`));
+      }
+    });
+
+    this.hydrateOrderFillPrices().catch(() => {});
+
+    console.log(`${this.tag} Connecting to ${IB_HOST}:${this.port} (clientId=${this.clientId})...`);
+    ib.connect();
+  }
+
+  // ── Reconnect ────────────────────────────────────────
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) return;
+
+    const delay = Math.min(
+      RECONNECT_BASE_MS * Math.pow(2, this.reconnectAttempts),
+      RECONNECT_MAX_MS
+    );
+    this.reconnectAttempts++;
+
+    console.log(`${this.tag} Reconnecting in ${delay / 1000}s (attempt ${this.reconnectAttempts})...`);
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, delay);
+  }
+
+  // ── Fill Price Hydration ─────────────────────────────
+
+  private async hydrateOrderFillPrices(): Promise<void> {
+    try {
+      const fills = await getTodayFillPrices(this.label);
+      let count = 0;
+      for (const [orderId, price] of fills) {
+        if (!this._orderFillPrices.has(orderId)) {
+          this._orderFillPrices.set(orderId, price);
+          count++;
+        }
+      }
+      if (count > 0) {
+        console.log(`${this.tag} Hydrated ${count} fill prices from DB`);
+      }
+    } catch (err) {
+      console.warn(`${this.tag} Failed to hydrate fill prices from DB:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  // ── Contract Helper ──────────────────────────────────
+
+  createStockContract(symbol: string): Contract {
+    return {
+      symbol: symbol.toUpperCase(),
+      secType: SecType.STK,
+      exchange: 'SMART',
+      currency: 'USD',
+    };
+  }
+
+  // ── Contract Search ──────────────────────────────────
+
+  async searchContract(symbol: string): Promise<ContractSearchResult | null> {
+    if (!this.ib || !this._connected) {
+      throw new Error(`${this.tag} Not connected to IB Gateway`);
+    }
+
+    await this.acquireRequestSlot();
+    try {
+      return await new Promise<ContractSearchResult | null>((resolve) => {
+        const reqId = this.getNextOrderId();
+        const contract: Contract = {
+          symbol: symbol.toUpperCase(),
+          secType: SecType.STK,
+          currency: 'USD',
+        };
+        let resolved = false;
+
+        const cleanup = () => { this.unregisterReqErrorCallback(reqId); };
+
+        const timeout = setTimeout(() => {
+          if (!resolved) {
+            resolved = true;
+            cleanup();
+            resolve(null);
+          }
+        }, 10_000);
+
+        this.registerReqErrorCallback(reqId, (_code: number, _msg: string) => {
+          if (resolved) return;
+          resolved = true;
+          clearTimeout(timeout);
+          resolve(null);
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const emitter = this.ib as any;
+
+        emitter.on(EventName.contractDetails, (rId: number, details: { contract: { conId?: number; symbol?: string; secType?: string; primaryExch?: string; currency?: string }; longName?: string }) => {
+          if (rId !== reqId || resolved) return;
+          resolved = true;
+          clearTimeout(timeout);
+          cleanup();
+          resolve({
+            conId: details.contract.conId ?? 0,
+            symbol: details.contract.symbol ?? symbol,
+            secType: details.contract.secType ?? 'STK',
+            primaryExch: details.contract.primaryExch ?? '',
+            currency: details.contract.currency ?? 'USD',
+            description: details.longName ?? '',
+          });
+        });
+
+        emitter.on(EventName.contractDetailsEnd, (rId: number) => {
+          if (rId !== reqId || resolved) return;
+          resolved = true;
+          clearTimeout(timeout);
+          cleanup();
+          resolve(null);
+        });
+
+        this.ib!.reqContractDetails(reqId, contract);
+      });
+    } finally {
+      this.releaseRequestSlot();
+    }
+  }
+
+  // ── Place Bracket Order ──────────────────────────────
+
+  placeBracketOrder(params: BracketOrderParams): Promise<BracketOrderResult> {
+    return new Promise((resolve, reject) => {
+      if (!this.ib || !this._connected) {
+        return reject(new Error(`${this.tag} Not connected to IB Gateway`));
+      }
+
+      const { symbol, side, quantity, entryPrice, stopLoss, takeProfit, tif = 'GTC' } = params;
+
+      if (tif === 'DAY') {
+        const etNow = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
+        const etDay = etNow.getDay();
+        const etMins = etNow.getHours() * 60 + etNow.getMinutes();
+        const marketOpen = 9 * 60 + 30;
+        if (etDay !== 0 && etDay !== 6 && etMins < marketOpen) {
+          const etStr = `${String(etNow.getHours()).padStart(2, '0')}:${String(etNow.getMinutes()).padStart(2, '0')} ET`;
+          console.error(`${this.tag} DAY bracket order for ${symbol} rejected — market not open yet (${etStr})`);
+          return reject(new Error(`DAY order rejected: market not open (${etStr}) — order would be invalid before 9:30 AM ET`));
+        }
+      }
+
+      const contract = this.createStockContract(symbol);
+      const parentId = this.getNextOrderId();
+      const tpId = this.getNextOrderId();
+      const slId = this.getNextOrderId();
+      const closeSide = side === 'BUY' ? OrderAction.SELL : OrderAction.BUY;
+      const ibTif = tif === 'DAY' ? TimeInForce.DAY : TimeInForce.GTC;
+
+      const parentOrder: Order = {
+        action: side === 'BUY' ? OrderAction.BUY : OrderAction.SELL,
+        orderType: OrderType.LMT,
+        totalQuantity: quantity,
+        lmtPrice: entryPrice,
+        tif: ibTif,
+        transmit: false,
+      };
+
+      const takeProfitOrder: Order = {
+        action: closeSide,
+        orderType: OrderType.LMT,
+        totalQuantity: quantity,
+        lmtPrice: takeProfit,
+        parentId,
+        tif: ibTif,
+        transmit: false,
+      };
+
+      const stopLossOrder: Order = {
+        action: closeSide,
+        orderType: OrderType.STP,
+        totalQuantity: quantity,
+        auxPrice: stopLoss,
+        parentId,
+        tif: ibTif,
+        transmit: true,
+      };
+
+      try {
+        this.ib.placeOrder(parentId, contract, parentOrder);
+        this.ib.placeOrder(tpId, contract, takeProfitOrder);
+        this.ib.placeOrder(slId, contract, stopLossOrder);
+        console.log(`${this.tag} Bracket order placed: ${side} ${quantity}x ${symbol} entry=$${entryPrice} tp=$${takeProfit} sl=$${stopLoss}`);
+        resolve({ parentOrderId: parentId, takeProfitOrderId: tpId, stopLossOrderId: slId });
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+
+  // ── Place Market Order ───────────────────────────────
+
+  placeMarketOrder(params: MarketOrderParams): Promise<MarketOrderResult> {
+    return new Promise((resolve, reject) => {
+      if (!this.ib || !this._connected) {
+        return reject(new Error(`${this.tag} Not connected to IB Gateway`));
+      }
+
+      const { symbol, side, quantity } = params;
+      const contract = this.createStockContract(symbol);
+      const orderId = this.getNextOrderId();
+
+      const order: Order = {
+        action: side === 'BUY' ? OrderAction.BUY : OrderAction.SELL,
+        orderType: OrderType.MKT,
+        totalQuantity: quantity,
+        tif: TimeInForce.DAY,
+        transmit: true,
+      };
+
+      const timer = setTimeout(() => {
+        this._pendingOrderCallbacks.delete(orderId);
+        const msg = `IB order ${orderId} (${symbol} ${side} ${quantity}) timed out after ${MKT_ORDER_TIMEOUT_MS / 1000}s — no fill/error received`;
+        console.error(`${this.tag} ${msg}`);
+        reject(new Error(msg));
+      }, MKT_ORDER_TIMEOUT_MS);
+
+      this._pendingOrderCallbacks.set(orderId, { resolve, reject, timer, symbol });
+
+      try {
+        this.ib.placeOrder(orderId, contract, order);
+        console.log(`${this.tag} Market order dispatched: ${side} ${quantity}x ${symbol} (orderId=${orderId}) — awaiting fill...`);
+      } catch (err) {
+        clearTimeout(timer);
+        this._pendingOrderCallbacks.delete(orderId);
+        reject(err);
+      }
+    });
+  }
+
+  // ── Cancel Order ─────────────────────────────────────
+
+  cancelOrder(orderId: number): void {
+    if (!this.ib || !this._connected) {
+      throw new Error(`${this.tag} Not connected to IB Gateway`);
+    }
+    this.ib.cancelOrder(orderId);
+  }
+
+  // ── Positions ────────────────────────────────────────
+
+  requestPositions(): Promise<PositionData[]> {
+    return new Promise((resolve, reject) => {
+      if (!this.ib || !this._connected) {
+        return reject(new Error(`${this.tag} Not connected to IB Gateway`));
+      }
+
+      const positions: PositionData[] = [];
+      let resolved = false;
+
+      const timeout = setTimeout(() => {
+        if (!resolved) { resolved = true; resolve(positions); }
+      }, 10_000);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const emitter = this.ib as any;
+
+      const posHandler = (account: string, contract: Contract, pos: number, avgCost: number) => {
+        if (resolved) return;
+        positions.push({
+          account,
+          symbol: contract.symbol ?? '',
+          secType: contract.secType ?? '',
+          position: pos,
+          avgCost,
+          conId: contract.conId ?? 0,
+        });
+      };
+
+      const endHandler = () => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timeout);
+        emitter.off(EventName.position, posHandler);
+        emitter.off(EventName.positionEnd, endHandler);
+        resolve(positions);
+      };
+
+      emitter.on(EventName.position, posHandler);
+      emitter.on(EventName.positionEnd, endHandler);
+      this.ib.reqPositions();
+    });
+  }
+
+  // ── Open Orders ──────────────────────────────────────
+
+  requestOpenOrders(): Promise<OpenOrderData[]> {
+    return new Promise((resolve, reject) => {
+      if (!this.ib || !this._connected) {
+        return reject(new Error(`${this.tag} Not connected to IB Gateway`));
+      }
+
+      const orders: OpenOrderData[] = [];
+      let resolved = false;
+
+      const timeout = setTimeout(() => {
+        if (!resolved) { resolved = true; resolve(orders); }
+      }, 10_000);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const emitter = this.ib as any;
+
+      const orderHandler = (orderId: number, contract: Contract, order: Order, orderState: { status?: string }) => {
+        if (resolved) return;
+        orders.push({
+          orderId,
+          symbol: contract.symbol ?? '',
+          action: String(order.action ?? ''),
+          orderType: String(order.orderType ?? ''),
+          totalQuantity: Number(order.totalQuantity ?? 0),
+          lmtPrice: Number(order.lmtPrice ?? 0),
+          auxPrice: Number(order.auxPrice ?? 0),
+          status: orderState.status ?? '',
+          parentId: Number(order.parentId ?? 0),
+        });
+      };
+
+      const endHandler = () => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timeout);
+        emitter.off(EventName.openOrder, orderHandler);
+        emitter.off(EventName.openOrderEnd, endHandler);
+        resolve(orders);
+      };
+
+      emitter.on(EventName.openOrder, orderHandler);
+      emitter.on(EventName.openOrderEnd, endHandler);
+      this.ib.reqAllOpenOrders();
+    });
+  }
+
+  // ── Options Order ────────────────────────────────────
+
+  placeOptionsOrder(params: OptionsOrderParams): Promise<OptionsOrderResult> {
+    return new Promise((resolve, reject) => {
+      if (!this.ib || !this._connected) {
+        return reject(new Error(`${this.tag} Not connected to IB Gateway`));
+      }
+
+      const { symbol, right, strike, expiry, contracts, account } = params;
+      const tick = params.limitPrice >= 3.0 ? 0.05 : 0.01;
+      const limitPrice = Math.round(params.limitPrice / tick) * tick;
+
+      const contract: Contract = {
+        symbol: symbol.toUpperCase(),
+        secType: SecType.OPT,
+        exchange: 'SMART',
+        currency: 'USD',
+        strike,
+        right: right === 'P' ? OptionType.Put : OptionType.Call,
+        lastTradeDateOrContractMonth: expiry,
+        multiplier: 100,
+      };
+
+      const orderId = this.getNextOrderId();
+
+      const order: Order = {
+        action: OrderAction.SELL,
+        orderType: OrderType.LMT,
+        totalQuantity: contracts,
+        lmtPrice: limitPrice,
+        tif: TimeInForce.DAY,
+        transmit: true,
+        ...(account ? { account } : {}),
+      };
+
+      const timer = setTimeout(() => {
+        this._pendingOrderCallbacks.delete(orderId);
+        const msg = `IB options order ${orderId} (${symbol} $${strike}${right}) timed out after ${OPT_ORDER_TIMEOUT_MS / 1000}s — no fill/reject received`;
+        console.error(`${this.tag} ${msg}`);
+        reject(new Error(msg));
+      }, OPT_ORDER_TIMEOUT_MS);
+
+      this._pendingOrderCallbacks.set(orderId, { resolve, reject, timer, symbol });
+
+      try {
+        this.ib.placeOrder(orderId, contract, order);
+        console.log(`${this.tag} Options order dispatched: SELL ${contracts}x ${symbol} $${strike}${right} ${expiry} @ $${limitPrice} (orderId=${orderId}) — awaiting fill...`);
+      } catch (err) {
+        clearTimeout(timer);
+        this._pendingOrderCallbacks.delete(orderId);
+        reject(err);
+      }
+    });
+  }
+
+  // ── Resolve Option ConId ─────────────────────────────
+
+  async resolveOptionConId(
+    symbol: string, right: 'P' | 'C', strike: number, expiry: string,
+  ): Promise<number | null> {
+    if (!this.ib || !this._connected) return null;
+    await this.acquireRequestSlot();
+    try {
+      return await new Promise<number | null>((resolve) => {
+        const reqId = this.getNextOrderId();
+        const emitter = this.ib! as unknown as NodeJS.EventEmitter;
+        let resolved = false;
+        const timeout = setTimeout(() => {
+          if (resolved) return;
+          resolved = true;
+          emitter.removeAllListeners(`contractDetails-${reqId}`);
+          resolve(null);
+        }, 8_000);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        emitter.once(EventName.contractDetails, (_rId: number, details: any) => {
+          if (resolved) return;
+          resolved = true;
+          clearTimeout(timeout);
+          resolve(details?.contract?.conId ?? null);
+        });
+
+        this.registerReqErrorCallback(reqId, () => {
+          if (resolved) return;
+          resolved = true;
+          clearTimeout(timeout);
+          resolve(null);
+        });
+
+        this.ib!.reqContractDetails(reqId, {
+          symbol: symbol.toUpperCase(),
+          secType: SecType.OPT,
+          exchange: 'SMART',
+          currency: 'USD',
+          strike,
+          right: right === 'P' ? OptionType.Put : OptionType.Call,
+          lastTradeDateOrContractMonth: expiry,
+          multiplier: 100,
+        });
+      });
+    } finally {
+      this.releaseRequestSlot();
+    }
+  }
+
+  // ── Calendar Spread ──────────────────────────────────
+
+  async placeCalendarSpreadOrder(
+    params: CalendarSpreadOrderParams,
+  ): Promise<CalendarSpreadOrderResult> {
+    if (!this.ib || !this._connected) {
+      throw new Error(`${this.tag} Not connected to IB Gateway`);
+    }
+
+    const { symbol, right, strike, frontExpiry, backExpiry, contracts, account } = params;
+
+    const [frontConId, backConId] = await Promise.all([
+      this.resolveOptionConId(symbol, right, strike, frontExpiry),
+      this.resolveOptionConId(symbol, right, strike, backExpiry),
+    ]);
+    if (!frontConId || !backConId) {
+      throw new Error(`Could not resolve conIds for ${symbol} ${strike}${right} ${frontExpiry}/${backExpiry}`);
+    }
+
     const tick = params.limitPrice >= 3.0 ? 0.05 : 0.01;
     const limitPrice = Math.round(params.limitPrice / tick) * tick;
 
     const contract: Contract = {
       symbol: symbol.toUpperCase(),
-      secType: SecType.OPT,
+      secType: SecType.BAG,
       exchange: 'SMART',
       currency: 'USD',
-      strike,
-      right: right === 'P' ? OptionType.Put : OptionType.Call,
-      lastTradeDateOrContractMonth: expiry,
-      multiplier: 100,
+      comboLegs: [
+        { conId: frontConId, ratio: 1, action: OrderAction.SELL, exchange: 'SMART' },
+        { conId: backConId,  ratio: 1, action: OrderAction.BUY,  exchange: 'SMART' },
+      ],
     };
 
-    const orderId = getNextOrderId();
+    const orderId = this.getNextOrderId();
+
+    const order: Order = {
+      action: OrderAction.BUY,
+      orderType: OrderType.LMT,
+      totalQuantity: contracts,
+      lmtPrice: limitPrice,
+      tif: TimeInForce.DAY,
+      transmit: true,
+      ...(account ? { account } : {}),
+    };
+
+    try {
+      this.ib.placeOrder(orderId, contract, order);
+      console.log(`${this.tag} Calendar spread placed: ${symbol} ${strike}${right} sell ${frontExpiry} / buy ${backExpiry} x${contracts} @ $${limitPrice} net debit (orderId=${orderId})`);
+      return { orderId };
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  // ── Vertical Spread ──────────────────────────────────
+
+  async placeVerticalSpreadOrder(
+    params: VerticalSpreadOrderParams,
+  ): Promise<VerticalSpreadOrderResult> {
+    if (!this.ib || !this._connected) {
+      throw new Error(`${this.tag} Not connected to IB Gateway`);
+    }
+
+    const { symbol, right, sellStrike, buyStrike, expiry, contracts, account } = params;
+
+    const [sellConId, buyConId] = await Promise.all([
+      this.resolveOptionConId(symbol, right, sellStrike, expiry),
+      this.resolveOptionConId(symbol, right, buyStrike, expiry),
+    ]);
+    if (!sellConId || !buyConId) {
+      throw new Error(`Could not resolve conIds for ${symbol} ${sellStrike}/${buyStrike}${right} ${expiry}`);
+    }
+
+    const tick = params.limitPrice >= 3.0 ? 0.05 : 0.01;
+    const limitPrice = Math.round(params.limitPrice / tick) * tick;
+
+    const contract: Contract = {
+      symbol: symbol.toUpperCase(),
+      secType: SecType.BAG,
+      exchange: 'SMART',
+      currency: 'USD',
+      comboLegs: [
+        { conId: sellConId, ratio: 1, action: OrderAction.SELL, exchange: 'SMART' },
+        { conId: buyConId,  ratio: 1, action: OrderAction.BUY,  exchange: 'SMART' },
+      ],
+    };
+
+    const orderId = this.getNextOrderId();
 
     const order: Order = {
       action: OrderAction.SELL,
@@ -799,246 +952,186 @@ export function placeOptionsOrder(params: OptionsOrderParams): Promise<OptionsOr
       ...(account ? { account } : {}),
     };
 
-    const timer = setTimeout(() => {
-      _pendingOrderCallbacks.delete(orderId);
-      const msg = `IB options order ${orderId} (${symbol} $${strike}${right}) timed out after ${OPT_ORDER_TIMEOUT_MS / 1000}s — no fill/reject received`;
-      console.error(`[IB] ${msg}`);
-      reject(new Error(msg));
-    }, OPT_ORDER_TIMEOUT_MS);
-
-    _pendingOrderCallbacks.set(orderId, { resolve, reject, timer, symbol });
-
     try {
-      ib.placeOrder(orderId, contract, order);
-      console.log(`[IB] Options order dispatched: SELL ${contracts}x ${symbol} $${strike}${right} ${expiry} @ $${limitPrice} (orderId=${orderId}) — awaiting fill...`);
+      this.ib.placeOrder(orderId, contract, order);
+      console.log(`${this.tag} Credit spread placed: SELL ${contracts}x ${symbol} ${sellStrike}/${buyStrike}${right} ${expiry} @ $${limitPrice} net credit (orderId=${orderId})`);
+      return { orderId };
     } catch (err) {
-      clearTimeout(timer);
-      _pendingOrderCallbacks.delete(orderId);
-      reject(err);
+      throw err;
     }
-  });
-}
+  }
 
-// ── Place Calendar Spread Order (combo / BAG) ────────────
+  // ── Disconnect ───────────────────────────────────────
 
-export interface CalendarSpreadOrderParams {
-  symbol: string;
-  right: 'P' | 'C';
-  strike: number;
-  frontExpiry: string;   // YYYYMMDD — sell (short) leg
-  backExpiry: string;    // YYYYMMDD — buy (long) leg
-  contracts: number;
-  limitPrice: number;    // net debit per spread (positive = pay)
-  account?: string;
-}
-
-export interface CalendarSpreadOrderResult {
-  orderId: number;
-}
-
-/**
- * Resolve an option contract to its IB conId.
- * Required for building combo leg definitions.
- */
-async function resolveOptionConId(
-  symbol: string, right: 'P' | 'C', strike: number, expiry: string,
-): Promise<number | null> {
-  if (!ib || !connected) return null;
-  await acquireRequestSlot();
-  try {
-    return await new Promise<number | null>((resolve) => {
-      const reqId = getNextOrderId();
-      const emitter = ib! as unknown as NodeJS.EventEmitter;
-      let resolved = false;
-      const timeout = setTimeout(() => {
-        if (resolved) return;
-        resolved = true;
-        emitter.removeAllListeners(`contractDetails-${reqId}`);
-        resolve(null);
-      }, 8_000);
-
-      emitter.once(EventName.contractDetails, (_rId: number, details: any) => {
-        if (resolved) return;
-        resolved = true;
-        clearTimeout(timeout);
-        resolve(details?.contract?.conId ?? null);
-      });
-
-      const err = registerReqErrorCallback(reqId, () => {
-        if (resolved) return;
-        resolved = true;
-        clearTimeout(timeout);
-        resolve(null);
-      });
-
-      ib!.reqContractDetails(reqId, {
-        symbol: symbol.toUpperCase(),
-        secType: SecType.OPT,
-        exchange: 'SMART',
-        currency: 'USD',
-        strike,
-        right: right === 'P' ? OptionType.Put : OptionType.Call,
-        lastTradeDateOrContractMonth: expiry,
-        multiplier: 100,
-      });
-    });
-  } finally {
-    releaseRequestSlot();
+  disconnect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ib) {
+      if (this._pnlReqId) {
+        try { this.ib.cancelPnL(this._pnlReqId); } catch { /* ignore */ }
+      }
+      try { this.ib.disconnect(); } catch { /* ignore */ }
+      this.ib = null;
+    }
+    this._dailyPnL = null;
+    this._unrealizedPnL = null;
+    this._realizedPnL = null;
+    this._connected = false;
   }
 }
 
-/**
- * Place a calendar spread as an IB combo (BAG) order.
- * Sells the front-month leg, buys the back-month leg at the same strike.
- * Net debit = back premium - front premium (you pay the difference).
- */
+// ══════════════════════════════════════════════════════════
+// ── Connection Registry (Module-Level) ───────────────────
+// ══════════════════════════════════════════════════════════
+
+let paperConn: IBConnection | null = null;
+let liveConn: IBConnection | null = null;
+
+export function initConnections(opts?: { liveKillSwitch?: boolean }): void {
+  paperConn = new IBConnection('paper', 4002, 1);
+  liveConn = new IBConnection('live', 4001, 2);
+
+  paperConn.connect();
+
+  if (!opts?.liveKillSwitch) {
+    liveConn.connect();
+  } else {
+    console.log('[IB:live] Not connecting — kill switch is active');
+  }
+}
+
+export function getPaperConnection(): IBConnection {
+  if (!paperConn) throw new Error('Paper connection not initialized — call initConnections() first');
+  return paperConn;
+}
+
+export function getLiveConnection(): IBConnection {
+  if (!liveConn) throw new Error('Live connection not initialized — call initConnections() first');
+  return liveConn;
+}
+
+export function getConnectionForAccount(accountType: AccountType): IBConnection {
+  return accountType === 'live' ? getLiveConnection() : getPaperConnection();
+}
+
+// ══════════════════════════════════════════════════════════
+// ── Backward Compatibility Layer ─────────────────────────
+// All existing module-level exports delegate to paperConn.
+// Existing callers (scheduler.ts, routes, etc.) continue to
+// work with ZERO changes during the transition.
+// ══════════════════════════════════════════════════════════
+
+export function isConnected(): boolean { return paperConn?.isConnected() ?? false; }
+export function getAccounts(): string[] { return paperConn?.getAccounts() ?? []; }
+export function getDefaultAccount(): string | null { return paperConn?.getDefaultAccount() ?? null; }
+export function getIBApi(): IBApi | null { return paperConn?.getIBApi() ?? null; }
+export function getNextOrderId(): number { return paperConn?.getNextOrderId() ?? 0; }
+
+export function onConnectionChange(fn: (state: boolean) => void): () => void {
+  if (!paperConn) return () => {};
+  return paperConn.onConnectionChange(fn);
+}
+
+export function getDailyPnL(): AccountPnL {
+  return paperConn?.getDailyPnL() ?? { dailyPnL: null, unrealizedPnL: null, realizedPnL: null };
+}
+
+export function getOrderFillPrice(orderId: number): number | undefined {
+  return paperConn?.getOrderFillPrice(orderId);
+}
+
+export async function getOrderFillPriceWithFallback(orderId: number): Promise<number | undefined> {
+  if (!paperConn) return undefined;
+  return paperConn.getOrderFillPriceWithFallback(orderId);
+}
+
+export async function acquireRequestSlot(): Promise<void> {
+  if (!paperConn) return;
+  return paperConn.acquireRequestSlot();
+}
+
+export function releaseRequestSlot(): void {
+  paperConn?.releaseRequestSlot();
+}
+
+export function registerReqErrorCallback(reqId: number, cb: (code: number, msg: string) => void): void {
+  paperConn?.registerReqErrorCallback(reqId, cb);
+}
+
+export function unregisterReqErrorCallback(reqId: number): void {
+  paperConn?.unregisterReqErrorCallback(reqId);
+}
+
+export function connect(): void {
+  if (paperConn) {
+    paperConn.connect();
+  } else {
+    paperConn = new IBConnection('paper', 4002, 1);
+    paperConn.connect();
+  }
+}
+
+export function createStockContract(symbol: string): Contract {
+  return paperConn?.createStockContract(symbol) ?? {
+    symbol: symbol.toUpperCase(),
+    secType: SecType.STK,
+    exchange: 'SMART',
+    currency: 'USD',
+  };
+}
+
+export async function searchContract(symbol: string): Promise<ContractSearchResult | null> {
+  if (!paperConn) throw new Error('Not connected to IB Gateway');
+  return paperConn.searchContract(symbol);
+}
+
+export function placeBracketOrder(params: BracketOrderParams): Promise<BracketOrderResult> {
+  if (!paperConn) return Promise.reject(new Error('Not connected to IB Gateway'));
+  return paperConn.placeBracketOrder(params);
+}
+
+export function placeMarketOrder(params: MarketOrderParams): Promise<MarketOrderResult> {
+  if (!paperConn) return Promise.reject(new Error('Not connected to IB Gateway'));
+  return paperConn.placeMarketOrder(params);
+}
+
+export function cancelOrder(orderId: number): void {
+  if (!paperConn) throw new Error('Not connected to IB Gateway');
+  paperConn.cancelOrder(orderId);
+}
+
+export function requestPositions(): Promise<PositionData[]> {
+  if (!paperConn) return Promise.reject(new Error('Not connected to IB Gateway'));
+  return paperConn.requestPositions();
+}
+
+export function requestOpenOrders(): Promise<OpenOrderData[]> {
+  if (!paperConn) return Promise.reject(new Error('Not connected to IB Gateway'));
+  return paperConn.requestOpenOrders();
+}
+
+export function placeOptionsOrder(params: OptionsOrderParams): Promise<OptionsOrderResult> {
+  if (!paperConn) return Promise.reject(new Error('Not connected to IB Gateway'));
+  return paperConn.placeOptionsOrder(params);
+}
+
 export async function placeCalendarSpreadOrder(
   params: CalendarSpreadOrderParams,
 ): Promise<CalendarSpreadOrderResult> {
-  if (!ib || !connected) {
-    throw new Error('Not connected to IB Gateway');
-  }
-
-  const { symbol, right, strike, frontExpiry, backExpiry, contracts, account } = params;
-
-  // Resolve conIds for both legs
-  const [frontConId, backConId] = await Promise.all([
-    resolveOptionConId(symbol, right, strike, frontExpiry),
-    resolveOptionConId(symbol, right, strike, backExpiry),
-  ]);
-  if (!frontConId || !backConId) {
-    throw new Error(`Could not resolve conIds for ${symbol} ${strike}${right} ${frontExpiry}/${backExpiry}`);
-  }
-
-  const tick = params.limitPrice >= 3.0 ? 0.05 : 0.01;
-  const limitPrice = Math.round(params.limitPrice / tick) * tick;
-
-  const contract: Contract = {
-    symbol: symbol.toUpperCase(),
-    secType: SecType.BAG,
-    exchange: 'SMART',
-    currency: 'USD',
-    comboLegs: [
-      { conId: frontConId, ratio: 1, action: OrderAction.SELL, exchange: 'SMART' },
-      { conId: backConId,  ratio: 1, action: OrderAction.BUY,  exchange: 'SMART' },
-    ],
-  };
-
-  const orderId = getNextOrderId();
-
-  const order: Order = {
-    action: OrderAction.BUY,
-    orderType: OrderType.LMT,
-    totalQuantity: contracts,
-    lmtPrice: limitPrice,
-    tif: TimeInForce.DAY,
-    transmit: true,
-    ...(account ? { account } : {}),
-  };
-
-  try {
-    ib.placeOrder(orderId, contract, order);
-    console.log(`[IB] Calendar spread placed: ${symbol} ${strike}${right} sell ${frontExpiry} / buy ${backExpiry} x${contracts} @ $${limitPrice} net debit (orderId=${orderId})`);
-    return { orderId };
-  } catch (err) {
-    throw err;
-  }
+  if (!paperConn) throw new Error('Not connected to IB Gateway');
+  return paperConn.placeCalendarSpreadOrder(params);
 }
 
-// ── Place Vertical Spread Order (credit spread combo / BAG) ──
-
-export interface VerticalSpreadOrderParams {
-  symbol: string;
-  right: 'P' | 'C';
-  sellStrike: number;    // ATM — income leg
-  buyStrike: number;     // OTM — protection leg
-  expiry: string;        // YYYYMMDD (same for both legs)
-  contracts: number;
-  limitPrice: number;    // net credit per share (positive = you receive)
-  account?: string;
-}
-
-export interface VerticalSpreadOrderResult {
-  orderId: number;
-}
-
-/**
- * Place a vertical credit spread as an IB combo (BAG) order.
- * Bull put spread: sell higher put + buy lower put at same expiry.
- * Bear call spread: sell lower call + buy higher call at same expiry.
- * Net credit = you receive premium upfront.
- */
 export async function placeVerticalSpreadOrder(
   params: VerticalSpreadOrderParams,
 ): Promise<VerticalSpreadOrderResult> {
-  if (!ib || !connected) {
-    throw new Error('Not connected to IB Gateway');
-  }
-
-  const { symbol, right, sellStrike, buyStrike, expiry, contracts, account } = params;
-
-  const [sellConId, buyConId] = await Promise.all([
-    resolveOptionConId(symbol, right, sellStrike, expiry),
-    resolveOptionConId(symbol, right, buyStrike, expiry),
-  ]);
-  if (!sellConId || !buyConId) {
-    throw new Error(`Could not resolve conIds for ${symbol} ${sellStrike}/${buyStrike}${right} ${expiry}`);
-  }
-
-  // IB credit spread: SELL the income leg, BUY the protection leg.
-  // Order action = SELL (selling the spread for a net credit).
-  // Limit price = positive net credit per share.
-  const tick = params.limitPrice >= 3.0 ? 0.05 : 0.01;
-  const limitPrice = Math.round(params.limitPrice / tick) * tick;
-
-  const contract: Contract = {
-    symbol: symbol.toUpperCase(),
-    secType: SecType.BAG,
-    exchange: 'SMART',
-    currency: 'USD',
-    comboLegs: [
-      { conId: sellConId, ratio: 1, action: OrderAction.SELL, exchange: 'SMART' },
-      { conId: buyConId,  ratio: 1, action: OrderAction.BUY,  exchange: 'SMART' },
-    ],
-  };
-
-  const orderId = getNextOrderId();
-
-  const order: Order = {
-    action: OrderAction.SELL,
-    orderType: OrderType.LMT,
-    totalQuantity: contracts,
-    lmtPrice: limitPrice,
-    tif: TimeInForce.DAY,
-    transmit: true,
-    ...(account ? { account } : {}),
-  };
-
-  try {
-    ib.placeOrder(orderId, contract, order);
-    console.log(`[IB] Credit spread placed: SELL ${contracts}x ${symbol} ${sellStrike}/${buyStrike}${right} ${expiry} @ $${limitPrice} net credit (orderId=${orderId})`);
-    return { orderId };
-  } catch (err) {
-    throw err;
-  }
+  if (!paperConn) throw new Error('Not connected to IB Gateway');
+  return paperConn.placeVerticalSpreadOrder(params);
 }
 
-// ── Disconnect ───────────────────────────────────────────
-
 export function disconnect(): void {
-  if (reconnectTimer) {
-    clearTimeout(reconnectTimer);
-    reconnectTimer = null;
-  }
-  if (ib) {
-    if (_pnlReqId) {
-      try { ib.cancelPnL(_pnlReqId); } catch { /* ignore */ }
-    }
-    try { ib.disconnect(); } catch { /* ignore */ }
-    ib = null;
-  }
-  _dailyPnL = null;
-  _unrealizedPnL = null;
-  _realizedPnL = null;
-  connected = false;
+  paperConn?.disconnect();
+  liveConn?.disconnect();
 }

--- a/auto-trader/src/index.ts
+++ b/auto-trader/src/index.ts
@@ -22,6 +22,7 @@ import strategyRoutes from './routes/strategies.js';
 import performanceLogRoutes from './routes/performance-log.js';
 import paperTradingRoutes from './routes/paper-trading.js';
 import optionsRoutes from './routes/options.js';
+import liveRoutes from './routes/live.js';
 import { startScheduler, stopScheduler } from './scheduler.js';
 
 const PORT = parseInt(process.env.PORT ?? '3001', 10);
@@ -60,6 +61,7 @@ app.use('/api', strategyRoutes);
 app.use('/api', performanceLogRoutes);
 app.use('/api', paperTradingRoutes);
 app.use('/api', optionsRoutes);
+app.use('/api', liveRoutes);
 
 // ── Compatibility endpoints (match old CPGW paths) ──────
 

--- a/auto-trader/src/lib/mode-router.ts
+++ b/auto-trader/src/lib/mode-router.ts
@@ -1,0 +1,91 @@
+/**
+ * Mode-based routing for dual-account trade execution.
+ *
+ * Determines which IB connection (paper vs live) a trade should use,
+ * based on the trade's mode and the runtime config.modeRouting map.
+ *
+ * Safety: if live is requested but the connection is down or the kill
+ * switch is active, this module THROWS — it never silently falls through
+ * to paper. Callers must catch and handle the error explicitly.
+ */
+
+import type { TradeMode, AccountType } from '../../../shared/trade-types.js';
+import type { AutoTraderConfig } from '../../../shared/config-defaults.js';
+import { getConnectionForAccount, getLiveConnection, type IBConnection } from '../ib-connection.js';
+import { saveConfigPartial, createAutoTradeEvent } from './supabase.js';
+
+/**
+ * Determine which account a trade mode routes to.
+ * Reads from config.modeRouting (DB-backed, changeable at runtime).
+ * Falls back to 'paper' if the mode is not configured.
+ */
+export function getAccountForMode(mode: TradeMode, config: AutoTraderConfig): AccountType {
+  const routing = config.modeRouting as Record<string, AccountType>;
+  return routing[mode] ?? 'paper';
+}
+
+/**
+ * Get the IB connection for a given trade mode.
+ * Throws if live is requested but live connection is down or kill switch is active.
+ */
+export function getConnectionForMode(
+  mode: TradeMode,
+  config: AutoTraderConfig,
+): { connection: IBConnection; accountType: AccountType } {
+  const accountType = getAccountForMode(mode, config);
+
+  if (accountType === 'live') {
+    if (config.liveKillSwitch) {
+      throw new Error(`Live trading halted: kill switch is active (mode=${mode})`);
+    }
+    const conn = getConnectionForAccount('live');
+    if (!conn.isConnected()) {
+      throw new Error(`Live IB connection is down — refusing to route ${mode} to live`);
+    }
+    return { connection: conn, accountType: 'live' };
+  }
+
+  const conn = getConnectionForAccount('paper');
+  return { connection: conn, accountType: 'paper' };
+}
+
+/**
+ * Get position sizing configuration for an account type.
+ * Live uses conservative overrides; paper uses the standard config values.
+ */
+export function getPositionSizeConfig(accountType: AccountType, config: AutoTraderConfig) {
+  if (accountType === 'live') {
+    return {
+      positionSize: config.livePositionSize,
+      maxPositions: config.liveMaxPositions,
+      maxDailyDeployment: config.liveMaxDailyDeployment,
+      portfolioValue: config.livePortfolioValue,
+    };
+  }
+  return {
+    positionSize: config.positionSize,
+    maxPositions: config.maxPositions,
+    maxDailyDeployment: config.maxDailyDeployment,
+    portfolioValue: config.portfolioValue,
+  };
+}
+
+/**
+ * Assert that the live daily loss limit has not been breached.
+ * If breached, auto-engages the kill switch and throws.
+ * Call this before every live order placement.
+ */
+export async function assertLiveLossLimitNotBreached(config: AutoTraderConfig): Promise<void> {
+  const livePnL = getLiveConnection().getDailyPnL();
+  if (livePnL.realizedPnL !== null && livePnL.realizedPnL <= config.liveDailyLossLimit) {
+    await saveConfigPartial({ live_kill_switch: true });
+    await createAutoTradeEvent({
+      ticker: 'SYSTEM',
+      event_type: 'error',
+      message: `Live daily loss limit breached: $${livePnL.realizedPnL.toFixed(2)} <= $${config.liveDailyLossLimit}. Kill switch engaged.`,
+      action: 'failed',
+      source: 'system',
+    }, 'live').catch(() => {});
+    throw new Error(`Live daily loss limit breached ($${livePnL.realizedPnL.toFixed(2)} <= $${config.liveDailyLossLimit}) — kill switch engaged`);
+  }
+}

--- a/auto-trader/src/lib/reconcile-executions.ts
+++ b/auto-trader/src/lib/reconcile-executions.ts
@@ -6,9 +6,10 @@
  */
 
 import { EventName } from '@stoqey/ib';
-import { getIBApi, isConnected, getNextOrderId, getDefaultAccount } from '../ib-connection.js';
-import { getSupabase, createAutoTradeEvent, type PaperTrade } from './supabase.js';
+import { getIBApi, isConnected, getNextOrderId, getDefaultAccount, type IBConnection, getConnectionForAccount } from '../ib-connection.js';
+import { getSupabase, createAutoTradeEvent, tradesTable, type PaperTrade } from './supabase.js';
 import { recalculatePerformance } from './feedback.js';
+import type { AccountType } from '../../../shared/trade-types.js';
 
 interface IBExecution {
   orderId: number;
@@ -28,25 +29,26 @@ function log(msg: string): void {
   console.log(`[Reconcile] ${msg}`);
 }
 
-export async function runEndOfDayReconciliation(): Promise<void> {
-  if (!isConnected()) {
-    log('Skipped — IB not connected');
+export async function runEndOfDayReconciliation(accountType: AccountType = 'paper'): Promise<void> {
+  const conn = getConnectionForAccount(accountType);
+  if (!conn.isConnected()) {
+    log(`Skipped — IB:${accountType} not connected`);
     return;
   }
 
-  const ib = getIBApi();
+  const ib = conn.getIBApi();
   if (!ib) {
-    log('Skipped — no IB API instance');
+    log(`Skipped — no IB:${accountType} API instance`);
     return;
   }
 
-  const account = getDefaultAccount();
+  const account = conn.getDefaultAccount();
   if (!account) {
-    log('Skipped — no account available');
+    log(`Skipped — no IB:${accountType} account available`);
     return;
   }
 
-  log('Starting end-of-day reconciliation...');
+  log(`Starting end-of-day reconciliation for ${accountType}...`);
 
   // Get today's date in ET for the IB filter
   const etNow = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
@@ -56,12 +58,12 @@ export async function runEndOfDayReconciliation(): Promise<void> {
   const todayFilterET = `${yyyy}${mm}${dd} 00:00:00`;
 
   // 1. Request all of today's executions from IB
-  const executions = await requestExecutions(ib, account, todayFilterET);
+  const executions = await requestExecutions(ib, account, todayFilterET, conn);
   log(`Received ${executions.length} executions from IB`);
 
   if (executions.length === 0) {
     log('No executions found — nothing to reconcile');
-    await logReconciliationSummary(0, 0, 0, 0);
+    await logReconciliationSummary(0, 0, 0, 0, undefined, accountType);
     return;
   }
 
@@ -71,14 +73,15 @@ export async function runEndOfDayReconciliation(): Promise<void> {
   todayStartET.setHours(0, 0, 0, 0);
   const todayStartUTC = new Date(todayStartET.toLocaleString('en-US', { timeZone: 'UTC' }));
 
+  const tTable = tradesTable(accountType);
   const { data: todayTrades } = await sb
-    .from('paper_trades')
+    .from(tTable)
     .select('*')
     .or(`opened_at.gte.${todayStartUTC.toISOString()},closed_at.gte.${todayStartUTC.toISOString()},filled_at.gte.${todayStartUTC.toISOString()}`)
     .not('status', 'in', '(CANCELLED,REJECTED)');
 
   const trades = (todayTrades ?? []) as PaperTrade[];
-  log(`Found ${trades.length} paper_trades for today`);
+  log(`Found ${trades.length} ${tTable} for today`);
 
   // Build lookup: ib_order_id → trade
   const tradeByOrderId = new Map<number, PaperTrade>();
@@ -117,7 +120,7 @@ export async function runEndOfDayReconciliation(): Promise<void> {
       const isCoverBuy = exec.side === 'BOT' || exec.side === 'BUY';
       if (isCoverBuy) {
         const { data: coverTrade } = await sb
-          .from('paper_trades')
+          .from(tTable)
           .select('*')
           .eq('ticker', exec.ticker)
           .eq('close_reason', 'reconcile_cover')
@@ -132,7 +135,7 @@ export async function runEndOfDayReconciliation(): Promise<void> {
           const qty = ct.quantity ?? 1;
           // For a covered short: entry was SELL (fill_price is the short entry), cover is BUY (exec.price)
           const pnl = (fillPrice - exec.price) * qty;
-          await sb.from('paper_trades').update({
+          await sb.from(tTable).update({
             close_price: exec.price,
             pnl: parseFloat(pnl.toFixed(2)),
             pnl_percent: fillPrice > 0 ? parseFloat(((pnl / (fillPrice * qty)) * 100).toFixed(2)) : null,
@@ -170,7 +173,7 @@ export async function runEndOfDayReconciliation(): Promise<void> {
           updates.pnl_percent = parseFloat(((pnl / (exec.price * qty)) * 100).toFixed(2));
         }
 
-        await sb.from('paper_trades').update(updates).eq('id', trade.id);
+        await sb.from(tTable).update(updates).eq('id', trade.id);
         corrected++;
         correctionDetails.push(`${trade.ticker}: fill_price ${currentFill.toFixed(2)} → ${exec.price.toFixed(2)}`);
         log(`Corrected ${trade.ticker} fill_price: $${currentFill.toFixed(2)} → $${exec.price.toFixed(2)}`);
@@ -210,7 +213,7 @@ export async function runEndOfDayReconciliation(): Promise<void> {
           const costBasis = fillPrice * qty;
           const pnlPct = costBasis > 0 ? (pnl / costBasis) * 100 : 0;
 
-          await sb.from('paper_trades').update({
+          await sb.from(tTable).update({
             close_price: exec.price,
             pnl: parseFloat(pnl.toFixed(2)),
             pnl_percent: parseFloat(pnlPct.toFixed(2)),
@@ -249,18 +252,19 @@ export async function runEndOfDayReconciliation(): Promise<void> {
   }
 
   // 6. Log summary
-  await logReconciliationSummary(matched, corrected, orphaned, flagged, correctionDetails);
-  log(`Done: ${matched} matched, ${corrected} corrected, ${orphaned} orphaned, ${flagged} flagged`);
+  await logReconciliationSummary(matched, corrected, orphaned, flagged, correctionDetails, accountType);
+  log(`Done (${accountType}): ${matched} matched, ${corrected} corrected, ${orphaned} orphaned, ${flagged} flagged`);
 }
 
 function requestExecutions(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ib: any,
   account: string,
-  timeFilter: string
+  timeFilter: string,
+  conn: IBConnection,
 ): Promise<IBExecution[]> {
   return new Promise((resolve) => {
-    const reqId = getNextOrderId();
+    const reqId = conn.getNextOrderId();
     const executions: IBExecution[] = [];
     // execId → realizedPnl from IB's commissionReport. IB fires commissionReport for each
     // execution, usually shortly after execDetails, but may arrive after execDetailsEnd.
@@ -341,7 +345,8 @@ async function logReconciliationSummary(
   corrected: number,
   orphaned: number,
   flagged: number,
-  details?: string[]
+  details?: string[],
+  accountType: AccountType = 'paper',
 ): Promise<void> {
   try {
     await createAutoTradeEvent({
@@ -355,7 +360,7 @@ async function logReconciliationSummary(
         matched, corrected, orphaned, flagged,
         notes: (details ?? []).join('\n') || undefined,
       },
-    });
+    }, accountType);
   } catch (err) {
     log(`Failed to log reconciliation summary: ${err instanceof Error ? err.message : err}`);
   }

--- a/auto-trader/src/lib/streak-tracker.ts
+++ b/auto-trader/src/lib/streak-tracker.ts
@@ -13,8 +13,9 @@
  *   base × Kelly × regime × streak = final size
  */
 
-import { getSupabase } from './supabase.js';
+import { getSupabase, tradesTable, streakTable } from './supabase.js';
 import { CLOSED_STATUSES } from '../../../shared/trade-status-sets.js';
+import type { AccountType } from '../../../shared/trade-types.js';
 
 const log = (msg: string) => console.log(`[StreakTracker] ${msg}`);
 
@@ -45,16 +46,17 @@ interface StreakState {
  *
  * Non-blocking: returns 1.0 on any error (never silently kills sizing).
  */
-export async function getStreakMultiplier(mode: string): Promise<number> {
+export async function getStreakMultiplier(mode: string, accountType: AccountType = 'paper'): Promise<number> {
   const config = STREAK_CONFIGS[mode];
   if (!config) return 1.0;
 
   try {
     const sb = getSupabase();
+    const tTable = tradesTable(accountType);
+    const sTable = streakTable(accountType);
 
-    // Fetch last N completed trades for this mode
     const { data: trades, error: tradeErr } = await sb
-      .from('paper_trades')
+      .from(tTable)
       .select('pnl')
       .eq('mode', mode)
       .in('status', [...CLOSED_STATUSES])
@@ -64,16 +66,14 @@ export async function getStreakMultiplier(mode: string): Promise<number> {
       .limit(config.windowSize);
 
     if (tradeErr || !trades || trades.length < config.windowSize) {
-      // Not enough trades to judge — don't apply cold streak
       return 1.0;
     }
 
     const wins = trades.filter(t => (t.pnl ?? 0) > 0).length;
     const winRate = wins / trades.length;
 
-    // Fetch current state
     const { data: stateRow } = await sb
-      .from('strategy_streak_state')
+      .from(sTable)
       .select('is_cold, entered_cold_at, rolling_win_rate')
       .eq('mode', mode)
       .single();
@@ -82,18 +82,15 @@ export async function getStreakMultiplier(mode: string): Promise<number> {
     let isCold: boolean;
 
     if (wasCold) {
-      // Currently cold — only recover if win rate exceeds recovery threshold
       isCold = winRate < config.recoveryThreshold;
     } else {
-      // Currently normal — enter cold if win rate drops below cold threshold
       isCold = winRate < config.coldThreshold;
     }
 
-    // Persist state change
     const stateChanged = isCold !== wasCold;
     if (stateChanged || !stateRow) {
       await sb
-        .from('strategy_streak_state')
+        .from(sTable)
         .upsert({
           mode,
           is_cold: isCold,
@@ -109,9 +106,8 @@ export async function getStreakMultiplier(mode: string): Promise<number> {
         log(`✅ ${mode} recovered from cold streak — win rate ${(winRate * 100).toFixed(0)}% > ${(config.recoveryThreshold * 100).toFixed(0)}% recovery threshold → full size restored`);
       }
     } else {
-      // Update rolling stats even if state didn't change
       await sb
-        .from('strategy_streak_state')
+        .from(sTable)
         .update({
           last_checked_at: new Date().toISOString(),
           rolling_win_rate: winRate,

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -7,6 +7,7 @@
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { ACTIVE_STATUSES, CLOSED_STATUSES } from '../../../shared/trade-status-sets.js';
+import type { AccountType } from '../../../shared/trade-types.js';
 
 const SUPABASE_URL = process.env.SUPABASE_URL ?? '';
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
@@ -31,6 +32,24 @@ export function getSupabaseAnonKey(): string { return SUPABASE_ANON_KEY; }
 export function getSupabaseServiceRoleKey(): string { return SUPABASE_SERVICE_KEY; }
 export function isConfigured(): boolean {
   return !!(SUPABASE_URL && SUPABASE_SERVICE_KEY && SUPABASE_ANON_KEY);
+}
+
+// ── Dual-Account Table Routing ───────────────────────────
+
+export function tradesTable(acct: AccountType): 'paper_trades' | 'live_trades' {
+  return acct === 'live' ? 'live_trades' : 'paper_trades';
+}
+
+export function eventsTable(acct: AccountType): 'auto_trade_events' | 'live_trade_events' {
+  return acct === 'live' ? 'live_trade_events' : 'auto_trade_events';
+}
+
+export function fillsTable(acct: AccountType): 'ib_fills' | 'live_ib_fills' {
+  return acct === 'live' ? 'live_ib_fills' : 'ib_fills';
+}
+
+export function streakTable(acct: AccountType): 'strategy_streak_state' | 'live_strategy_streak_state' {
+  return acct === 'live' ? 'live_strategy_streak_state' : 'strategy_streak_state';
 }
 
 // ── Auto-Trader Config (shared single source of truth) ──
@@ -110,6 +129,14 @@ export async function loadConfig(): Promise<AutoTraderConfig> {
     pennyMaxDailyLoss: Number(data.penny_max_daily_loss ?? DEFAULT_CONFIG.pennyMaxDailyLoss),
     pennyMaxDailyTrades: Number(data.penny_max_daily_trades ?? DEFAULT_CONFIG.pennyMaxDailyTrades),
     trendFilterEnabled: data.trend_filter_enabled ?? DEFAULT_CONFIG.trendFilterEnabled,
+    // Dual-account routing
+    modeRouting: data.mode_routing ?? DEFAULT_CONFIG.modeRouting,
+    liveKillSwitch: data.live_kill_switch ?? DEFAULT_CONFIG.liveKillSwitch,
+    liveDailyLossLimit: Number(data.live_daily_loss_limit ?? DEFAULT_CONFIG.liveDailyLossLimit),
+    livePortfolioValue: Number(data.live_portfolio_value ?? DEFAULT_CONFIG.livePortfolioValue),
+    livePositionSize: Number(data.live_position_size ?? DEFAULT_CONFIG.livePositionSize),
+    liveMaxPositions: Number(data.live_max_positions ?? DEFAULT_CONFIG.liveMaxPositions),
+    liveMaxDailyDeployment: Number(data.live_max_daily_deployment ?? DEFAULT_CONFIG.liveMaxDailyDeployment),
   };
 }
 
@@ -186,10 +213,10 @@ export interface StrategyClosedTradeOutcome {
 
 import { formatDateToEtIso } from '../../../shared/date-helpers.js';
 
-export async function getActiveTrades(): Promise<PaperTrade[]> {
+export async function getActiveTrades(accountType: AccountType = 'paper'): Promise<PaperTrade[]> {
   const sb = getSupabase();
   const { data, error } = await sb
-    .from('paper_trades')
+    .from(tradesTable(accountType))
     .select('*')
     .in('status', [...ACTIVE_STATUSES])
     .order('opened_at', { ascending: false });
@@ -245,11 +272,11 @@ export async function getLongTermExposureByTag(): Promise<{
 
 export async function hasActiveTrade(
   ticker: string,
-  opts?: { excludeMode?: 'LONG_TERM'; signal?: 'BUY' | 'SELL'; excludeOptions?: boolean }
+  opts?: { excludeMode?: 'LONG_TERM'; signal?: 'BUY' | 'SELL'; excludeOptions?: boolean; accountType?: AccountType }
 ): Promise<boolean> {
   const sb = getSupabase();
   let query = sb
-    .from('paper_trades')
+    .from(tradesTable(opts?.accountType ?? 'paper'))
     .select('id', { count: 'exact', head: true })
     .eq('ticker', ticker)
     .in('status', [...ACTIVE_STATUSES]);
@@ -345,12 +372,10 @@ export async function getTickerWinRate(
   return { wins, losses, winRate, total };
 }
 
-export async function countActivePositions(): Promise<number> {
+export async function countActivePositions(accountType: AccountType = 'paper'): Promise<number> {
   const sb = getSupabase();
-  // Options positions run on their own pipeline and budget — exclude them from
-  // the stock scanner's max-positions slot count so they don't starve day/swing trades.
   const { count } = await sb
-    .from('paper_trades')
+    .from(tradesTable(accountType))
     .select('id', { count: 'exact', head: true })
     .in('status', [...ACTIVE_STATUSES])
     .not('mode', 'in', '(OPTIONS_PUT,OPTIONS_CALL)');
@@ -358,11 +383,12 @@ export async function countActivePositions(): Promise<number> {
 }
 
 export async function createPaperTrade(
-  trade: Record<string, unknown>
+  trade: Record<string, unknown>,
+  accountType: AccountType = 'paper',
 ): Promise<PaperTrade> {
   const sb = getSupabase();
   const { data, error } = await sb
-    .from('paper_trades')
+    .from(tradesTable(accountType))
     .insert(trade)
     .select()
     .single();
@@ -372,11 +398,12 @@ export async function createPaperTrade(
 
 export async function updatePaperTrade(
   id: string,
-  updates: Record<string, unknown>
+  updates: Record<string, unknown>,
+  accountType: AccountType = 'paper',
 ): Promise<void> {
   const sb = getSupabase();
   const { error } = await sb
-    .from('paper_trades')
+    .from(tradesTable(accountType))
     .update(updates)
     .eq('id', id);
   if (error) throw new Error(`updatePaperTrade: ${error.message}`);
@@ -631,10 +658,11 @@ export type { AutoTradeAction, AutoTradeSource, AutoTradeEventInput, AutoTradeEv
 import type { AutoTradeAction, AutoTradeSource, AutoTradeEventInput } from '../../../shared/auto-trade-events.js';
 
 export async function createAutoTradeEvent(
-  event: AutoTradeEventInput
+  event: AutoTradeEventInput,
+  accountType: AccountType = 'paper',
 ): Promise<void> {
   const sb = getSupabase();
-  const { error } = await sb.from('auto_trade_events').insert(event);
+  const { error } = await sb.from(eventsTable(accountType)).insert(event);
   if (error) {
     throw new Error(`Failed to persist event for ${event.ticker}: ${error.message}`);
   }
@@ -724,35 +752,32 @@ export interface IbFill {
   filled_at: string;
 }
 
-export async function insertIbFill(fill: IbFill): Promise<void> {
+export async function insertIbFill(fill: IbFill, accountType: AccountType = 'paper'): Promise<void> {
   const sb = getSupabase();
-  const { error } = await sb.from('ib_fills').insert(fill);
+  const { error } = await sb.from(fillsTable(accountType)).insert(fill);
   if (error) {
     console.warn(`[Supabase] Failed to persist IB fill for order ${fill.order_id}: ${error.message}`);
   }
 }
 
-export async function updateIbFillCommission(execId: string, commission: number, realizedPnl?: number | null): Promise<void> {
+export async function updateIbFillCommission(execId: string, commission: number, realizedPnl?: number | null, accountType: AccountType = 'paper'): Promise<void> {
   const sb = getSupabase();
   const updates: Record<string, unknown> = { commission };
-  // Store IB's FIFO-based realized P&L alongside the commission. This is the source of
-  // truth for P&L when IB's FIFO cost basis differs from our tracked fill_price
-  // (e.g. orphaned prior-day lots). The EOD reconciler reads this to correct paper_trades.
   if (realizedPnl != null && isFinite(realizedPnl) && Math.abs(realizedPnl) < 1e6) {
     updates.realized_pnl = realizedPnl;
   }
-  const { error } = await sb.from('ib_fills').update(updates).eq('exec_id', execId);
+  const { error } = await sb.from(fillsTable(accountType)).update(updates).eq('exec_id', execId);
   if (error) {
     console.warn(`[Supabase] Failed to update commission for exec ${execId}: ${error.message}`);
   }
 }
 
-export async function getTodayFillPrices(): Promise<Map<number, number>> {
+export async function getTodayFillPrices(accountType: AccountType = 'paper'): Promise<Map<number, number>> {
   const sb = getSupabase();
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
   const { data, error } = await sb
-    .from('ib_fills')
+    .from(fillsTable(accountType))
     .select('order_id, fill_price')
     .gte('filled_at', todayStart.toISOString());
   if (error || !data) return new Map();
@@ -763,10 +788,10 @@ export async function getTodayFillPrices(): Promise<Map<number, number>> {
   return map;
 }
 
-export async function getFillPriceByOrderId(orderId: number): Promise<number | undefined> {
+export async function getFillPriceByOrderId(orderId: number, accountType: AccountType = 'paper'): Promise<number | undefined> {
   const sb = getSupabase();
   const { data } = await sb
-    .from('ib_fills')
+    .from(fillsTable(accountType))
     .select('fill_price')
     .eq('order_id', orderId)
     .order('filled_at', { ascending: false })

--- a/auto-trader/src/lib/tradePerformanceLog.ts
+++ b/auto-trader/src/lib/tradePerformanceLog.ts
@@ -5,6 +5,7 @@
 
 import { getSupabase } from './supabase.js';
 import type { PaperTrade } from './supabase.js';
+import type { AccountType } from '../../../shared/trade-types.js';
 
 // ── Regime helper (SPY SMA50/SMA200 + VIX, cached per day) ─────────────────
 
@@ -155,7 +156,8 @@ export interface LogContext {
 /** Log a closed trade to trade_performance_log. Idempotent. */
 export async function logClosedTradePerformance(
   closedTrade: PaperTrade,
-  context?: LogContext
+  context?: LogContext,
+  accountType: AccountType = 'paper',
 ): Promise<void> {
   if (!closedTrade.closed_at) return;
   const strategy = closedTrade.mode as 'DAY_TRADE' | 'DAY_PENNY' | 'SWING_TRADE' | 'LONG_TERM';
@@ -233,6 +235,7 @@ export async function logClosedTradePerformance(
       ? { spy_above_50: regimeAtExit.spy_above_50, spy_above_200: regimeAtExit.spy_above_200, vix_bucket: regimeAtExit.vix_bucket }
       : null,
     trigger_label: context?.trigger ?? 'IB_POSITION_GONE',
+    account_type: accountType,
   };
 
   const sb = getSupabase();

--- a/auto-trader/src/routes/live.ts
+++ b/auto-trader/src/routes/live.ts
@@ -1,0 +1,101 @@
+/**
+ * Live trading control endpoints:
+ *   POST /api/live/kill-switch — engage/disengage the live kill switch
+ *   GET  /api/live/status      — live connection status, P&L, positions
+ *   GET  /api/live/mode-routing — current mode→account routing config
+ *   PUT  /api/live/mode-routing — update mode→account routing
+ */
+
+import { Router } from 'express';
+import { getLiveConnection, getPaperConnection } from '../ib-connection.js';
+import { loadConfig, saveConfigPartial } from '../lib/supabase.js';
+import type { AccountType } from '../../../shared/trade-types.js';
+
+const router = Router();
+
+router.post('/live/kill-switch', async (req, res) => {
+  try {
+    const { engage } = req.body as { engage?: boolean };
+    if (typeof engage !== 'boolean') {
+      res.status(400).json({ error: 'Missing required boolean field: engage' });
+      return;
+    }
+
+    await saveConfigPartial({ liveKillSwitch: engage });
+
+    const liveConn = getLiveConnection();
+    if (engage && liveConn.isConnected()) {
+      liveConn.disconnect();
+    }
+
+    res.json({ ok: true, liveKillSwitch: engage });
+  } catch (err) {
+    res.status(500).json({ error: err instanceof Error ? err.message : 'unknown' });
+  }
+});
+
+router.get('/live/status', async (_req, res) => {
+  try {
+    const config = await loadConfig();
+    const liveConn = getLiveConnection();
+    const paperConn = getPaperConnection();
+
+    res.json({
+      liveKillSwitch: config.liveKillSwitch ?? false,
+      live: {
+        connected: liveConn.isConnected(),
+        accounts: liveConn.getAccounts(),
+        defaultAccount: liveConn.getDefaultAccount(),
+        pnl: liveConn.isConnected() ? liveConn.getDailyPnL() : null,
+      },
+      paper: {
+        connected: paperConn.isConnected(),
+        accounts: paperConn.getAccounts(),
+        defaultAccount: paperConn.getDefaultAccount(),
+        pnl: paperConn.isConnected() ? paperConn.getDailyPnL() : null,
+      },
+      modeRouting: config.modeRouting ?? {},
+    });
+  } catch (err) {
+    res.status(500).json({ error: err instanceof Error ? err.message : 'unknown' });
+  }
+});
+
+router.get('/live/mode-routing', async (_req, res) => {
+  try {
+    const config = await loadConfig();
+    res.json({ modeRouting: config.modeRouting ?? {} });
+  } catch (err) {
+    res.status(500).json({ error: err instanceof Error ? err.message : 'unknown' });
+  }
+});
+
+router.put('/live/mode-routing', async (req, res) => {
+  try {
+    const { modeRouting } = req.body as { modeRouting?: Record<string, AccountType> };
+    if (!modeRouting || typeof modeRouting !== 'object') {
+      res.status(400).json({ error: 'Missing required object field: modeRouting' });
+      return;
+    }
+
+    const validModes = ['DAY_TRADE', 'DAY_PENNY', 'SWING_TRADE', 'LONG_TERM', 'OPTIONS_PUT', 'OPTIONS_CALL'];
+    const validAccounts: AccountType[] = ['paper', 'live'];
+    for (const [mode, acct] of Object.entries(modeRouting)) {
+      if (!validModes.includes(mode)) {
+        res.status(400).json({ error: `Invalid mode: ${mode}` });
+        return;
+      }
+      if (!validAccounts.includes(acct)) {
+        res.status(400).json({ error: `Invalid account type for ${mode}: ${acct}` });
+        return;
+      }
+    }
+
+    await saveConfigPartial({ modeRouting });
+    res.json({ ok: true, modeRouting });
+  } catch (err) {
+    res.status(500).json({ error: err instanceof Error ? err.message : 'unknown' });
+  }
+});
+
+export default router;

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -23,8 +23,14 @@ import {
   cancelOrder,
   getOrderFillPrice,
   getOrderFillPriceWithFallback,
+  getPaperConnection,
+  getLiveConnection,
+  getConnectionForAccount,
   type PositionData,
+  type IBConnection,
 } from './ib-connection.js';
+import { getConnectionForMode, getAccountForMode, getPositionSizeConfig, assertLiveLossLimitNotBreached } from './lib/mode-router.js';
+import type { AccountType } from '../../shared/trade-types.js';
 import {
   isConfigured,
   getSupabase,
@@ -65,6 +71,7 @@ import {
   type AutoTraderConfig,
   type ExternalStrategySignal,
   type PaperTrade,
+  tradesTable,
 } from './lib/supabase.js';
 import { ACTIVE_STATUSES, CLOSED_STATUSES } from '../../shared/trade-status-sets.js';
 import type { AutoTradeEventType } from '../../shared/auto-trade-events.js';
@@ -620,104 +627,90 @@ export function stopScheduler(): void {
  */
 async function closeAllDayTrades(config: AutoTraderConfig): Promise<void> {
   log('EOD day-trade sweep: closing all open day trade positions…');
-  const activeTrades = await getActiveTrades();
-  // Include SUBMITTED + PARTIAL — IB fill confirmations sometimes don't write back before
-  // the EOD sweep fires, leaving orders in SUBMITTED state. At 3:55 PM ET the position is
-  // effectively closed by IB regardless; mark them closed in paper_trades too.
-  const dayTrades = activeTrades.filter(t => (t.mode === 'DAY_TRADE' || t.mode === 'DAY_PENNY') && ['FILLED', 'SUBMITTED', 'PARTIAL'].includes(t.status));
 
-  if (dayTrades.length === 0) {
-    log('EOD sweep: no open day trades');
-    return;
-  }
+  // Close day trades on both paper and live accounts
+  for (const acctType of ['paper', 'live'] as AccountType[]) {
+    const conn = getConnectionForAccount(acctType);
+    if (!conn.isConnected()) {
+      if (acctType === 'paper') log('EOD sweep: paper IB not connected, skipping paper');
+      continue;
+    }
 
-  log(`EOD sweep: ${dayTrades.length} open day trade(s) to close`);
-  for (const trade of dayTrades) {
-    try {
-      if (!isConnected()) {
-        log(`EOD sweep: ${trade.ticker} — IB not connected, skipping`);
-        continue;
-      }
-      const closeSide = trade.signal === 'BUY' ? 'SELL' : 'BUY';
-      const qty = trade.quantity ?? 0;
-      if (qty <= 0) {
-        log(`EOD sweep: ${trade.ticker} — quantity is 0, skipping`);
-        continue;
-      }
+    const activeTrades = await getActiveTrades(acctType);
+    const dayTrades = activeTrades.filter(t => (t.mode === 'DAY_TRADE' || t.mode === 'DAY_PENNY') && ['FILLED', 'SUBMITTED', 'PARTIAL'].includes(t.status));
 
-      // ── Double-close guard ────────────────────────────────────────────────
-      // Mark as CLOSED (with null price) BEFORE placing the IB order. This
-      // prevents any concurrent process (a second cron firing, another
-      // scheduler cycle, or a leftover browser closeAllDayTrades call) from
-      // seeing the trade as FILLED and placing a duplicate close order.
-      // The EOD reconciler at 4:15 PM will write the correct close_price/pnl.
-      if (trade.status === 'FILLED') {
+    if (dayTrades.length === 0) {
+      if (acctType === 'paper') log('EOD sweep: no open day trades (paper)');
+      continue;
+    }
+
+    log(`EOD sweep [${acctType}]: ${dayTrades.length} open day trade(s) to close`);
+    for (const trade of dayTrades) {
+      try {
+        const closeSide = trade.signal === 'BUY' ? 'SELL' : 'BUY';
+        const qty = trade.quantity ?? 0;
+        if (qty <= 0) {
+          log(`EOD sweep: ${trade.ticker} — quantity is 0, skipping`);
+          continue;
+        }
+
+        if (trade.status === 'FILLED') {
+          await updatePaperTrade(trade.id, {
+            status: 'CLOSED',
+            close_reason: 'eod_close',
+            closed_at: new Date().toISOString(),
+          }, acctType);
+        }
+
+        if (trade.status === 'SUBMITTED' || trade.status === 'PARTIAL') {
+          const orderId = trade.ib_order_id ? parseInt(trade.ib_order_id, 10) : NaN;
+          if (!Number.isNaN(orderId)) {
+            try {
+              conn.cancelOrder(orderId);
+              log(`${trade.ticker}: EOD — cancelled open entry IB order #${orderId}`);
+            } catch (cancelErr) {
+              log(`${trade.ticker}: EOD — cancel IB order #${orderId} failed (${cancelErr instanceof Error ? cancelErr.message : 'unknown'}) — continuing`);
+            }
+          }
+          await updatePaperTrade(trade.id, {
+            status: 'CANCELLED',
+            close_reason: 'never_filled',
+            closed_at: new Date().toISOString(),
+          }, acctType);
+          log(`${trade.ticker}: EOD cancelled (unfilled SUBMITTED order — no IB position to close)`);
+          continue;
+        }
+
+        let fillResult: { avgFillPrice: number } | null = null;
+        try {
+          fillResult = await conn.placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });
+          log(`${trade.ticker}: EOD close filled [${acctType}] (${qty} shares ${closeSide}) @ $${fillResult.avgFillPrice.toFixed(2)}`);
+        } catch (orderErr) {
+          log(`EOD sweep: ${trade.ticker} — IB order failed (${orderErr instanceof Error ? orderErr.message : 'unknown'}) — will retry on next sweep`);
+        }
+
+        if (!fillResult) continue;
+
+        const entryFillPrice = trade.fill_price ?? trade.entry_price ?? 0;
+        const isLong = trade.signal === 'BUY';
+        const pnl = isLong
+          ? (fillResult.avgFillPrice - entryFillPrice) * qty
+          : (entryFillPrice - fillResult.avgFillPrice) * qty;
+        const costBasis = entryFillPrice * qty;
+        const pnlPct = costBasis > 0 ? (pnl / costBasis) * 100 : 0;
+
         await updatePaperTrade(trade.id, {
           status: 'CLOSED',
           close_reason: 'eod_close',
+          close_price: fillResult.avgFillPrice,
+          pnl: parseFloat(pnl.toFixed(2)),
+          pnl_percent: parseFloat(pnlPct.toFixed(2)),
           closed_at: new Date().toISOString(),
-        });
+        }, acctType);
+        log(`${trade.ticker}: EOD closed [${acctType}] (${qty} shares ${closeSide}) @ $${fillResult.avgFillPrice.toFixed(2)} — P&L $${pnl.toFixed(2)}`);
+      } catch (err) {
+        log(`EOD sweep: ${trade.ticker} — close failed: ${err instanceof Error ? err.message : 'unknown'}`);
       }
-
-      // Cancel the original IB entry order first (SUBMITTED/PARTIAL trades that haven't filled).
-      // This is the root-cause fix for pre-market fills: without cancellation, IB holds the open
-      // entry order overnight and fills it the next morning. DAY tif should auto-expire, but
-      // explicit cancel is belt-and-suspenders in case IB extended-hours settings are active.
-      if (trade.status === 'SUBMITTED' || trade.status === 'PARTIAL') {
-        const orderId = trade.ib_order_id ? parseInt(trade.ib_order_id, 10) : NaN;
-        if (!Number.isNaN(orderId)) {
-          try {
-            cancelOrder(orderId);
-            log(`${trade.ticker}: EOD — cancelled open entry IB order #${orderId}`);
-          } catch (cancelErr) {
-            log(`${trade.ticker}: EOD — cancel IB order #${orderId} failed (${cancelErr instanceof Error ? cancelErr.message : 'unknown'}) — continuing`);
-          }
-        }
-        // SUBMITTED = entry never filled, so there is no position to close in IB.
-        // Mark CANCELLED (not CLOSED) so it doesn't pollute the P&L activity log
-        // with $0 entries. CANCELLED trades are excluded from win/loss calculations.
-        await updatePaperTrade(trade.id, {
-          status: 'CANCELLED',
-          close_reason: 'never_filled',
-          closed_at: new Date().toISOString(),
-        });
-        log(`${trade.ticker}: EOD cancelled (unfilled SUBMITTED order — no IB position to close)`);
-        continue;
-      }
-
-      let fillResult: { avgFillPrice: number } | null = null;
-      try {
-        fillResult = await placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });
-        log(`${trade.ticker}: EOD close filled (${qty} shares ${closeSide}) @ $${fillResult.avgFillPrice.toFixed(2)}`);
-      } catch (orderErr) {
-        log(`EOD sweep: ${trade.ticker} — IB order failed (${orderErr instanceof Error ? orderErr.message : 'unknown'}) — will retry on next sweep`);
-      }
-
-      if (!fillResult) {
-        // Don't mark CLOSED if IB rejected the order — the position is still open.
-        // Leave status unchanged so the 4:05 safety sweep or IBReconcile picks it up.
-        continue;
-      }
-
-      const entryFillPrice = trade.fill_price ?? trade.entry_price ?? 0;
-      const isLong = trade.signal === 'BUY';
-      const pnl = isLong
-        ? (fillResult.avgFillPrice - entryFillPrice) * qty
-        : (entryFillPrice - fillResult.avgFillPrice) * qty;
-      const costBasis = entryFillPrice * qty;
-      const pnlPct = costBasis > 0 ? (pnl / costBasis) * 100 : 0;
-
-      await updatePaperTrade(trade.id, {
-        status: 'CLOSED',
-        close_reason: 'eod_close',
-        close_price: fillResult.avgFillPrice,
-        pnl: parseFloat(pnl.toFixed(2)),
-        pnl_percent: parseFloat(pnlPct.toFixed(2)),
-        closed_at: new Date().toISOString(),
-      });
-      log(`${trade.ticker}: EOD closed (${qty} shares ${closeSide}) @ $${fillResult.avgFillPrice.toFixed(2)} — P&L $${pnl.toFixed(2)}`);
-    } catch (err) {
-      log(`EOD sweep: ${trade.ticker} — close failed: ${err instanceof Error ? err.message : 'unknown'}`);
     }
   }
 }
@@ -731,77 +724,82 @@ async function closeAllDayTrades(config: AutoTraderConfig): Promise<void> {
 // Winning trades with room to run are left for the trailing stop or bracket.
 
 async function softCloseDayTrades(positions: EnrichedPosition[]): Promise<void> {
-  const activeTrades = await getActiveTrades();
-  const dayTrades = activeTrades.filter(t => (t.mode === 'DAY_TRADE' || t.mode === 'DAY_PENNY') && ['FILLED', 'SUBMITTED', 'PARTIAL'].includes(t.status));
-  if (dayTrades.length === 0) return;
+  // Soft-close day trades on both paper and live accounts
+  for (const acctType of ['paper', 'live'] as AccountType[]) {
+    const conn = getConnectionForAccount(acctType);
+    if (!conn.isConnected()) continue;
 
-  log(`[SoftClose] Checking ${dayTrades.length} open day trade(s) before power hour`);
-  let closed = 0;
+    const activeTrades = await getActiveTrades(acctType);
+    const dayTrades = activeTrades.filter(t => (t.mode === 'DAY_TRADE' || t.mode === 'DAY_PENNY') && ['FILLED', 'SUBMITTED', 'PARTIAL'].includes(t.status));
+    if (dayTrades.length === 0) continue;
 
-  for (const trade of dayTrades) {
-    const ibPos = positions.find(p => p.symbol.toUpperCase() === trade.ticker.toUpperCase());
-    if (!ibPos || ibPos.mktPrice <= 0) continue;
+    log(`[SoftClose:${acctType}] Checking ${dayTrades.length} open day trade(s) before power hour`);
+    let closed = 0;
 
-    const fillPrice    = trade.fill_price ?? trade.entry_price ?? 0;
-    const targetPrice  = trade.target_price ?? 0;
-    const currentPrice = ibPos.mktPrice;
-    const isBuy        = trade.signal === 'BUY';
+    for (const trade of dayTrades) {
+      const ibPos = positions.find(p => p.symbol.toUpperCase() === trade.ticker.toUpperCase());
+      if (!ibPos || ibPos.mktPrice <= 0) continue;
 
-    const unrealizedPnl = isBuy
-      ? (currentPrice - fillPrice) * (trade.quantity ?? 0)
-      : (fillPrice - currentPrice) * (trade.quantity ?? 0);
+      const fillPrice    = trade.fill_price ?? trade.entry_price ?? 0;
+      const targetPrice  = trade.target_price ?? 0;
+      const currentPrice = ibPos.mktPrice;
+      const isBuy        = trade.signal === 'BUY';
 
-    // Determine whether near-target (75% of full gain achieved)
-    let nearTarget = false;
-    if (fillPrice > 0 && targetPrice > 0) {
-      const fullGain   = Math.abs(targetPrice - fillPrice);
-      const actualGain = Math.abs(currentPrice - fillPrice);
-      nearTarget = fullGain > 0 && actualGain / fullGain >= 0.75;
-    }
+      const unrealizedPnl = isBuy
+        ? (currentPrice - fillPrice) * (trade.quantity ?? 0)
+        : (fillPrice - currentPrice) * (trade.quantity ?? 0);
 
-    const shouldClose = unrealizedPnl < 0 || nearTarget;
-    const reason      = unrealizedPnl < 0 ? `losing (${unrealizedPnl.toFixed(0)})` : `near target (75%+)`;
-
-    if (!shouldClose) {
-      log(`${trade.ticker}: [SoftClose] skip — P&L ${unrealizedPnl.toFixed(0)}, not near target`);
-      continue;
-    }
-
-    const closeSide = isBuy ? 'SELL' : 'BUY';
-    const qty       = trade.quantity ?? 0;
-    if (qty <= 0) continue;
-
-    try {
-      let orderPlaced = false;
-      try {
-        await placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });
-        log(`${trade.ticker}: [SoftClose] close order placed at 3:45 PM — ${reason}`);
-        orderPlaced = true;
-      } catch (orderErr) {
-        log(`${trade.ticker}: [SoftClose] IB order failed (${orderErr instanceof Error ? orderErr.message : 'unknown'}) — will retry at 3:55 PM hard close`);
+      let nearTarget = false;
+      if (fillPrice > 0 && targetPrice > 0) {
+        const fullGain   = Math.abs(targetPrice - fillPrice);
+        const actualGain = Math.abs(currentPrice - fillPrice);
+        nearTarget = fullGain > 0 && actualGain / fullGain >= 0.75;
       }
 
-      if (!orderPlaced) continue;
+      const shouldClose = unrealizedPnl < 0 || nearTarget;
+      const reason      = unrealizedPnl < 0 ? `losing (${unrealizedPnl.toFixed(0)})` : `near target (75%+)`;
 
-      const pnl = unrealizedPnl;
-      const costBasis = fillPrice * (trade.quantity ?? 1);
-      const pnlPct = costBasis > 0 ? (pnl / costBasis) * 100 : 0;
+      if (!shouldClose) {
+        log(`${trade.ticker}: [SoftClose] skip — P&L ${unrealizedPnl.toFixed(0)}, not near target`);
+        continue;
+      }
 
-      await updatePaperTrade(trade.id, {
-        status:       'CLOSED',
-        close_reason: 'soft_eod_close',
-        close_price:  currentPrice,
-        pnl:          parseFloat(pnl.toFixed(2)),
-        pnl_percent:  parseFloat(pnlPct.toFixed(2)),
-        closed_at:    new Date().toISOString(),
-      });
-      log(`${trade.ticker}: [SoftClose] DB marked closed at 3:45 PM — ${reason} — P&L $${pnl.toFixed(2)}`);
-      closed++;
-    } catch (err) {
-      log(`${trade.ticker}: [SoftClose] close failed — ${err instanceof Error ? err.message : 'unknown'}`);
+      const closeSide = isBuy ? 'SELL' : 'BUY';
+      const qty       = trade.quantity ?? 0;
+      if (qty <= 0) continue;
+
+      try {
+        let orderPlaced = false;
+        try {
+          await conn.placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });
+          log(`${trade.ticker}: [SoftClose:${acctType}] close order placed at 3:45 PM — ${reason}`);
+          orderPlaced = true;
+        } catch (orderErr) {
+          log(`${trade.ticker}: [SoftClose] IB order failed (${orderErr instanceof Error ? orderErr.message : 'unknown'}) — will retry at 3:55 PM hard close`);
+        }
+
+        if (!orderPlaced) continue;
+
+        const pnl = unrealizedPnl;
+        const costBasis = fillPrice * (trade.quantity ?? 1);
+        const pnlPct = costBasis > 0 ? (pnl / costBasis) * 100 : 0;
+
+        await updatePaperTrade(trade.id, {
+          status:       'CLOSED',
+          close_reason: 'soft_eod_close',
+          close_price:  currentPrice,
+          pnl:          parseFloat(pnl.toFixed(2)),
+          pnl_percent:  parseFloat(pnlPct.toFixed(2)),
+          closed_at:    new Date().toISOString(),
+        }, acctType);
+        log(`${trade.ticker}: [SoftClose:${acctType}] DB marked closed at 3:45 PM — ${reason} — P&L $${pnl.toFixed(2)}`);
+        closed++;
+      } catch (err) {
+        log(`${trade.ticker}: [SoftClose] close failed — ${err instanceof Error ? err.message : 'unknown'}`);
+      }
     }
+    log(`[SoftClose:${acctType}] Done — ${closed} position(s) closed`);
   }
-  log(`[SoftClose] Done — ${closed} position(s) closed`);
 }
 
 // ── Stale Day-Trade Detector ───────────────────────────────────────────────────
@@ -2349,14 +2347,15 @@ async function persistEvent(
   ticker: string,
   eventType: string,
   message: string,
-  extra?: Omit<AutoTradeEventInput, 'ticker' | 'message'>
+  extra?: Omit<AutoTradeEventInput, 'ticker' | 'message'>,
+  accountType: AccountType = 'paper',
 ): Promise<void> {
   const safeType = (VALID_EVENT_TYPES.has(eventType as AutoTradeEventType) ? eventType : 'info') as AutoTradeEventType;
   const payload: AutoTradeEventInput = { ticker, event_type: safeType, message, ...extra };
   const delays = [1000, 2000];
   for (let attempt = 0; attempt <= delays.length; attempt++) {
     try {
-      await createAutoTradeEvent(payload);
+      await createAutoTradeEvent(payload, accountType);
       return;
     } catch (err) {
       const label = `${ticker}/${eventType}`;
@@ -3299,10 +3298,27 @@ async function executeScannerTrade(
     log(`${ticker}: order validation OK — ${orderCheck.reason}`);
   }
 
-  // Verify IB connection is live before attempting order placement.
-  // We skip reqContractDetails for STK orders — it can fail transiently (empty
-  // results with SMART routing) while placeOrder handles contract resolution itself.
-  if (!isConnected()) return 'failed:no_contract';
+  // Resolve connection via mode router (paper or live based on config.modeRouting)
+  let connection: IBConnection;
+  let accountType: AccountType;
+  try {
+    const routed = getConnectionForMode(mode, config);
+    connection = routed.connection;
+    accountType = routed.accountType;
+  } catch (routeErr) {
+    log(`${ticker}: routing failed — ${routeErr instanceof Error ? routeErr.message : 'unknown'}`);
+    return 'failed:routing';
+  }
+
+  if (!connection.isConnected()) return 'failed:no_contract';
+
+  // Live safety: assert daily loss limit not breached
+  if (accountType === 'live') {
+    try { await assertLiveLossLimitNotBreached(config); } catch (limitErr) {
+      log(`${ticker}: ${limitErr instanceof Error ? limitErr.message : 'live loss limit breached'}`);
+      return 'failed:live_loss_limit';
+    }
+  }
 
   // SWING only: skip if price too far from entry (entry precision matters)
   if (mode === 'SWING_TRADE' && entryPrice > 0) {
@@ -3318,7 +3334,7 @@ async function executeScannerTrade(
   }
 
   try {
-    const result = await placeBracketOrder({
+    const result = await connection.placeBracketOrder({
       symbol: ticker,
       side: signal,
       quantity: sizing.quantity,
@@ -3350,10 +3366,10 @@ async function executeScannerTrade(
       pass1_confidence: idea.pass1_confidence,
       entry_trigger_type: 'bracket_limit',
       market_condition: idea.market_condition,
-    });
+    }, accountType);
 
     recordPendingOrder(sizing.dollarSize);
-    log(`${ticker}: ORDER PLACED — ${signal} ${sizing.quantity} @ $${entryPrice}`);
+    log(`${ticker}: ORDER PLACED [${accountType}] — ${signal} ${sizing.quantity} @ $${entryPrice}`);
     if (mode === 'SWING_TRADE') {
       upsertSwingMetrics({ date: getETDateString(), swing_orders_placed: 1 }).catch(() => {});
     }
@@ -3362,7 +3378,7 @@ async function executeScannerTrade(
       scanner_signal: signal, scanner_confidence: Math.round(effectiveScannerConf),
       fa_recommendation: faRec, fa_confidence: faConf != null ? Math.round(faConf) : null,
       ...(candlePatternLog.length > 0 && { metadata: { candle_patterns: candlePatternLog } }),
-    });
+    }, accountType);
     return 'executed';
   } catch (err) {
     log(`${ticker}: Order FAILED — ${err instanceof Error ? err.message : 'unknown'}`);
@@ -3419,23 +3435,29 @@ async function _executeSuggestedFindTradeInner(
   // where that check runs at the boundary (e.g. slow event loop crossing the 9:30 threshold).
   if (!isMarketHoursET()) return 'skipped:outside-market-hours';
 
-  if (await hasActiveTrade(ticker, { excludeOptions: true })) return 'skipped:duplicate';
+  // Resolve account routing for LONG_TERM mode
+  let connection: IBConnection;
+  let accountType: AccountType;
+  try {
+    const routed = getConnectionForMode('LONG_TERM', config);
+    connection = routed.connection;
+    accountType = routed.accountType;
+  } catch (routeErr) {
+    log(`${ticker}: LONG_TERM route error — ${routeErr instanceof Error ? routeErr.message : routeErr}`);
+    return 'failed:route_error';
+  }
 
-  // ── Recent-loss cooldown gate ─────────────────────────────────────────
-  // LONG_TERM trades use a 21-day lookback.
+  if (await hasActiveTrade(ticker, { excludeOptions: true, accountType })) return 'skipped:duplicate';
+
   if (await hasRecentLoss(ticker, 21, { excludeOptions: true })) {
     log(`${ticker}: LONG_TERM skipped — recent loss within 21d cooldown`);
     persistEvent(ticker, 'skipped', `LONG_TERM re-entry blocked — ticker had a loss within 21 days`, {
       action: 'skipped', source: 'suggested_finds', mode: 'LONG_TERM',
       skip_reason: 'recent_loss_cooldown',
-    });
+    }, accountType);
     return 'skipped:recent_loss_cooldown';
   }
 
-  // ── Repeated stop-out gate ────────────────────────────────────────────
-  // If a ticker has been loss-cut 3+ times in the last 90 days, the thesis
-  // is broken regardless of the current conviction score. Block re-entry
-  // indefinitely until the window clears. Prevents POOL/AOS-style churn.
   {
     const stopOuts = await countRecentStopOuts(ticker, 90, { excludeOptions: true });
     if (stopOuts >= 3) {
@@ -3443,19 +3465,16 @@ async function _executeSuggestedFindTradeInner(
       persistEvent(ticker, 'skipped', `LONG_TERM re-entry blocked — ${stopOuts} stop-outs in 90d`, {
         action: 'skipped', source: 'suggested_finds', mode: 'LONG_TERM',
         skip_reason: 'repeated_stop_out',
-      });
+      }, accountType);
       return 'skipped:repeated_stop_out';
     }
   }
 
-  // Same-day guard: block a second entry for the same ticker on the same ET calendar day.
-  // Protects against TEN-style duplicate orders that slip through hasActiveTrade due to
-  // a narrow race between two scheduler cycles.
   {
     const todayEt = getETDateString();
     const sb = getSupabase();
     const { data: todayTrades } = await sb
-      .from('paper_trades')
+      .from(tradesTable(accountType))
       .select('id')
       .eq('ticker', ticker)
       .eq('mode', 'LONG_TERM')
@@ -3569,10 +3588,17 @@ async function _executeSuggestedFindTradeInner(
     return 'skipped:pre_trade_check';
   }
 
-  if (!isConnected()) return 'failed:no_contract';
+  if (!connection.isConnected()) return 'failed:no_contract';
+
+  if (accountType === 'live') {
+    try { await assertLiveLossLimitNotBreached(config); } catch (limitErr) {
+      log(`${ticker}: LONG_TERM live loss limit hit — ${limitErr instanceof Error ? limitErr.message : limitErr}`);
+      return 'failed:live_loss_limit';
+    }
+  }
 
   try {
-    const result = await placeMarketOrder({
+    const result = await connection.placeMarketOrder({
       symbol: ticker, side: 'BUY', quantity: sizing.quantity,
     });
 
@@ -3598,13 +3624,13 @@ async function _executeSuggestedFindTradeInner(
         stock.tag === 'Dip Discovery' && stock.sector ? `Sector: ${stock.sector}` : null,
       ].filter(Boolean).join(' | '),
       entry_trigger_type: 'market',
-    });
+    }, accountType);
 
     recordPendingOrder(sizing.dollarSize);
-    log(`${ticker}: SUGGESTED FIND BUY — ${sizing.quantity} shares @ ~$${currentPrice.toFixed(2)}`);
+    log(`${ticker}: SUGGESTED FIND BUY [${accountType}] — ${sizing.quantity} shares @ ~$${currentPrice.toFixed(2)}`);
     persistEvent(ticker, 'success', `Suggested Find BUY: ${sizing.quantity} shares @ $${currentPrice.toFixed(2)}`, {
       action: 'executed', source: 'suggested_finds', mode: 'LONG_TERM',
-    });
+    }, accountType);
     return 'executed';
   } catch (err) {
     log(`${ticker}: Suggested Find order FAILED — ${err instanceof Error ? err.message : 'unknown'}`);
@@ -3643,7 +3669,19 @@ async function executeExternalStrategySignal(
 ): Promise<'executed' | 'skipped' | 'failed' | 'waiting'> {
   const ticker = signal.ticker.toUpperCase();
 
-  // ── Daily max-loss gate ───────────────────────────────────────────────
+  // Resolve account routing
+  let extConnection: IBConnection;
+  let extAccountType: AccountType;
+  try {
+    const routed = getConnectionForMode(signal.mode, config);
+    extConnection = routed.connection;
+    extAccountType = routed.accountType;
+  } catch (routeErr) {
+    log(`${ticker}: external signal route error — ${routeErr instanceof Error ? routeErr.message : routeErr}`);
+    await updateExternalStrategySignal(signal.id, { status: 'FAILED', failure_reason: `Route error: ${routeErr instanceof Error ? routeErr.message : routeErr}` });
+    return 'failed';
+  }
+
   if (signal.mode === 'DAY_TRADE' && await isDayTradeLossGateActive(config)) {
     log(`${ticker}: external signal skipped — daily loss gate active`);
     return 'skipped';
@@ -3712,14 +3750,10 @@ async function executeExternalStrategySignal(
   // expert's specific level. Only block if the SAME video already has an active trade open.
   if (!skipConfirmationGates) {
     if (allowDuplicateTicker || isGenericAutoSignal || signal.strategy_video_id != null) {
-      const activeTrades = await getActiveTrades();
+      const activeTrades = await getActiveTrades(extAccountType);
       const sameTickerTrades = activeTrades.filter(
         trade => trade.ticker.toUpperCase() === ticker
       );
-      // True duplicate: same strategy video already has an active trade in the same
-      // mode + direction for this ticker (e.g. allocation split already executed).
-      // Different direction (BUY vs SELL) or non-influencer (scanner) trades are NOT
-      // conflicts — a day trader can hold both a long and a short simultaneously.
       const hasConflict = sameTickerTrades.some(trade =>
         trade.mode === signal.mode &&
         trade.signal === signal.signal &&
@@ -3733,6 +3767,7 @@ async function executeExternalStrategySignal(
       ...(signal.mode !== 'LONG_TERM' ? { excludeMode: 'LONG_TERM' as const } : {}),
       signal: signal.signal,
       excludeOptions: true,
+      accountType: extAccountType,
     })) {
       return skipExternalSignal('Duplicate active trade for ticker', 'duplicate_active_trade');
     }
@@ -3945,12 +3980,19 @@ async function executeExternalStrategySignal(
     return 'skipped';
   }
 
-  if (!isConnected()) {
+  if (!extConnection.isConnected()) {
     await updateExternalStrategySignal(signal.id, {
       status: 'FAILED',
       failure_reason: 'IB Gateway not connected',
     });
     return 'failed';
+  }
+
+  if (extAccountType === 'live') {
+    try { await assertLiveLossLimitNotBreached(config); } catch (limitErr) {
+      await updateExternalStrategySignal(signal.id, { status: 'FAILED', failure_reason: `Live loss limit: ${limitErr instanceof Error ? limitErr.message : limitErr}` });
+      return 'failed';
+    }
   }
 
   const hasBracketLevels = (
@@ -3959,7 +4001,6 @@ async function executeExternalStrategySignal(
     effectiveTargetPrice != null
   );
 
-  // SWING only: skip bracket limit if price too far from entry (bypassed for manual execute)
   if (
     !skipConfirmationGates &&
     signal.mode === 'SWING_TRADE' &&
@@ -3979,7 +4020,6 @@ async function executeExternalStrategySignal(
     }
   }
 
-  // ── Pure order sanity check (synchronous, no DB) ─────────────────────
   {
     const deployed = await getTotalDeployed(positions);
     const orderCheck = validateOrder({
@@ -4011,7 +4051,7 @@ async function executeExternalStrategySignal(
     let ibTpOrderId: string | undefined;
     let ibSlOrderId: string | undefined;
     if (hasBracketLevels) {
-      const result = await placeBracketOrder({
+      const result = await extConnection.placeBracketOrder({
         symbol: ticker,
         side,
         quantity: sizing.quantity,
@@ -4027,7 +4067,7 @@ async function executeExternalStrategySignal(
         upsertSwingMetrics({ date: getETDateString(), swing_orders_placed: 1 }).catch(() => {});
       }
     } else {
-      const result = await placeMarketOrder({
+      const result = await extConnection.placeMarketOrder({
         symbol: ticker,
         side,
         quantity: sizing.quantity,
@@ -4035,8 +4075,6 @@ async function executeExternalStrategySignal(
       ibOrderId = String(result.orderId);
     }
 
-    // Derive market_condition from SPY change for the Trade Validation tab.
-    // spyChangePct is already fetched above for both gate-checked and influencer signals.
     const marketCondition: 'trend' | 'chop' | undefined =
       spyChangePct == null ? undefined
       : Math.abs(spyChangePct) >= 0.5 ? 'trend'
@@ -4066,7 +4104,7 @@ async function executeExternalStrategySignal(
       scanner_reason: `External strategy signal from ${signal.source_name}`,
       notes: signal.notes ? `External signal${splitLabel} | ${signal.notes}` : `External signal${splitLabel}`,
       market_condition: marketCondition,
-    });
+    }, extAccountType);
 
     recordPendingOrder(sizing.dollarSize);
     await updateExternalStrategySignal(signal.id, {
@@ -4076,7 +4114,7 @@ async function executeExternalStrategySignal(
       failure_reason: null,
     });
 
-    persistEvent(ticker, 'success', `External signal executed: ${side} ${sizing.quantity} @ $${entryForRecord.toFixed(2)}`, {
+    persistEvent(ticker, 'success', `External signal executed [${extAccountType}]: ${side} ${sizing.quantity} @ $${entryForRecord.toFixed(2)}`, {
       action: 'executed',
       source: resolvedSource,
       mode: signal.mode,
@@ -4094,7 +4132,7 @@ async function executeExternalStrategySignal(
         spy_change_pct: spyChangePct,
         also_in_scanner: alsoInScanner,
       },
-    });
+    }, extAccountType);
     return 'executed';
   } catch (err) {
     const message = err instanceof Error ? err.message : 'unknown';
@@ -4113,7 +4151,7 @@ async function executeExternalStrategySignal(
       scanner_signal: signal.signal,
       scanner_confidence: signal.confidence,
       metadata: { external_signal_id: signal.id },
-    });
+    }, extAccountType);
     return 'failed';
   }
 }
@@ -4295,7 +4333,20 @@ async function syncPositions(
   config: AutoTraderConfig,
   positions: EnrichedPosition[],
 ): Promise<void> {
-  const activeTrades = await getActiveTrades();
+  // Sync positions on both paper and live accounts
+  for (const syncAcct of ['paper', 'live'] as AccountType[]) {
+    const syncConn = getConnectionForAccount(syncAcct);
+    if (!syncConn.isConnected()) continue;
+    await _syncPositionsForAccount(config, positions, syncAcct);
+  }
+}
+
+async function _syncPositionsForAccount(
+  config: AutoTraderConfig,
+  positions: EnrichedPosition[],
+  syncAcct: AccountType,
+): Promise<void> {
+  const activeTrades = await getActiveTrades(syncAcct);
 
   for (const trade of activeTrades) {
     // Options positions are managed exclusively by options-manager — never touch them here.
@@ -4308,7 +4359,7 @@ async function syncPositions(
     if (ibPos && ibPos.position !== 0) {
       // Position exists — clear missing_since if it was set (position reappeared)
       if (trade.missing_since) {
-        await updatePaperTrade(trade.id, { missing_since: null });
+        await updatePaperTrade(trade.id, { missing_since: null }, syncAcct);
         log(`${trade.ticker}: Position reappeared — cleared missing_since`);
       }
       if (trade.status === 'SUBMITTED' || trade.status === 'PENDING') {
@@ -4350,7 +4401,7 @@ async function syncPositions(
             log(`${trade.ticker}: Entry log failed — ${err instanceof Error ? err.message : 'unknown'}`);
           }
         }
-        await updatePaperTrade(trade.id, updates);
+        await updatePaperTrade(trade.id, updates, syncAcct);
         log(`${trade.ticker}: Filled @ $${fillPrice.toFixed(2)}`);
       }
 
@@ -4372,7 +4423,7 @@ async function syncPositions(
         await updatePaperTrade(trade.id, {
           pnl: parseFloat(unrealizedPnl.toFixed(2)),
           pnl_percent: parseFloat(((unrealizedPnl / costBasis) * 100).toFixed(2)),
-        });
+        }, syncAcct);
       }
     } else if (trade.status === 'FILLED') {
       // Position gone — closed by bracket TP/SL or manual action.
@@ -4392,7 +4443,7 @@ async function syncPositions(
 
       if (!hasConfirmedFill && !trade.missing_since) {
         // First detection — mark as missing, don't close yet
-        await updatePaperTrade(trade.id, { missing_since: new Date().toISOString() });
+        await updatePaperTrade(trade.id, { missing_since: new Date().toISOString() }, syncAcct);
         log(`${trade.ticker}: Position missing — marking missing_since (will confirm in ~30 min)`);
         continue;
       }
@@ -4452,8 +4503,8 @@ async function syncPositions(
         pnl_percent: pnlPct,
         r_multiple: rMultiple,
         missing_since: null,
-      });
-      log(`${trade.ticker}: Closed (${closeReason}) — P&L $${pnl.toFixed(2)}${hasConfirmedFill ? '' : ' [fallback price]'}`);
+      }, syncAcct);
+      log(`${trade.ticker}: Closed [${syncAcct}] (${closeReason}) — P&L $${pnl.toFixed(2)}${hasConfirmedFill ? '' : ' [fallback price]'}`);
       const closedTrade = {
         ...trade,
         status,
@@ -4479,7 +4530,7 @@ async function syncPositions(
       logClosedTradePerformance(closedTrade as import('./lib/supabase.js').PaperTrade, {
         source: 'scheduler',
         trigger: hasConfirmedFill ? 'IB_FILL_CONFIRMED' : 'IB_POSITION_GONE_FALLBACK',
-      }).catch(err => log(`Trade perf log failed for ${trade.ticker}: ${err instanceof Error ? err.message : 'unknown'}`));
+      }, syncAcct).catch(err => log(`Trade perf log failed for ${trade.ticker}: ${err instanceof Error ? err.message : 'unknown'}`));
     } else if (trade.status === 'SUBMITTED') {
       // ── Fill detection for SUBMITTED orders ───────────────────────────────
       // Market/limit orders (no bracket) don't get monitored via TP/SL fill lookup.
@@ -4504,11 +4555,9 @@ async function syncPositions(
               status: 'FILLED',
               fill_price: fillPrice,
               filled_at: new Date().toISOString(),
-            });
+            }, syncAcct);
             log(`${trade.ticker}: SUBMITTED → FILLED (fill detected in ib_fills: orderId=${orderId} @ $${fillPrice})`);
 
-            // For plain SELL orders (closing a long with no further management),
-            // immediately close the trade — there's no open position to monitor.
             if (isSell) {
               const originalFillPrice = trade.fill_price ?? trade.entry_price ?? fillPrice;
               const pnl = (fillPrice - originalFillPrice) * qty;
@@ -4523,7 +4572,7 @@ async function syncPositions(
                 pnl: parseFloat(pnl.toFixed(2)),
                 pnl_percent: originalFillPrice > 0 ? parseFloat(((pnl / (originalFillPrice * qty)) * 100).toFixed(2)) : null,
                 closed_at: closedAt,
-              });
+              }, syncAcct);
               log(`${trade.ticker}: SELL closed immediately — fill @ $${fillPrice}, P&L $${pnl.toFixed(2)}`);
               continue;
             }
@@ -4545,10 +4594,11 @@ async function syncPositions(
           status: 'CLOSED', close_reason: 'manual',
           closed_at: closedAt,
           notes: (trade.notes ?? '') + ' | Expired: DAY order not filled by market close',
-        });
+        }, syncAcct);
         logClosedTradePerformance(
           { ...trade, status: 'CLOSED', close_reason: 'manual', closed_at: closedAt } as import('./lib/supabase.js').PaperTrade,
-          { source: 'scheduler', trigger: 'EXPIRED_DAY_ORDER' }
+          { source: 'scheduler', trigger: 'EXPIRED_DAY_ORDER' },
+          syncAcct,
         ).catch(() => {});
         log(`${trade.ticker}: Day trade expired (market closed)`);
       }
@@ -4562,7 +4612,7 @@ async function syncPositions(
         const orderId = trade.ib_order_id ? parseInt(trade.ib_order_id, 10) : NaN;
         if (!Number.isNaN(orderId)) {
           try {
-            cancelOrder(orderId);
+            getConnectionForAccount(syncAcct).cancelOrder(orderId);
             log(`${trade.ticker}: Swing bracket limit cancelled (expired >2 trading days)`);
           } catch (err) {
             log(`${trade.ticker}: Cancel failed — ${err instanceof Error ? err.message : 'unknown'}`);
@@ -4574,10 +4624,11 @@ async function syncPositions(
           status: 'CLOSED', close_reason: 'manual',
           closed_at: closedAt,
           notes: (trade.notes ?? '') + ' | Expired: SWING limit not filled within 2 trading days',
-        });
+        }, syncAcct);
         logClosedTradePerformance(
           { ...trade, status: 'CLOSED', close_reason: 'manual', closed_at: closedAt } as import('./lib/supabase.js').PaperTrade,
-          { source: 'scheduler', trigger: 'EXPIRED_SWING_BRACKET' }
+          { source: 'scheduler', trigger: 'EXPIRED_SWING_BRACKET' },
+          syncAcct,
         ).catch(() => {});
       }
     }
@@ -4769,11 +4820,18 @@ async function checkDipBuyOpportunities(
   positions: EnrichedPosition[],
 ): Promise<void> {
   if (!config.dipBuyEnabled || !config.accountId) return;
-  const activeTrades = await getActiveTrades();
+  // Resolve LONG_TERM routing for dip buys
+  let dipConn: IBConnection;
+  let dipAcct: AccountType;
+  try {
+    const routed = getConnectionForMode('LONG_TERM', config);
+    dipConn = routed.connection;
+    dipAcct = routed.accountType;
+  } catch { return; }
+
+  const activeTrades = await getActiveTrades(dipAcct);
   const longTermFilled = activeTrades.filter(t => t.mode === 'LONG_TERM' && t.status === 'FILLED');
 
-  // Build primary (non-dip-buy) entry map and cross-channel entry count per ticker.
-  // The entry count includes ALL open LONG_TERM positions (SC + dip buys) for the ticker.
   const initialByTicker = new Map<string, { trade: PaperTrade; isGoldMine: boolean }>();
   const openEntriesByTicker = new Map<string, number>();
   for (const t of longTermFilled) {
@@ -4856,9 +4914,13 @@ async function checkDipBuyOpportunities(
     if (!(await checkAllocationCap(config, addOnDollar, ticker, positions, 'LONG_TERM'))) continue;
 
     try {
-      if (!isConnected()) continue;
+      if (!dipConn.isConnected()) continue;
 
-      const result = await placeMarketOrder({
+      if (dipAcct === 'live') {
+        try { await assertLiveLossLimitNotBreached(config); } catch { continue; }
+      }
+
+      const result = await dipConn.placeMarketOrder({
         symbol: ticker, side: 'BUY', quantity: addOnQty,
       });
 
@@ -4873,14 +4935,14 @@ async function checkDipBuyOpportunities(
         status: 'SUBMITTED',
         notes: `Dip buy ${triggered.label} at -${absDip.toFixed(1)}%`,
         entry_trigger_type: 'dip_buy',
-      });
+      }, dipAcct);
 
       recordPendingOrder(addOnDollar);
-      log(`${ticker}: DIP BUY ${triggered.label} — +${addOnQty} shares at -${absDip.toFixed(1)}%`);
+      log(`${ticker}: DIP BUY ${triggered.label} [${dipAcct}] — +${addOnQty} shares at -${absDip.toFixed(1)}%`);
       persistEvent(ticker, 'success', `Dip buy ${triggered.label}: +${addOnQty} shares`, {
         action: 'executed', source: 'dip_buy', mode: 'LONG_TERM',
         metadata: { tier: triggered.label, dipPct: absDip, addOnQty, addOnDollar },
-      });
+      }, dipAcct);
     } catch (err) {
       log(`${ticker}: Dip buy failed — ${err instanceof Error ? err.message : 'unknown'}`);
     }
@@ -4901,7 +4963,15 @@ async function checkSwingHoldExpiry(
   const maxDays = config.swingMaxHoldDays ?? 5;
   if (maxDays <= 0 || !config.accountId) return;
 
-  const activeTrades = await getActiveTrades();
+  let swingConn: IBConnection;
+  let swingAcct: AccountType;
+  try {
+    const routed = getConnectionForMode('SWING_TRADE', config);
+    swingConn = routed.connection;
+    swingAcct = routed.accountType;
+  } catch { return; }
+
+  const activeTrades = await getActiveTrades(swingAcct);
   const stale = activeTrades.filter(t =>
     t.mode === 'SWING_TRADE' &&
     t.status === 'FILLED' &&
@@ -4921,7 +4991,7 @@ async function checkSwingHoldExpiry(
       : '?';
 
     try {
-      await placeMarketOrder({ symbol: trade.ticker, side, quantity: qty });
+      await swingConn.placeMarketOrder({ symbol: trade.ticker, side, quantity: qty });
       await createPaperTrade({
         ticker: trade.ticker, mode: 'SWING_TRADE', signal: side,
         entry_price: ibPos.mktPrice,
@@ -4930,13 +5000,14 @@ async function checkSwingHoldExpiry(
         status: 'SUBMITTED',
         notes: `Auto-exit: swing held ${daysHeld} days (max ${maxDays}) — P&L ${gainPct}%`,
         entry_trigger_type: 'swing_expiry',
-      });
+      }, swingAcct);
 
-      log(`${trade.ticker}: SWING EXPIRY — held ${daysHeld} days, closing ${qty} shares at ${gainPct}% P&L`);
+      log(`${trade.ticker}: SWING EXPIRY [${swingAcct}] — held ${daysHeld} days, closing ${qty} shares at ${gainPct}% P&L`);
       persistEvent(trade.ticker, 'success',
-        `⏱️ ${trade.ticker} swing auto-closed after ${daysHeld} days (max ${maxDays}d) — P&L ${gainPct}% — capital freed`,
+        `${trade.ticker} swing auto-closed after ${daysHeld} days (max ${maxDays}d) — P&L ${gainPct}% — capital freed`,
         { action: 'executed', source: 'swing_expiry', mode: 'SWING_TRADE',
-          metadata: { daysHeld, maxDays, gainPct, qty } }
+          metadata: { daysHeld, maxDays, gainPct, qty } },
+        swingAcct,
       );
     } catch (err) {
       log(`${trade.ticker}: Swing expiry close failed — ${err instanceof Error ? err.message : 'unknown'}`);
@@ -5008,7 +5079,6 @@ async function checkLongTermAutoSell(
   positions: EnrichedPosition[],
   skipTickers?: Set<string>,
 ): Promise<void> {
-  // Compounder fallback rules (unchanged from original)
   const compounderProfitTakePct = config.ltProfitTakePct ?? 15;
   const compounderMaxHoldDays   = config.ltMaxHoldDays ?? 0;
   const compounderTrailingStop  = config.ltTrailingStopPct ?? 10;
@@ -5016,7 +5086,15 @@ async function checkLongTermAutoSell(
 
   if (!config.accountId) return;
 
-  const activeTrades = await getActiveTrades();
+  let ltConn: IBConnection;
+  let ltAcct: AccountType;
+  try {
+    const routed = getConnectionForMode('LONG_TERM', config);
+    ltConn = routed.connection;
+    ltAcct = routed.accountType;
+  } catch { return; }
+
+  const activeTrades = await getActiveTrades(ltAcct);
   // Only BUY records are actual open positions. SELL records (profit-take trims)
   // must be excluded — they are completed actions, not positions to close.
   // Also deduplicate by ticker to prevent multiple sells against the same IB position.
@@ -5049,7 +5127,7 @@ async function checkLongTermAutoSell(
     // Track price peak across cycles
     const storedPeak = trade.price_peak ?? 0;
     if (currentPrice > storedPeak || !trade.price_peak_date) {
-      await updatePaperTrade(trade.id, { price_peak: currentPrice, price_peak_date: today });
+      await updatePaperTrade(trade.id, { price_peak: currentPrice, price_peak_date: today }, ltAcct);
     }
     const effectivePeak = Math.max(storedPeak, currentPrice);
     // Was this position ever meaningfully above entry (>0.1% buffer for noise)?
@@ -5156,7 +5234,7 @@ async function checkLongTermAutoSell(
     processedTickers.add(tickerUpper);
 
     try {
-      const { avgFillPrice } = await placeMarketOrder({ symbol: trade.ticker, side, quantity: qty });
+      const { avgFillPrice } = await ltConn.placeMarketOrder({ symbol: trade.ticker, side, quantity: qty });
       const fillPnl = ibPos.position > 0
         ? (avgFillPrice - ibPos.avgCost) * qty
         : (ibPos.avgCost - avgFillPrice) * qty;
@@ -5170,9 +5248,8 @@ async function checkLongTermAutoSell(
         pnl_percent: fillPnlPct,
         close_reason: reason,
         closed_at: new Date().toISOString(),
-      });
+      }, ltAcct);
 
-      const emoji = fillPnlPct >= 0 ? '✅' : '🛑';
       const label = reason.startsWith('dd_profit_take') ? 'Dip Discovery profit-take'
         : reason.startsWith('dd_stop_loss')    ? 'Dip Discovery stop-loss'
         : reason.startsWith('dd_max_hold')     ? 'Dip Discovery max-hold exit'
@@ -5185,11 +5262,12 @@ async function checkLongTermAutoSell(
         : reason.startsWith('trailing_stop')   ? 'trailing stop'
         : reason.startsWith('stop_loss')       ? 'stop-loss'
         : 'max-hold exit';
-      log(`${trade.ticker}: LT AUTO-SELL (${label}) — ${fillPnlPct.toFixed(1)}% P&L, fill $${avgFillPrice.toFixed(2)}, peak $${effectivePeak.toFixed(2)}, held ${daysHeld.toFixed(0)}d`);
+      log(`${trade.ticker}: LT AUTO-SELL [${ltAcct}] (${label}) — ${fillPnlPct.toFixed(1)}% P&L, fill $${avgFillPrice.toFixed(2)}, peak $${effectivePeak.toFixed(2)}, held ${daysHeld.toFixed(0)}d`);
       persistEvent(trade.ticker, 'success',
-        `${emoji} ${trade.ticker} long-term auto-closed (${label}) — ${fillPnlPct.toFixed(1)}% P&L @ $${avgFillPrice.toFixed(2)} — capital freed`,
+        `${trade.ticker} long-term auto-closed (${label}) — ${fillPnlPct.toFixed(1)}% P&L @ $${avgFillPrice.toFixed(2)} — capital freed`,
         { action: 'closed', source: 'lt_auto_sell', mode: 'LONG_TERM',
-          metadata: { reason, gainPct: fillPnlPct, daysHeld, qty, effectivePeak, entryPrice, avgFillPrice } }
+          metadata: { reason, gainPct: fillPnlPct, daysHeld, qty, effectivePeak, entryPrice, avgFillPrice } },
+        ltAcct,
       );
     } catch (err) {
       log(`${trade.ticker}: Long-term auto-sell failed — ${err instanceof Error ? err.message : 'unknown'}`);
@@ -5265,7 +5343,16 @@ async function checkProfitTakeOpportunities(
 ): Promise<Set<string>> {
   const trimmedTickers = new Set<string>();
   if (!config.profitTakeEnabled || !config.accountId) return trimmedTickers;
-  const activeTrades = await getActiveTrades();
+
+  let ptConn: IBConnection;
+  let ptAcct: AccountType;
+  try {
+    const routed = getConnectionForMode('LONG_TERM', config);
+    ptConn = routed.connection;
+    ptAcct = routed.accountType;
+  } catch { return trimmedTickers; }
+
+  const activeTrades = await getActiveTrades(ptAcct);
   const longTermFilled = activeTrades.filter(t => t.mode === 'LONG_TERM' && t.status === 'FILLED');
 
   const tiers = [
@@ -5284,7 +5371,6 @@ async function checkProfitTakeOpportunities(
     const triggered = tiers.find(t => gainPct >= t.pct);
     if (!triggered) continue;
 
-    // Check if already trimmed at this tier
     const pastEvents = await getPastTrimEvents(trade.ticker);
     if (pastEvents.some(e => e.metadata?.tier === triggered.label)) continue;
 
@@ -5296,9 +5382,9 @@ async function checkProfitTakeOpportunities(
     if (actualTrimQty < 1) continue;
 
     try {
-      if (!isConnected()) continue;
+      if (!ptConn.isConnected()) continue;
 
-      const { orderId, avgFillPrice } = await placeMarketOrder({
+      const { orderId, avgFillPrice } = await ptConn.placeMarketOrder({
         symbol: trade.ticker, side: 'SELL', quantity: actualTrimQty,
       });
 
@@ -5317,14 +5403,14 @@ async function checkProfitTakeOpportunities(
         closed_at: new Date().toISOString(),
         notes: `Profit take ${triggered.label} at +${gainPct.toFixed(1)}%`,
         entry_trigger_type: 'profit_take',
-      });
+      }, ptAcct);
 
       trimmedTickers.add(trade.ticker.toUpperCase());
-      log(`${trade.ticker}: PROFIT TAKE ${triggered.label} — sold ${actualTrimQty} shares @ $${avgFillPrice.toFixed(2)}, +${gainPct.toFixed(1)}% ($${realizedPnl.toFixed(2)})`);
+      log(`${trade.ticker}: PROFIT TAKE ${triggered.label} [${ptAcct}] — sold ${actualTrimQty} shares @ $${avgFillPrice.toFixed(2)}, +${gainPct.toFixed(1)}% ($${realizedPnl.toFixed(2)})`);
       persistEvent(trade.ticker, 'success', `Profit take ${triggered.label}: sold ${actualTrimQty} shares @ $${avgFillPrice.toFixed(2)}`, {
         action: 'executed', source: 'profit_take', mode: 'LONG_TERM',
         metadata: { tier: triggered.label, gainPct, trimQty: actualTrimQty, realizedPnl, fillPrice: avgFillPrice, orderId },
-      });
+      }, ptAcct);
     } catch (err) {
       log(`${trade.ticker}: Profit take failed — ${err instanceof Error ? err.message : 'unknown'}`);
     }
@@ -5350,87 +5436,90 @@ const TRAIL_ACTIVATION_R  = 0.5;  // activate at +0.5R (was 1.0 — only 5/430 t
 const TRAIL_RETRACE_PCT   = 0.60; // close if 60% of peak gain retraces (was 0.50)
 
 async function checkDayTradeTrailingStops(
+  config: AutoTraderConfig,
   positions: EnrichedPosition[],
 ): Promise<void> {
-  const activeTrades = await getActiveTrades();
-  const dayTrades = activeTrades.filter(
-    t => (t.mode === 'DAY_TRADE' || t.mode === 'DAY_PENNY') && (t.status === 'FILLED' || t.status === 'PARTIAL'),
-  );
-  if (dayTrades.length === 0) return;
+  // Day trades may be on different accounts based on mode routing
+  for (const acctType of ['paper', 'live'] as AccountType[]) {
+    const conn = getConnectionForAccount(acctType);
+    if (!conn.isConnected()) continue;
 
-  for (const trade of dayTrades) {
-    const ibPos = positions.find(p => p.symbol.toUpperCase() === trade.ticker.toUpperCase());
-    if (!ibPos || ibPos.mktPrice <= 0) continue;
-
-    const fillPrice  = trade.fill_price ?? trade.entry_price ?? 0;
-    const stopPrice  = trade.stop_loss ?? 0;
-    if (!fillPrice || !stopPrice) continue;
-
-    const risk = Math.abs(fillPrice - stopPrice);
-    if (risk <= 0) continue;
-
-    const currentPrice = ibPos.mktPrice;
-    const isBuy = trade.signal === 'BUY';
-
-    // Gain in multiples of initial risk (positive = in profit)
-    const gainInR = isBuy
-      ? (currentPrice - fillPrice) / risk
-      : (fillPrice - currentPrice) / risk;
-
-    if (gainInR < TRAIL_ACTIVATION_R) continue; // not yet in profit enough to trail
-
-    // Track peak price (persist to DB when it moves)
-    const storedPeak = trade.price_peak ?? 0;
-    const newPeak = isBuy
-      ? Math.max(storedPeak, currentPrice)
-      : (storedPeak <= 0 ? currentPrice : Math.min(storedPeak, currentPrice));
-
-    if (newPeak !== storedPeak) {
-      await updatePaperTrade(trade.id, { price_peak: newPeak });
-    }
-
-    // Trail stop = peak minus TRAIL_RETRACE_PCT of the peak gain
-    const peakGain    = Math.abs(newPeak - fillPrice);
-    const trailDist   = peakGain * TRAIL_RETRACE_PCT;
-    const trailStop   = isBuy ? newPeak - trailDist : newPeak + trailDist;
-    const violated    = isBuy ? currentPrice <= trailStop : currentPrice >= trailStop;
-
-    log(
-      `${trade.ticker}: trail check — fill ${fillPrice} peak ${newPeak.toFixed(2)} ` +
-      `current ${currentPrice.toFixed(2)} trailStop ${trailStop.toFixed(2)} ` +
-      `(+${gainInR.toFixed(1)}R) ${violated ? '→ TRIGGERED' : 'ok'}`,
+    const activeTrades = await getActiveTrades(acctType);
+    const dayTrades = activeTrades.filter(
+      t => (t.mode === 'DAY_TRADE' || t.mode === 'DAY_PENNY') && (t.status === 'FILLED' || t.status === 'PARTIAL'),
     );
+    if (dayTrades.length === 0) continue;
 
-    if (!violated) continue;
+    for (const trade of dayTrades) {
+      const ibPos = positions.find(p => p.symbol.toUpperCase() === trade.ticker.toUpperCase());
+      if (!ibPos || ibPos.mktPrice <= 0) continue;
 
-    // Close the position at market
-    const closeSide = isBuy ? 'SELL' : 'BUY';
-    const qty       = trade.quantity ?? 0;
-    if (qty <= 0) continue;
+      const fillPrice  = trade.fill_price ?? trade.entry_price ?? 0;
+      const stopPrice  = trade.stop_loss ?? 0;
+      if (!fillPrice || !stopPrice) continue;
 
-    try {
-      const { avgFillPrice } = await placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });
-      const pnl = isBuy
-        ? parseFloat(((avgFillPrice - fillPrice) * qty).toFixed(2))
-        : parseFloat(((fillPrice - avgFillPrice) * qty).toFixed(2));
-      const pnlPct = fillPrice > 0
-        ? parseFloat(((pnl / (fillPrice * qty)) * 100).toFixed(2))
-        : null;
-      await updatePaperTrade(trade.id, {
-        status:       'CLOSED',
-        close_reason: 'trailing_stop',
-        close_price:  avgFillPrice,
-        pnl,
-        pnl_percent:  pnlPct,
-        closed_at:    new Date().toISOString(),
-      });
+      const risk = Math.abs(fillPrice - stopPrice);
+      if (risk <= 0) continue;
+
+      const currentPrice = ibPos.mktPrice;
+      const isBuy = trade.signal === 'BUY';
+
+      const gainInR = isBuy
+        ? (currentPrice - fillPrice) / risk
+        : (fillPrice - currentPrice) / risk;
+
+      if (gainInR < TRAIL_ACTIVATION_R) continue;
+
+      const storedPeak = trade.price_peak ?? 0;
+      const newPeak = isBuy
+        ? Math.max(storedPeak, currentPrice)
+        : (storedPeak <= 0 ? currentPrice : Math.min(storedPeak, currentPrice));
+
+      if (newPeak !== storedPeak) {
+        await updatePaperTrade(trade.id, { price_peak: newPeak }, acctType);
+      }
+
+      const peakGain    = Math.abs(newPeak - fillPrice);
+      const trailDist   = peakGain * TRAIL_RETRACE_PCT;
+      const trailStop   = isBuy ? newPeak - trailDist : newPeak + trailDist;
+      const violated    = isBuy ? currentPrice <= trailStop : currentPrice >= trailStop;
+
       log(
-        `${trade.ticker}: DAY_TRADE trailing stop closed — peak ${newPeak.toFixed(2)}, ` +
-        `current ${currentPrice.toFixed(2)}, trail stop ${trailStop.toFixed(2)}, ` +
-        `P&L $${pnl.toFixed(2)}`,
+        `${trade.ticker}: trail check [${acctType}] — fill ${fillPrice} peak ${newPeak.toFixed(2)} ` +
+        `current ${currentPrice.toFixed(2)} trailStop ${trailStop.toFixed(2)} ` +
+        `(+${gainInR.toFixed(1)}R) ${violated ? '→ TRIGGERED' : 'ok'}`,
       );
-    } catch (err) {
-      log(`${trade.ticker}: trailing stop close failed — ${err instanceof Error ? err.message : 'unknown'}`);
+
+      if (!violated) continue;
+
+      const closeSide = isBuy ? 'SELL' : 'BUY';
+      const qty       = trade.quantity ?? 0;
+      if (qty <= 0) continue;
+
+      try {
+        const { avgFillPrice } = await conn.placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });
+        const pnl = isBuy
+          ? parseFloat(((avgFillPrice - fillPrice) * qty).toFixed(2))
+          : parseFloat(((fillPrice - avgFillPrice) * qty).toFixed(2));
+        const pnlPct = fillPrice > 0
+          ? parseFloat(((pnl / (fillPrice * qty)) * 100).toFixed(2))
+          : null;
+        await updatePaperTrade(trade.id, {
+          status:       'CLOSED',
+          close_reason: 'trailing_stop',
+          close_price:  avgFillPrice,
+          pnl,
+          pnl_percent:  pnlPct,
+          closed_at:    new Date().toISOString(),
+        }, acctType);
+        log(
+          `${trade.ticker}: DAY_TRADE trailing stop closed [${acctType}] — peak ${newPeak.toFixed(2)}, ` +
+          `current ${currentPrice.toFixed(2)}, trail stop ${trailStop.toFixed(2)}, ` +
+          `P&L $${pnl.toFixed(2)}`,
+        );
+      } catch (err) {
+        log(`${trade.ticker}: trailing stop close failed — ${err instanceof Error ? err.message : 'unknown'}`);
+      }
     }
   }
 }
@@ -5440,86 +5529,86 @@ async function checkLossCutOpportunities(
   positions: EnrichedPosition[],
 ): Promise<void> {
   if (!config.lossCutEnabled || !config.accountId) return;
-  const activeTrades = await getActiveTrades();
-  const eligible = activeTrades.filter(t =>
-    (t.mode === 'LONG_TERM' || t.mode === 'SWING_TRADE') &&
-    (t.status === 'FILLED' || t.status === 'PARTIAL')
-  );
 
-  const tiers = [
-    { pct: config.lossCutTier3Pct, sellPct: config.lossCutTier3SellPct, label: 'Tier 3 (full exit)' },
-    { pct: config.lossCutTier2Pct, sellPct: config.lossCutTier2SellPct, label: 'Tier 2' },
-    { pct: config.lossCutTier1Pct, sellPct: config.lossCutTier1SellPct, label: 'Tier 1' },
-  ];
+  // Loss cuts may apply to both paper and live accounts
+  for (const acctType of ['paper', 'live'] as AccountType[]) {
+    const conn = getConnectionForAccount(acctType);
+    if (!conn.isConnected()) continue;
 
-  // Macro circuit breaker for LONG_TERM positions: if SPY has dropped >5% in the last
-  // 5 trading days, this is broad-market turbulence, not individual business failure.
-  // Suspend LONG_TERM loss cuts for one cycle — the thesis re-check happens on next run.
-  // SWING_TRADE loss cuts are NOT suppressed (different time horizon, thesis is price-based).
-  let spyMacroSelloff = false;
-  const eligibleLongTerm = eligible.filter(t => t.mode === 'LONG_TERM');
-  if (eligibleLongTerm.length > 0) {
-    const spy5d = await fetchSpy5DayChangePct();
-    if (spy5d !== null && spy5d <= -5) {
-      spyMacroSelloff = true;
-      log(`[LossCut] SPY 5d = ${spy5d.toFixed(1)}% — macro selloff circuit breaker active: LONG_TERM loss cuts suppressed this cycle`);
-    }
-  }
+    const activeTrades = await getActiveTrades(acctType);
+    const eligible = activeTrades.filter(t =>
+      (t.mode === 'LONG_TERM' || t.mode === 'SWING_TRADE') &&
+      (t.status === 'FILLED' || t.status === 'PARTIAL')
+    );
+    if (eligible.length === 0) continue;
 
-  for (const trade of eligible) {
-    const ibPos = positions.find(p => p.symbol.toUpperCase() === trade.ticker.toUpperCase());
-    if (!ibPos || ibPos.mktPrice <= 0 || ibPos.avgCost <= 0) continue;
+    const tiers = [
+      { pct: config.lossCutTier3Pct, sellPct: config.lossCutTier3SellPct, label: 'Tier 3 (full exit)' },
+      { pct: config.lossCutTier2Pct, sellPct: config.lossCutTier2SellPct, label: 'Tier 2' },
+      { pct: config.lossCutTier1Pct, sellPct: config.lossCutTier1SellPct, label: 'Tier 1' },
+    ];
 
-    const lossPct = ((ibPos.avgCost - ibPos.mktPrice) / ibPos.avgCost) * 100;
-    if (lossPct <= 0) continue;
-
-    // Suppress LONG_TERM loss cuts during broad market selloffs (see circuit breaker above).
-    if (trade.mode === 'LONG_TERM' && spyMacroSelloff) continue;
-
-    // Min hold period
-    if (trade.created_at) {
-      const holdDays = (Date.now() - new Date(trade.created_at).getTime()) / 86400000;
-      if (holdDays < config.lossCutMinHoldDays) continue;
+    let spyMacroSelloff = false;
+    const eligibleLongTerm = eligible.filter(t => t.mode === 'LONG_TERM');
+    if (eligibleLongTerm.length > 0) {
+      const spy5d = await fetchSpy5DayChangePct();
+      if (spy5d !== null && spy5d <= -5) {
+        spyMacroSelloff = true;
+        log(`[LossCut:${acctType}] SPY 5d = ${spy5d.toFixed(1)}% — macro selloff circuit breaker active: LONG_TERM loss cuts suppressed this cycle`);
+      }
     }
 
-    const triggered = tiers.find(t => lossPct >= t.pct);
-    if (!triggered) continue;
+    for (const trade of eligible) {
+      const ibPos = positions.find(p => p.symbol.toUpperCase() === trade.ticker.toUpperCase());
+      if (!ibPos || ibPos.mktPrice <= 0 || ibPos.avgCost <= 0) continue;
 
-    const pastEvents = await getPastLossCutEvents(trade.ticker);
-    if (pastEvents.some(e => e.metadata?.tier === triggered.label)) continue;
+      const lossPct = ((ibPos.avgCost - ibPos.mktPrice) / ibPos.avgCost) * 100;
+      if (lossPct <= 0) continue;
 
-    const currentQty = Math.abs(ibPos.position);
-    const sellQty = triggered.sellPct >= 100
-      ? currentQty
-      : Math.max(1, Math.floor(currentQty * (triggered.sellPct / 100)));
-    if (sellQty < 1) continue;
+      if (trade.mode === 'LONG_TERM' && spyMacroSelloff) continue;
 
-    try {
-      if (!isConnected()) continue;
+      if (trade.created_at) {
+        const holdDays = (Date.now() - new Date(trade.created_at).getTime()) / 86400000;
+        if (holdDays < config.lossCutMinHoldDays) continue;
+      }
 
-      const side = ibPos.position > 0 ? 'SELL' : 'BUY';
-      await placeMarketOrder({ symbol: trade.ticker, side: side as 'BUY' | 'SELL', quantity: sellQty });
+      const triggered = tiers.find(t => lossPct >= t.pct);
+      if (!triggered) continue;
 
-      await createPaperTrade({
-        ticker: trade.ticker, mode: trade.mode as 'LONG_TERM' | 'SWING_TRADE',
-        signal: 'SELL', entry_price: ibPos.mktPrice,
-        quantity: sellQty,
-        position_size: sellQty * ibPos.mktPrice,
-        status: 'SUBMITTED',
-        notes: `Loss cut ${triggered.label} at -${lossPct.toFixed(1)}%`,
-        entry_trigger_type: 'loss_cut',
-      });
+      const pastEvents = await getPastLossCutEvents(trade.ticker);
+      if (pastEvents.some(e => e.metadata?.tier === triggered.label)) continue;
 
-      const realizedLoss = ibPos.position > 0
-        ? sellQty * (ibPos.avgCost - ibPos.mktPrice)
-        : sellQty * (ibPos.mktPrice - ibPos.avgCost);
-      log(`${trade.ticker}: LOSS CUT ${triggered.label} — sold ${sellQty} shares at -${lossPct.toFixed(1)}% ($${realizedLoss.toFixed(2)})`);
-      persistEvent(trade.ticker, 'success', `Loss cut ${triggered.label}: sold ${sellQty} shares`, {
-        action: 'executed', source: 'loss_cut', mode: trade.mode,
-        metadata: { tier: triggered.label, lossPct, sellQty, realizedLoss },
-      });
-    } catch (err) {
-      log(`${trade.ticker}: Loss cut failed — ${err instanceof Error ? err.message : 'unknown'}`);
+      const currentQty = Math.abs(ibPos.position);
+      const sellQty = triggered.sellPct >= 100
+        ? currentQty
+        : Math.max(1, Math.floor(currentQty * (triggered.sellPct / 100)));
+      if (sellQty < 1) continue;
+
+      try {
+        const side = ibPos.position > 0 ? 'SELL' : 'BUY';
+        await conn.placeMarketOrder({ symbol: trade.ticker, side: side as 'BUY' | 'SELL', quantity: sellQty });
+
+        await createPaperTrade({
+          ticker: trade.ticker, mode: trade.mode as 'LONG_TERM' | 'SWING_TRADE',
+          signal: 'SELL', entry_price: ibPos.mktPrice,
+          quantity: sellQty,
+          position_size: sellQty * ibPos.mktPrice,
+          status: 'SUBMITTED',
+          notes: `Loss cut ${triggered.label} at -${lossPct.toFixed(1)}%`,
+          entry_trigger_type: 'loss_cut',
+        }, acctType);
+
+        const realizedLoss = ibPos.position > 0
+          ? sellQty * (ibPos.avgCost - ibPos.mktPrice)
+          : sellQty * (ibPos.mktPrice - ibPos.avgCost);
+        log(`${trade.ticker}: LOSS CUT ${triggered.label} [${acctType}] — sold ${sellQty} shares at -${lossPct.toFixed(1)}% ($${realizedLoss.toFixed(2)})`);
+        persistEvent(trade.ticker, 'success', `Loss cut ${triggered.label}: sold ${sellQty} shares`, {
+          action: 'executed', source: 'loss_cut', mode: trade.mode,
+          metadata: { tier: triggered.label, lossPct, sellQty, realizedLoss },
+        }, acctType);
+      } catch (err) {
+        log(`${trade.ticker}: Loss cut failed — ${err instanceof Error ? err.message : 'unknown'}`);
+      }
     }
   }
 }
@@ -6012,7 +6101,7 @@ async function runSchedulerCycle(): Promise<void> {
     // 6. Position management: dip buy, profit take, loss cut, swing expiry
     // These ALWAYS run regardless of config.enabled — existing positions must be actively managed.
     await checkStaleDayTrades(positions);              // flag/close day trades stuck FILLED from a prior day
-    await checkDayTradeTrailingStops(positions);       // software trailing stop for day trades in profit (+1R)
+    await checkDayTradeTrailingStops(config, positions);       // software trailing stop for day trades in profit (+1R)
     await checkDipBuyOpportunities(config, positions);
     const trimmedTickers = await checkProfitTakeOpportunities(config, positions);
     await checkLossCutOpportunities(config, positions);

--- a/docs/cursor/2026-05-17-dual-account-architecture.md
+++ b/docs/cursor/2026-05-17-dual-account-architecture.md
@@ -1,0 +1,1165 @@
+# Dual-Account Architecture: Paper + Live Auto-Trading
+
+**Date:** 2026-05-17  
+**Status:** Implementation Plan  
+**Goal:** Run the auto-trader against both a paper and live IB account simultaneously, with mode-based routing, physical table isolation for trade-critical data, and a frontend account switcher.
+
+---
+
+## Table of Contents
+
+1. [Architecture Overview](#1-architecture-overview)
+2. [Phase 1: Database Migrations](#2-phase-1-database-migrations)
+3. [Phase 2: Auto-Trader Connection Registry](#3-phase-2-auto-trader-connection-registry)
+4. [Phase 3: Trade Execution Routing](#4-phase-3-trade-execution-routing)
+5. [Phase 4: Frontend Account Switcher](#5-phase-4-frontend-account-switcher)
+6. [Phase 5: Kill Switches & Safety Guards](#6-phase-5-kill-switches--safety-guards)
+7. [Phase 6: Testing & Validation](#7-phase-6-testing--validation)
+
+---
+
+## 1. Architecture Overview
+
+### Current State
+
+```
+auto-trader (Node.js)
+  └── IBApi (port 4002, paper) ──→ IB Gateway (paper account)
+  └── Supabase
+        ├── paper_trades
+        ├── auto_trade_events
+        ├── ib_fills
+        ├── strategy_streak_state
+        ├── trade_performance_log
+        └── portfolio_snapshots
+```
+
+One IB connection, one set of tables, all trades are paper.
+
+### Target State
+
+```
+auto-trader (Node.js)
+  ├── paperIb (port 4002, clientId=1) ──→ IB Gateway (paper account)
+  ├── liveIb  (port 4001, clientId=2) ──→ IB Gateway (live account)
+  └── Supabase
+        ├── paper_trades          (unchanged — paper only)
+        ├── live_trades           (NEW — identical schema, live only)
+        ├── auto_trade_events     (unchanged — paper only)
+        ├── live_trade_events     (NEW — identical schema, live only)
+        ├── ib_fills              (unchanged — paper only)
+        ├── live_ib_fills         (NEW — identical schema, live only)
+        ├── strategy_streak_state (unchanged — paper only)
+        ├── live_strategy_streak_state (NEW — identical schema, live only)
+        ├── trade_performance_log (ADD account_type discriminator)
+        └── portfolio_snapshots   (ADD account_type discriminator)
+```
+
+### Mode Routing (Initial Configuration)
+
+| TradeMode          | Account  | Rationale                               |
+|--------------------|----------|-----------------------------------------|
+| `DAY_TRADE`        | **LIVE** | Proven strategy, highest confidence     |
+| `SWING_TRADE`      | PAPER    | Still validating hold-period logic      |
+| `OPTIONS_PUT`      | PAPER    | Options strategies still maturing       |
+| `OPTIONS_CALL`     | PAPER    | Options strategies still maturing       |
+| `CALENDAR_SPREAD`  | PAPER    | Options strategies still maturing       |
+| `CREDIT_SPREAD`    | PAPER    | Options strategies still maturing       |
+| `DAY_PENNY`        | PAPER    | High risk, needs more data              |
+| `LONG_TERM`        | PAPER    | Eventually live once validated          |
+| `EARNINGS_CALENDAR`| PAPER    | Seasonal, needs more data               |
+
+Routing is configurable via the `auto_trader_config` table (new `mode_routing` JSONB column), changeable at runtime without restart.
+
+### Key Design Decisions
+
+1. **Physical table isolation** for trade-critical data — `paper_trades` and `live_trades` are separate tables. This means zero risk of a query accidentally mixing paper and live trades, and zero changes needed to existing paper-only queries.
+
+2. **Discriminator column** for analytics tables — `trade_performance_log` and `portfolio_snapshots` get an `account_type` column. These tables are append-only analytics with fewer query sites, so a discriminator is lower risk and avoids duplicating complex analytical queries.
+
+3. **One Node.js process, two IB connections** — avoids the operational complexity of running two separate auto-trader processes. Routing is a function call, not inter-process communication.
+
+4. **IB Gateway instances share the same IB user** — IB allows multiple gateway sessions on different ports. Paper on 4002 (existing), live on 4001 (new).
+
+---
+
+## 2. Phase 1: Database Migrations
+
+### Migration File: `supabase/migrations/YYYYMMDD000001_dual_account_tables.sql`
+
+#### 2.1 `live_trades` — Clone of `paper_trades`
+
+```sql
+-- Live Trades — identical schema to paper_trades, physically separate for safety.
+-- All queries that touch paper_trades do NOT need updating; live_trades has its own query set.
+
+CREATE TABLE live_trades (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    ticker TEXT NOT NULL,
+    mode TEXT NOT NULL CHECK (mode IN (
+      'DAY_TRADE', 'SWING_TRADE', 'LONG_TERM',
+      'OPTIONS_PUT', 'OPTIONS_CALL',
+      'EARNINGS_CALENDAR', 'CALENDAR_SPREAD', 'CREDIT_SPREAD',
+      'DAY_PENNY'
+    )),
+    signal TEXT NOT NULL CHECK (signal IN ('BUY', 'SELL')),
+    strategy_source TEXT,
+    strategy_source_url TEXT,
+    strategy_video_id TEXT,
+    strategy_video_heading TEXT,
+    scanner_confidence INT,
+    fa_confidence INT,
+    fa_recommendation TEXT,
+    entry_price NUMERIC,
+    stop_loss NUMERIC,
+    target_price NUMERIC,
+    target_price2 NUMERIC,
+    risk_reward TEXT,
+    quantity INT,
+    position_size NUMERIC,
+    ib_order_id TEXT,
+    ib_parent_order_id TEXT,
+    ib_tp_order_id TEXT,
+    ib_sl_order_id TEXT,
+    status TEXT NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL',
+                          'STOPPED', 'TARGET_HIT', 'CLOSED', 'CANCELLED', 'REJECTED')),
+    fill_price NUMERIC,
+    close_price NUMERIC,
+    pnl NUMERIC,
+    pnl_percent NUMERIC,
+    opened_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    filled_at TIMESTAMPTZ,
+    closed_at TIMESTAMPTZ,
+    close_reason TEXT,
+    scanner_reason TEXT,
+    fa_rationale JSONB,
+    notes TEXT,
+    in_play_score NUMERIC,
+    pass1_confidence INT,
+    entry_trigger_type TEXT,
+    r_multiple NUMERIC,
+    market_condition TEXT,
+    pct_distance_sma20_at_entry NUMERIC,
+    macd_histogram_slope_at_entry TEXT,
+    volume_vs_10d_avg_at_entry NUMERIC,
+    regime_alignment_at_entry TEXT,
+    price_peak NUMERIC(12,4),
+    price_peak_date DATE,
+    missing_since TIMESTAMPTZ,
+    -- Options fields (from options_wheel / options_auto_trade migrations)
+    option_strike NUMERIC,
+    option_expiry DATE,
+    option_premium NUMERIC,
+    option_contracts INT DEFAULT 1,
+    option_delta NUMERIC,
+    option_iv_rank NUMERIC,
+    option_prob_profit NUMERIC,
+    option_net_price NUMERIC,
+    option_capital_req NUMERIC,
+    option_annual_yield NUMERIC,
+    option_assigned BOOLEAN DEFAULT FALSE,
+    option_close_pct NUMERIC,
+    -- Roll tracking (from options_roll_tracking migration)
+    roll_count INT NOT NULL DEFAULT 0,
+    rolled_from_id UUID,
+    -- Spread fields (from credit_spreads migration)
+    spread_type TEXT,
+    spread_short_strike NUMERIC,
+    spread_long_strike NUMERIC,
+    spread_width NUMERIC,
+    spread_net_credit NUMERIC,
+    spread_credit_pct NUMERIC,
+    spread_max_loss NUMERIC,
+    spread_max_gain NUMERIC,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_live_trades_status ON live_trades (status);
+CREATE INDEX idx_live_trades_ticker ON live_trades (ticker);
+CREATE INDEX idx_live_trades_opened ON live_trades (opened_at DESC);
+CREATE INDEX idx_live_trades_strategy_source ON live_trades (strategy_source)
+  WHERE strategy_source IS NOT NULL;
+CREATE INDEX idx_live_trades_rolled_from ON live_trades (rolled_from_id)
+  WHERE rolled_from_id IS NOT NULL;
+CREATE INDEX idx_live_trades_spread_type ON live_trades (spread_type)
+  WHERE spread_type IS NOT NULL;
+
+ALTER TABLE live_trades ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read live trades" ON live_trades FOR SELECT USING (true);
+CREATE POLICY "Anyone can insert live trades" ON live_trades FOR INSERT WITH CHECK (true);
+CREATE POLICY "Anyone can update live trades" ON live_trades FOR UPDATE USING (true);
+CREATE POLICY "Anyone can delete live trades" ON live_trades FOR DELETE USING (true);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON live_trades TO anon;
+```
+
+#### 2.2 `live_trade_events` — Clone of `auto_trade_events`
+
+```sql
+CREATE TABLE live_trade_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    ticker TEXT NOT NULL,
+    event_type TEXT NOT NULL CHECK (event_type IN ('info', 'success', 'warning', 'error')),
+    action TEXT,
+    source TEXT,
+    mode TEXT,
+    message TEXT NOT NULL,
+    scanner_signal TEXT,
+    scanner_confidence INT,
+    fa_recommendation TEXT,
+    fa_confidence INT,
+    skip_reason TEXT,
+    strategy_source TEXT,
+    strategy_source_url TEXT,
+    strategy_video_id TEXT,
+    strategy_video_heading TEXT,
+    metadata JSONB,
+    candle_patterns TEXT[],
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_live_trade_events_created ON live_trade_events (created_at DESC);
+CREATE INDEX idx_live_trade_events_ticker ON live_trade_events (ticker);
+CREATE INDEX idx_live_trade_events_action ON live_trade_events (action);
+
+ALTER TABLE live_trade_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read live trade events" ON live_trade_events FOR SELECT USING (true);
+CREATE POLICY "Anyone can insert live trade events" ON live_trade_events FOR INSERT WITH CHECK (true);
+
+GRANT SELECT, INSERT ON live_trade_events TO anon;
+```
+
+> **Note:** No CHECK constraints on `action`, `source`, or `mode` — following the precedent set by migration `20260514000001` which dropped these constraints from `auto_trade_events` because the app code is the real authority.
+
+#### 2.3 `live_ib_fills` — Clone of `ib_fills`
+
+```sql
+CREATE TABLE live_ib_fills (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  order_id integer NOT NULL,
+  exec_id text,
+  ticker text NOT NULL,
+  side text NOT NULL,
+  quantity numeric NOT NULL,
+  fill_price numeric NOT NULL,
+  commission numeric,
+  realized_pnl numeric,
+  filled_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE live_ib_fills ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "read_live_ib_fills" ON live_ib_fills FOR SELECT USING (true);
+CREATE POLICY "insert_live_ib_fills" ON live_ib_fills FOR INSERT WITH CHECK (true);
+CREATE POLICY "update_live_ib_fills" ON live_ib_fills FOR UPDATE USING (true);
+
+CREATE INDEX idx_live_ib_fills_order_id ON live_ib_fills(order_id);
+CREATE INDEX idx_live_ib_fills_ticker_filled ON live_ib_fills(ticker, filled_at);
+```
+
+#### 2.4 `live_strategy_streak_state` — Clone of `strategy_streak_state`
+
+```sql
+CREATE TABLE IF NOT EXISTS live_strategy_streak_state (
+  mode TEXT PRIMARY KEY,
+  is_cold BOOLEAN NOT NULL DEFAULT false,
+  entered_cold_at TIMESTAMPTZ,
+  last_checked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  rolling_win_rate NUMERIC,
+  window_size INT NOT NULL DEFAULT 10
+);
+
+ALTER TABLE live_strategy_streak_state ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read live_strategy_streak_state" ON live_strategy_streak_state FOR SELECT USING (true);
+CREATE POLICY "Anyone can insert live_strategy_streak_state" ON live_strategy_streak_state FOR INSERT WITH CHECK (true);
+CREATE POLICY "Anyone can update live_strategy_streak_state" ON live_strategy_streak_state FOR UPDATE USING (true);
+
+-- Seed only DAY_TRADE initially (only mode routed to live at launch)
+INSERT INTO live_strategy_streak_state (mode, is_cold, window_size)
+VALUES ('DAY_TRADE', false, 10)
+ON CONFLICT (mode) DO NOTHING;
+```
+
+#### 2.5 Analytics Tables — Add `account_type` Discriminator
+
+```sql
+-- trade_performance_log: add account_type with default 'paper' (all existing rows are paper)
+ALTER TABLE trade_performance_log
+  ADD COLUMN IF NOT EXISTS account_type TEXT NOT NULL DEFAULT 'paper'
+    CHECK (account_type IN ('paper', 'live'));
+
+-- Update the unique constraint: trade_id is already unique, but add a composite index
+-- for filtered queries
+CREATE INDEX IF NOT EXISTS idx_trade_perf_log_account_type
+  ON trade_performance_log (account_type);
+
+-- portfolio_snapshots: add account_type with default 'paper'
+ALTER TABLE portfolio_snapshots
+  ADD COLUMN IF NOT EXISTS account_type TEXT NOT NULL DEFAULT 'paper'
+    CHECK (account_type IN ('paper', 'live'));
+
+-- Update the unique constraint to include account_type
+ALTER TABLE portfolio_snapshots
+  DROP CONSTRAINT IF EXISTS portfolio_snapshots_snapshot_date_account_id_key;
+
+ALTER TABLE portfolio_snapshots
+  ADD CONSTRAINT portfolio_snapshots_snapshot_date_account_id_account_type_key
+    UNIQUE (snapshot_date, account_id, account_type);
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_snapshots_account_type
+  ON portfolio_snapshots (account_type);
+```
+
+#### 2.6 `auto_trader_config` — Add Mode Routing + Kill Switches
+
+```sql
+-- Mode routing: maps TradeMode → account_type ('paper' | 'live')
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS mode_routing JSONB NOT NULL DEFAULT '{
+    "DAY_TRADE": "live",
+    "SWING_TRADE": "paper",
+    "OPTIONS_PUT": "paper",
+    "OPTIONS_CALL": "paper",
+    "CALENDAR_SPREAD": "paper",
+    "CREDIT_SPREAD": "paper",
+    "DAY_PENNY": "paper",
+    "LONG_TERM": "paper",
+    "EARNINGS_CALENDAR": "paper"
+  }'::jsonb;
+
+-- Global kill switch: halts ALL live trading immediately
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS live_kill_switch BOOLEAN NOT NULL DEFAULT false;
+
+-- Hard daily loss limit for live account (dollars). If realized P&L
+-- on the live account drops below this (negative), halt all live trading
+-- for the rest of the day.
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS live_daily_loss_limit NUMERIC NOT NULL DEFAULT -500;
+
+-- Live account portfolio value (separate from paper portfolioValue)
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS live_portfolio_value NUMERIC NOT NULL DEFAULT 100000;
+
+-- Live account position sizing overrides (initially conservative)
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS live_position_size NUMERIC NOT NULL DEFAULT 500;
+
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS live_max_positions INT NOT NULL DEFAULT 2;
+
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS live_max_daily_deployment NUMERIC NOT NULL DEFAULT 5000;
+```
+
+### Config Interface Update
+
+**File:** `shared/config-defaults.ts`
+
+Add to `AutoTraderConfig`:
+
+```typescript
+// Dual-account routing
+modeRouting: Record<string, 'paper' | 'live'>;
+liveKillSwitch: boolean;
+liveDailyLossLimit: number;
+livePortfolioValue: number;
+livePositionSize: number;
+liveMaxPositions: number;
+liveMaxDailyDeployment: number;
+```
+
+Add to `DEFAULT_CONFIG`:
+
+```typescript
+modeRouting: {
+  DAY_TRADE: 'live',
+  SWING_TRADE: 'paper',
+  OPTIONS_PUT: 'paper',
+  OPTIONS_CALL: 'paper',
+  CALENDAR_SPREAD: 'paper',
+  CREDIT_SPREAD: 'paper',
+  DAY_PENNY: 'paper',
+  LONG_TERM: 'paper',
+  EARNINGS_CALENDAR: 'paper',
+},
+liveKillSwitch: false,
+liveDailyLossLimit: -500,
+livePortfolioValue: 100_000,
+livePositionSize: 500,
+liveMaxPositions: 2,
+liveMaxDailyDeployment: 5_000,
+```
+
+### New Shared Type
+
+**File:** `shared/trade-types.ts`
+
+```typescript
+export type AccountType = 'paper' | 'live';
+```
+
+---
+
+## 3. Phase 2: Auto-Trader Connection Registry
+
+### 3.1 Refactor `ib-connection.ts` → Connection Registry
+
+The current `ib-connection.ts` uses module-level state (single `ib`, `connected`, `nextOrderId`, etc.). Refactor to a class-based `IBConnection` that can be instantiated twice.
+
+**File:** `auto-trader/src/ib-connection.ts`
+
+#### New Class: `IBConnection`
+
+```typescript
+import type { AccountType } from '../../shared/trade-types.js';
+
+export class IBConnection {
+  readonly label: AccountType;
+  readonly port: number;
+  readonly clientId: number;
+
+  private ib: IBApi | null = null;
+  private connected = false;
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private accounts: string[] = [];
+  private nextOrderId = 0;
+  private connectionListeners: Array<(state: boolean) => void> = [];
+
+  // P&L tracking (per connection)
+  private _pnlReqId = 0;
+  private _dailyPnL: number | null = null;
+  private _unrealizedPnL: number | null = null;
+  private _realizedPnL: number | null = null;
+
+  // Fill price cache (per connection)
+  private _orderFillPrices = new Map<number, number>();
+  private _pendingReqCallbacks = new Map<number, (code: number, msg: string) => void>();
+  private _pendingOrderCallbacks = new Map<number, PendingOrder>();
+
+  // Semaphore (per connection)
+  private _activeRequests = 0;
+  private _requestQueue: Array<() => void> = [];
+
+  constructor(label: AccountType, port: number, clientId: number) {
+    this.label = label;
+    this.port = port;
+    this.clientId = clientId;
+  }
+
+  // All existing functions become methods:
+  // connect(), isConnected(), getAccounts(), getDefaultAccount(),
+  // getIBApi(), getNextOrderId(), getDailyPnL(),
+  // placeMarketOrder(), placeBracketOrder(), placeOptionsOrder(),
+  // requestPositions(), requestOpenOrders(), cancelOrder(),
+  // searchContract(), etc.
+  //
+  // Log prefix changes from [IB] to [IB:paper] or [IB:live]
+}
+```
+
+#### Connection Registry (Module-Level)
+
+```typescript
+let paperConn: IBConnection | null = null;
+let liveConn: IBConnection | null = null;
+
+export function initConnections(): void {
+  paperConn = new IBConnection('paper', 4002, 1);
+  liveConn = new IBConnection('live', 4001, 2);
+
+  paperConn.connect();
+  // Live connection only starts if liveKillSwitch is false
+  if (!config.liveKillSwitch) {
+    liveConn.connect();
+  }
+}
+
+export function getPaperConnection(): IBConnection { return paperConn!; }
+export function getLiveConnection(): IBConnection { return liveConn!; }
+
+export function getConnectionForAccount(accountType: AccountType): IBConnection {
+  return accountType === 'live' ? liveConn! : paperConn!;
+}
+```
+
+#### Backward Compatibility Layer
+
+To avoid a big-bang rewrite of all callers, keep the existing module-level exports as thin wrappers that delegate to `paperConn`:
+
+```typescript
+// Backward compat — these all delegate to paperConn (unchanged behavior)
+export function isConnected(): boolean { return paperConn?.isConnected() ?? false; }
+export function getAccounts(): string[] { return paperConn?.getAccounts() ?? []; }
+export function getDefaultAccount(): string | null { return paperConn?.getDefaultAccount() ?? null; }
+export function getIBApi(): IBApi | null { return paperConn?.getIBApi() ?? null; }
+export function getNextOrderId(): number { return paperConn?.getNextOrderId() ?? 0; }
+export function getDailyPnL(): AccountPnL { return paperConn?.getDailyPnL() ?? { dailyPnL: null, unrealizedPnL: null, realizedPnL: null }; }
+// ... etc
+```
+
+This means **all existing callers keep working with zero changes** during the transition. New dual-account code uses the class API directly.
+
+### 3.2 Supabase Table Routing
+
+**File:** `auto-trader/src/lib/supabase.ts`
+
+Add table name resolver functions:
+
+```typescript
+import type { AccountType } from '../../../shared/trade-types.js';
+
+export function tradesTable(acct: AccountType): 'paper_trades' | 'live_trades' {
+  return acct === 'live' ? 'live_trades' : 'paper_trades';
+}
+
+export function eventsTable(acct: AccountType): 'auto_trade_events' | 'live_trade_events' {
+  return acct === 'live' ? 'live_trade_events' : 'auto_trade_events';
+}
+
+export function fillsTable(acct: AccountType): 'ib_fills' | 'live_ib_fills' {
+  return acct === 'live' ? 'live_ib_fills' : 'ib_fills';
+}
+
+export function streakTable(acct: AccountType): 'strategy_streak_state' | 'live_strategy_streak_state' {
+  return acct === 'live' ? 'live_strategy_streak_state' : 'strategy_streak_state';
+}
+```
+
+All existing Supabase functions (`createPaperTrade`, `updatePaperTrade`, `getActiveTrades`, `createAutoTradeEvent`, `insertIbFill`, etc.) gain an optional `accountType: AccountType = 'paper'` parameter. When `'paper'` (default), they hit the original tables — zero behavior change. When `'live'`, they hit the live tables.
+
+Example:
+
+```typescript
+export async function createPaperTrade(
+  trade: Partial<PaperTrade>,
+  accountType: AccountType = 'paper',
+): Promise<PaperTrade> {
+  const table = tradesTable(accountType);
+  const { data, error } = await supabase
+    .from(table)
+    .insert(trade)
+    .select()
+    .single();
+  // ...
+}
+```
+
+### 3.3 IB Fill Routing
+
+The `insertIbFill` and `updateIbFillCommission` functions are called from IB event handlers inside `IBConnection`. Each connection instance knows its `label` (`'paper'` or `'live'`), so it passes that to the Supabase functions:
+
+```typescript
+// Inside IBConnection.connect() event handlers:
+ib.on(EventName.orderStatus, (orderId, status, filled, _remaining, avgFillPrice) => {
+  if (status === 'Filled' && avgFillPrice > 0) {
+    insertIbFill({
+      order_id: orderId,
+      ticker: '',
+      side: '',
+      quantity: filled,
+      fill_price: avgFillPrice,
+      filled_at: new Date().toISOString(),
+    }, this.label).catch(/* ... */);
+  }
+});
+```
+
+---
+
+## 4. Phase 3: Trade Execution Routing
+
+### 4.1 Mode Router
+
+**New file:** `auto-trader/src/lib/mode-router.ts`
+
+```typescript
+import type { TradeMode, AccountType } from '../../../shared/trade-types.js';
+import type { AutoTraderConfig } from '../../../shared/config-defaults.js';
+import { getConnectionForAccount, type IBConnection } from '../ib-connection.js';
+
+/**
+ * Determine which account a trade mode routes to.
+ * Reads from config.modeRouting (DB-backed, changeable at runtime).
+ * Falls back to 'paper' if the mode is not configured.
+ */
+export function getAccountForMode(mode: TradeMode, config: AutoTraderConfig): AccountType {
+  const routing = config.modeRouting as Record<string, AccountType>;
+  return routing[mode] ?? 'paper';
+}
+
+/**
+ * Get the IB connection for a given trade mode.
+ * Throws if live is requested but live connection is down or kill switch is active.
+ */
+export function getConnectionForMode(
+  mode: TradeMode,
+  config: AutoTraderConfig,
+): { connection: IBConnection; accountType: AccountType } {
+  const accountType = getAccountForMode(mode, config);
+
+  if (accountType === 'live') {
+    if (config.liveKillSwitch) {
+      throw new Error(`Live trading halted: kill switch is active (mode=${mode})`);
+    }
+    const conn = getConnectionForAccount('live');
+    if (!conn.isConnected()) {
+      throw new Error(`Live IB connection is down — refusing to route ${mode} to live`);
+    }
+    return { connection: conn, accountType: 'live' };
+  }
+
+  const conn = getConnectionForAccount('paper');
+  return { connection: conn, accountType: 'paper' };
+}
+```
+
+**Critical safety rule:** If `getConnectionForMode` is asked for live but live is disconnected, it does **NOT** fall through to paper. It throws. This prevents accidental paper trades that the user thinks are live.
+
+### 4.2 Scheduler Changes
+
+**File:** `auto-trader/src/scheduler.ts`
+
+The scheduler is the orchestrator — every trade execution path goes through it. Changes needed:
+
+#### A. Import the router
+
+```typescript
+import { getConnectionForMode, getAccountForMode } from './lib/mode-router.js';
+import type { AccountType } from '../../shared/trade-types.js';
+```
+
+#### B. Update `executeScannerTrade()`
+
+Current: calls `placeMarketOrder()` / `placeBracketOrder()` directly (module-level, always paper).
+
+New: resolve the connection via mode router, then call the method on the correct connection.
+
+```typescript
+async function executeScannerTrade(scan: ScanResult, mode: TradeMode, config: AutoTraderConfig) {
+  const { connection, accountType } = getConnectionForMode(mode, config);
+
+  // ... existing validation, sizing, gates ...
+
+  // Use connection-scoped order placement
+  const result = await connection.placeMarketOrder({ symbol, side, quantity });
+
+  // Write to the correct trade table
+  await createPaperTrade({ /* ... */ }, accountType);
+  await createAutoTradeEvent({ /* ... */ }, accountType);
+}
+```
+
+#### C. Update all trade execution functions
+
+Each of these functions needs the same pattern (resolve connection → use it → write to correct table):
+
+| Function | Current Connection | New |
+|---|---|---|
+| `executeScannerTrade()` | module-level `placeMarketOrder` | `connection.placeMarketOrder()` |
+| `executeSuggestedFindTrade()` | module-level `placeBracketOrder` | `connection.placeBracketOrder()` |
+| `executeExternalSignalTrade()` | module-level `placeMarketOrder` | `connection.placeMarketOrder()` |
+| `executePennyTrade()` | module-level `placeMarketOrder` | `connection.placeMarketOrder()` |
+| `softCloseDayTrades()` | module-level `placeMarketOrder` | Per-trade: resolve mode → connection |
+| `closeAllDayTrades()` | module-level `placeMarketOrder` | Per-trade: resolve mode → connection |
+| `checkDipBuyOpportunities()` | module-level `placeMarketOrder` | `connection.placeMarketOrder()` |
+| `checkProfitTakeOpportunities()` | module-level `placeMarketOrder` | `connection.placeMarketOrder()` |
+| `checkLossCutOpportunities()` | module-level `placeMarketOrder` | `connection.placeMarketOrder()` |
+| `checkLongTermAutoSell()` | module-level `placeMarketOrder` | `connection.placeMarketOrder()` |
+| `syncPositions()` | module-level `requestPositions` | Per-connection sync |
+
+#### D. Position sync — dual-connection awareness
+
+`syncPositions()` currently calls `requestPositions()` and reconciles against `paper_trades`. It needs to run **twice** — once per connection:
+
+```typescript
+async function syncPositions(): Promise<void> {
+  // Sync paper positions (existing logic, unchanged)
+  const paperPositions = await getPaperConnection().requestPositions();
+  await reconcilePositions(paperPositions, 'paper');
+
+  // Sync live positions
+  if (getLiveConnection().isConnected()) {
+    const livePositions = await getLiveConnection().requestPositions();
+    await reconcilePositions(livePositions, 'live');
+  }
+}
+
+async function reconcilePositions(
+  ibPositions: PositionData[],
+  accountType: AccountType,
+): Promise<void> {
+  const activeTrades = await getActiveTrades(accountType);
+  // ... existing reconciliation logic, but using accountType-scoped queries
+}
+```
+
+#### E. P&L tracking — separate per connection
+
+Each `IBConnection` has its own P&L subscription. The scheduler's daily loss check needs to query both:
+
+```typescript
+function checkDailyLossLimit(config: AutoTraderConfig): boolean {
+  const livePnL = getLiveConnection().getDailyPnL();
+  if (livePnL.realizedPnL !== null && livePnL.realizedPnL <= config.liveDailyLossLimit) {
+    console.error(`[SAFETY] Live daily loss limit breached: $${livePnL.realizedPnL} <= $${config.liveDailyLossLimit}`);
+    return true; // limit breached
+  }
+  return false;
+}
+```
+
+#### F. Position sizing — account-specific config
+
+Live account uses `livePositionSize`, `liveMaxPositions`, `liveMaxDailyDeployment` from config. Paper uses existing `positionSize`, `maxPositions`, `maxDailyDeployment`.
+
+```typescript
+function getPositionSizeConfig(accountType: AccountType, config: AutoTraderConfig) {
+  if (accountType === 'live') {
+    return {
+      positionSize: config.livePositionSize,
+      maxPositions: config.liveMaxPositions,
+      maxDailyDeployment: config.liveMaxDailyDeployment,
+      portfolioValue: config.livePortfolioValue,
+    };
+  }
+  return {
+    positionSize: config.positionSize,
+    maxPositions: config.maxPositions,
+    maxDailyDeployment: config.maxDailyDeployment,
+    portfolioValue: config.portfolioValue,
+  };
+}
+```
+
+#### G. Portfolio snapshots
+
+`savePortfolioSnapshot()` already runs daily. It needs to save separate snapshots for each connected account:
+
+```typescript
+// Paper snapshot (existing)
+await savePortfolioSnapshot({
+  snapshot_date: today,
+  account_id: paperConn.getDefaultAccount(),
+  account_type: 'paper',
+  // ... positions from paperConn.requestPositions()
+});
+
+// Live snapshot (new)
+if (liveConn.isConnected()) {
+  await savePortfolioSnapshot({
+    snapshot_date: today,
+    account_id: liveConn.getDefaultAccount(),
+    account_type: 'live',
+    // ... positions from liveConn.requestPositions()
+  });
+}
+```
+
+### 4.3 Trade Performance Logging
+
+**File:** `auto-trader/src/lib/tradePerformanceLog.ts`
+
+`logClosedTradePerformance()` writes to `trade_performance_log`. Add `account_type` to the insert:
+
+```typescript
+export async function logClosedTradePerformance(
+  trade: PaperTrade,
+  accountType: AccountType = 'paper',
+): Promise<void> {
+  await supabase.from('trade_performance_log').insert({
+    trade_id: trade.id,
+    ticker: trade.ticker,
+    // ... existing fields ...
+    account_type: accountType,
+  });
+}
+```
+
+> **Note:** `trade_performance_log.trade_id` has a FK reference to `paper_trades(id)`. For live trades, we need to either:
+> (a) Drop the FK and rely on application-level integrity, or
+> (b) Add a conditional FK that references `live_trades(id)` when `account_type = 'live'`.
+>
+> **Recommendation:** Drop the FK. The performance log is append-only analytics. A dangling `trade_id` is annoying but not dangerous. A missing FK is better than complex conditional constraints.
+
+```sql
+-- Drop the FK so trade_performance_log can reference both paper_trades and live_trades
+ALTER TABLE trade_performance_log DROP CONSTRAINT IF EXISTS trade_performance_log_trade_id_fkey;
+```
+
+### 4.4 EOD Reconciliation
+
+**File:** `auto-trader/src/lib/reconcile-executions.ts`
+
+`runEndOfDayReconciliation()` queries `ib_fills` and `paper_trades` to correct fill prices and P&L. It needs to run once per account:
+
+```typescript
+export async function runEndOfDayReconciliation(accountType: AccountType = 'paper'): Promise<void> {
+  const fills = await supabase.from(fillsTable(accountType)).select('*')...;
+  const trades = await supabase.from(tradesTable(accountType)).select('*')...;
+  // ... existing reconciliation logic using accountType-scoped tables
+}
+```
+
+The scheduler calls it twice:
+
+```typescript
+await runEndOfDayReconciliation('paper');
+if (liveConn.isConnected()) {
+  await runEndOfDayReconciliation('live');
+}
+```
+
+---
+
+## 5. Phase 4: Frontend Account Switcher
+
+### 5.1 Account Context
+
+**New file:** `app/src/contexts/AccountContext.tsx`
+
+```typescript
+import { createContext, useContext, useState } from 'react';
+import type { AccountType } from '../../../shared/trade-types';
+
+type AccountView = 'live' | 'paper' | 'all';
+
+interface AccountContextValue {
+  accountView: AccountView;
+  setAccountView: (view: AccountView) => void;
+  tradesTable: string;        // 'paper_trades' | 'live_trades'
+  eventsTable: string;        // 'auto_trade_events' | 'live_trade_events'
+}
+
+const AccountContext = createContext<AccountContextValue>(/* ... */);
+
+export function AccountProvider({ children }: { children: React.ReactNode }) {
+  const [accountView, setAccountView] = useState<AccountView>('live');
+
+  const value: AccountContextValue = {
+    accountView,
+    setAccountView,
+    // For 'all' view, queries need to union both tables
+    tradesTable: accountView === 'live' ? 'live_trades' : 'paper_trades',
+    eventsTable: accountView === 'live' ? 'live_trade_events' : 'auto_trade_events',
+  };
+
+  return <AccountContext.Provider value={value}>{children}</AccountContext.Provider>;
+}
+
+export function useAccountView() {
+  return useContext(AccountContext);
+}
+```
+
+### 5.2 Pill Switcher Component
+
+**In:** `app/src/components/PaperTrading/index.tsx` (top nav area)
+
+```tsx
+function AccountPill() {
+  const { accountView, setAccountView } = useAccountView();
+
+  return (
+    <div className="inline-flex rounded-lg bg-zinc-800 p-0.5 gap-0.5">
+      {(['live', 'paper', 'all'] as const).map((view) => (
+        <button
+          key={view}
+          onClick={() => setAccountView(view)}
+          className={cn(
+            'px-3 py-1 rounded-md text-sm font-medium transition-colors',
+            accountView === view
+              ? view === 'live'
+                ? 'bg-green-600 text-white'
+                : view === 'paper'
+                ? 'bg-zinc-600 text-white'
+                : 'bg-blue-600 text-white'
+              : 'text-zinc-400 hover:text-zinc-200',
+          )}
+        >
+          {view === 'live' && '🟢 '}
+          {view.charAt(0).toUpperCase() + view.slice(1)}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+### 5.3 Query Routing in `paperTradesApi.ts`
+
+**File:** `app/src/lib/paperTradesApi.ts`
+
+All query functions gain an `accountView` parameter:
+
+```typescript
+export async function getAllTrades(accountView: AccountView = 'paper'): Promise<PaperTrade[]> {
+  if (accountView === 'all') {
+    const [paperResult, liveResult] = await Promise.all([
+      supabase.from('paper_trades').select('*').limit(2000),
+      supabase.from('live_trades').select('*').limit(2000),
+    ]);
+    return [
+      ...(paperResult.data ?? []).map(t => ({ ...t, _accountType: 'paper' as const })),
+      ...(liveResult.data ?? []).map(t => ({ ...t, _accountType: 'live' as const })),
+    ].sort((a, b) => new Date(b.opened_at).getTime() - new Date(a.opened_at).getTime());
+  }
+
+  const table = accountView === 'live' ? 'live_trades' : 'paper_trades';
+  const { data, error } = await supabase.from(table).select('*').limit(2000);
+  return (data ?? []) as PaperTrade[];
+}
+```
+
+### 5.4 Stat Cards — Separate P&L Display
+
+**Rule: Never merge live and paper P&L into one number.**
+
+When `accountView === 'all'`, stat cards show:
+- Live P&L: green/red card with live-only numbers
+- Paper P&L: gray card with paper-only numbers
+
+When `accountView === 'live'` or `'paper'`, show only that account's stats.
+
+### 5.5 Trade Row Badges
+
+In the trades table, each row shows a small badge indicating account:
+- 🟢 Green dot for live trades (from `live_trades` or `_accountType === 'live'`)
+- Gray dot for paper trades
+
+### 5.6 Files to Change
+
+| File | Change |
+|---|---|
+| `app/src/components/PaperTrading/index.tsx` | Add `AccountPill` to header, pass `accountView` to data hooks |
+| `app/src/lib/paperTradesApi.ts` | All query functions accept `accountView`, route to correct table |
+| `app/src/lib/autoTrader.ts` | `getTotalDeployed()` scoped by account |
+| `app/src/lib/ibClient.ts` | Add endpoints for live account positions/P&L |
+| `app/src/contexts/AccountContext.tsx` | New context for account view state |
+| `app/src/App.tsx` | Wrap with `AccountProvider` |
+| `app/src/components/PaperTrading/shared/` | Stat cards accept `accountView`, show appropriate data |
+| `app/src/components/PaperTrading/tabs/PortfolioTab.tsx` | Filter positions by account |
+| `app/src/components/PaperTrading/tabs/TodayActivityTab.tsx` | Query correct events table |
+| `app/src/components/PaperTrading/tabs/HistoryTab.tsx` | Query correct trades table |
+| `app/src/components/PaperTrading/tabs/PerformanceTab.tsx` | Filter `trade_performance_log` by `account_type` |
+
+---
+
+## 6. Phase 5: Kill Switches & Safety Guards
+
+### 6.1 Global Kill Switch
+
+**Behavior:** When `config.liveKillSwitch === true`:
+- `getConnectionForMode()` throws for any mode that resolves to `'live'`
+- The live IB connection is gracefully disconnected
+- All pending live orders are cancelled
+- A CRITICAL event is logged to `live_trade_events`
+
+**Activation paths:**
+1. Frontend toggle in Settings tab (writes to `auto_trader_config`)
+2. Automatic: triggered by daily loss limit breach
+3. Automatic: triggered by live gateway disconnect (doesn't reconnect — requires manual re-enable)
+
+### 6.2 Per-Mode Kill Switch
+
+The `mode_routing` JSONB column serves as the per-mode kill switch. Setting a mode to `'paper'` in the DB immediately routes that mode away from live.
+
+### 6.3 Daily Loss Limit
+
+```typescript
+// Checked before every live order placement
+function assertLiveLossLimitNotBreached(config: AutoTraderConfig): void {
+  const pnl = getLiveConnection().getDailyPnL();
+  if (pnl.realizedPnL !== null && pnl.realizedPnL <= config.liveDailyLossLimit) {
+    // Auto-engage kill switch
+    saveConfigPartial({ liveKillSwitch: true });
+    createAutoTradeEvent({
+      ticker: 'SYSTEM',
+      event_type: 'error',
+      message: `Live daily loss limit breached: $${pnl.realizedPnL.toFixed(2)} <= $${config.liveDailyLossLimit}. Kill switch engaged.`,
+      action: 'failed',
+      source: 'system',
+    }, 'live');
+    throw new Error('Live daily loss limit breached — kill switch engaged');
+  }
+}
+```
+
+### 6.4 Account Type Validation Before Order Submission
+
+The auto-trader validates `account_type` before every order. This is the final defense:
+
+```typescript
+// Inside IBConnection.placeMarketOrder():
+placeMarketOrder(params: MarketOrderParams): Promise<MarketOrderResult> {
+  // Verify we are on the expected connection
+  console.log(`[IB:${this.label}] Market order: ${params.side} ${params.quantity}x ${params.symbol}`);
+  // ... existing logic
+}
+```
+
+### 6.5 Health Monitoring
+
+```typescript
+// If live gateway drops, halt live trading immediately
+getLiveConnection().onConnectionChange((connected) => {
+  if (!connected) {
+    console.error('[SAFETY] Live IB connection lost — engaging kill switch');
+    saveConfigPartial({ liveKillSwitch: true });
+    createAutoTradeEvent({
+      ticker: 'SYSTEM',
+      event_type: 'error',
+      message: 'Live IB Gateway disconnected. Kill switch engaged. Manual re-enable required.',
+      action: 'failed',
+      source: 'system',
+    }, 'live');
+  }
+});
+```
+
+### 6.6 IB-Level Risk Controls (External)
+
+Configure on the live IB account directly (not in our code):
+- Max order size
+- Max daily trades
+- Max position value
+- These are a backup safety net — our application-level controls should catch everything first.
+
+### 6.7 Auto-Trader REST Endpoints
+
+**File:** `auto-trader/src/routes/`
+
+New endpoints for frontend kill switch control:
+
+| Endpoint | Method | Action |
+|---|---|---|
+| `/api/live/kill-switch` | POST | Engage/disengage live kill switch |
+| `/api/live/status` | GET | Live connection status, P&L, positions |
+| `/api/live/mode-routing` | GET/PUT | Read/update mode routing config |
+
+---
+
+## 7. Phase 6: Testing & Validation
+
+### 7.1 Pre-Launch Checklist
+
+- [ ] **Database:** Run migration, verify all 4 new tables exist with correct schemas
+- [ ] **Database:** Verify `account_type` column exists on `trade_performance_log` and `portfolio_snapshots`
+- [ ] **Database:** Verify existing data has `account_type = 'paper'` (default)
+- [ ] **Database:** Verify RLS policies exist on all new tables
+- [ ] **IB Gateway:** Start second gateway instance on port 4001 with live account
+- [ ] **IB Gateway:** Verify both gateways can run simultaneously with same IB user
+- [ ] **Auto-trader:** Verify `paperConn` connects on port 4002 (unchanged)
+- [ ] **Auto-trader:** Verify `liveConn` connects on port 4001
+- [ ] **Auto-trader:** Verify both connections show separate `managedAccounts`
+- [ ] **Auto-trader:** Verify P&L subscriptions work independently per connection
+- [ ] **Auto-trader:** Verify `getConnectionForMode('DAY_TRADE', config)` returns live connection
+- [ ] **Auto-trader:** Verify `getConnectionForMode('SWING_TRADE', config)` returns paper connection
+- [ ] **Auto-trader:** Verify live kill switch prevents all live orders
+- [ ] **Auto-trader:** Verify daily loss limit auto-engages kill switch
+- [ ] **Auto-trader:** Verify live gateway disconnect auto-engages kill switch
+- [ ] **Auto-trader:** Verify `syncPositions()` reconciles paper and live separately
+- [ ] **Auto-trader:** Verify EOD pipeline runs for both accounts
+- [ ] **Frontend:** Account pill renders and switches correctly
+- [ ] **Frontend:** Live view shows only `live_trades` data
+- [ ] **Frontend:** Paper view shows only `paper_trades` data
+- [ ] **Frontend:** All view shows both with badges
+- [ ] **Frontend:** P&L numbers never mix live and paper
+- [ ] **Frontend:** Kill switch toggle in settings works
+
+### 7.2 Safety Scenarios to Test
+
+| Scenario | Expected Behavior |
+|---|---|
+| Live gateway goes down during trading hours | Kill switch auto-engages, paper continues |
+| Live daily P&L hits loss limit | Kill switch auto-engages, paper continues |
+| User toggles kill switch ON | All live orders cancelled, live routing throws |
+| User toggles kill switch OFF | Live connection restarts, routing resumes |
+| Mode routing changed at runtime | Next trade cycle picks up new routing |
+| Both gateways down | All trading halted, health check alerts fire |
+| DAY_TRADE order placed on live | Writes to `live_trades`, `live_trade_events`, `live_ib_fills` |
+| SWING_TRADE order placed on paper | Writes to `paper_trades`, `auto_trade_events`, `ib_fills` |
+| EOD close fires for live day trades | Uses live connection to close, updates `live_trades` |
+| syncPositions finds orphan on live | Logs CRITICAL error to `live_trade_events`, does NOT close on paper |
+
+### 7.3 Rollback Plan
+
+If live trading needs to be disabled entirely:
+1. Set `liveKillSwitch = true` in `auto_trader_config`
+2. Set all modes in `mode_routing` to `'paper'`
+3. Disconnect live IB Gateway
+4. All existing paper logic continues to work unchanged
+
+The physical table separation means paper trading is completely unaffected by any live trading issues.
+
+---
+
+## Implementation Order & Dependencies
+
+```
+Phase 1 (DB) ─────────→ Phase 2 (Connection Registry) ──→ Phase 3 (Execution Routing)
+                                                                    │
+                                                                    ↓
+                         Phase 4 (Frontend) ←─────────────── Phase 5 (Kill Switches)
+                                                                    │
+                                                                    ↓
+                                                          Phase 6 (Testing)
+```
+
+**Phase 1** can be deployed immediately (additive, no breaking changes).  
+**Phases 2–3** are the core auto-trader changes — deploy together.  
+**Phase 4** can be developed in parallel with Phases 2–3.  
+**Phase 5** is integrated into Phase 2–3 but has its own testing requirements.  
+**Phase 6** must pass before any live trading begins.
+
+### Estimated Effort
+
+| Phase | Files Changed | Complexity | Estimate |
+|---|---|---|---|
+| Phase 1: Database | 1 migration + 1 shared type | Low | 1 session |
+| Phase 2: Connection Registry | `ib-connection.ts` + `supabase.ts` | High | 2–3 sessions |
+| Phase 3: Execution Routing | `scheduler.ts` + 5–8 lib files | High | 3–4 sessions |
+| Phase 4: Frontend | 10–12 component/API files | Medium | 2–3 sessions |
+| Phase 5: Kill Switches | Across phases 2–3 + REST routes | Medium | 1–2 sessions |
+| Phase 6: Testing | Manual + automated | Medium | 1–2 sessions |
+
+**Total: ~10–15 working sessions**
+
+---
+
+## Files Changed Summary
+
+### New Files
+- `supabase/migrations/YYYYMMDD000001_dual_account_tables.sql`
+- `auto-trader/src/lib/mode-router.ts`
+- `app/src/contexts/AccountContext.tsx`
+
+### Modified Files (Auto-Trader)
+- `auto-trader/src/ib-connection.ts` — class-based refactor with dual instances
+- `auto-trader/src/lib/supabase.ts` — table routing functions, `accountType` param on all CRUD
+- `auto-trader/src/scheduler.ts` — mode routing in all execution functions
+- `auto-trader/src/lib/reconcile-executions.ts` — dual-account EOD reconciliation
+- `auto-trader/src/lib/tradePerformanceLog.ts` — `account_type` on inserts
+- `auto-trader/src/lib/performanceLog.ts` — `account_type` on inserts
+- `auto-trader/src/lib/feedback.ts` — `account_type` param
+- `auto-trader/src/lib/streak-tracker.ts` — route to correct streak table
+- `auto-trader/src/lib/options-scanner.ts` — connection routing
+- `auto-trader/src/lib/options-manager.ts` — connection routing
+- `auto-trader/src/lib/earnings-scanner.ts` — connection routing
+- `auto-trader/src/lib/dip-watcher.ts` — connection routing
+- `auto-trader/src/routes/positions.ts` — dual-account position endpoints
+
+### Modified Files (Shared)
+- `shared/config-defaults.ts` — new config fields
+- `shared/trade-types.ts` — `AccountType` type
+
+### Modified Files (Frontend)
+- `app/src/App.tsx` — `AccountProvider` wrapper
+- `app/src/components/PaperTrading/index.tsx` — `AccountPill`, pass `accountView`
+- `app/src/lib/paperTradesApi.ts` — `accountView` routing on all queries
+- `app/src/lib/autoTrader.ts` — account-scoped helpers
+- `app/src/lib/ibClient.ts` — live account endpoints
+- `app/src/components/PaperTrading/tabs/*.tsx` — account-filtered queries + badges
+- `app/src/components/PaperTrading/shared/*.tsx` — account-aware stat cards

--- a/shared/config-defaults.ts
+++ b/shared/config-defaults.ts
@@ -60,6 +60,14 @@ export interface AutoTraderConfig {
   pennyMaxDailyLoss: number;
   pennyMaxDailyTrades: number;
   trendFilterEnabled: boolean;
+  // Dual-account routing
+  modeRouting: Record<string, 'paper' | 'live'>;
+  liveKillSwitch: boolean;
+  liveDailyLossLimit: number;
+  livePortfolioValue: number;
+  livePositionSize: number;
+  liveMaxPositions: number;
+  liveMaxDailyDeployment: number;
 }
 
 export const DEFAULT_CONFIG: AutoTraderConfig = {
@@ -115,4 +123,22 @@ export const DEFAULT_CONFIG: AutoTraderConfig = {
   pennyMaxDailyLoss: 200,
   pennyMaxDailyTrades: 10,
   trendFilterEnabled: true,
+  // Dual-account routing — all modes default to paper for safety
+  modeRouting: {
+    DAY_TRADE: 'paper',
+    SWING_TRADE: 'paper',
+    OPTIONS_PUT: 'paper',
+    OPTIONS_CALL: 'paper',
+    CALENDAR_SPREAD: 'paper',
+    CREDIT_SPREAD: 'paper',
+    DAY_PENNY: 'paper',
+    LONG_TERM: 'paper',
+    EARNINGS_CALENDAR: 'paper',
+  },
+  liveKillSwitch: true,
+  liveDailyLossLimit: -500,
+  livePortfolioValue: 100_000,
+  livePositionSize: 500,
+  liveMaxPositions: 2,
+  liveMaxDailyDeployment: 5_000,
 };

--- a/shared/trade-types.ts
+++ b/shared/trade-types.ts
@@ -6,6 +6,8 @@
  * DO NOT duplicate these types elsewhere.
  */
 
+export type AccountType = 'paper' | 'live';
+
 export type TradeMode =
   | 'DAY_TRADE'
   | 'DAY_PENNY'

--- a/supabase/migrations/20260517000001_dual_account_tables.sql
+++ b/supabase/migrations/20260517000001_dual_account_tables.sql
@@ -1,0 +1,269 @@
+-- Dual-Account Architecture — Phase 1: Database Migrations
+--
+-- Physical table isolation for trade-critical data (live_trades, live_trade_events,
+-- live_ib_fills, live_strategy_streak_state) plus discriminator columns on analytics
+-- tables (trade_performance_log, portfolio_snapshots) and mode routing config.
+--
+-- All existing paper-only queries are UNCHANGED — live tables have their own query set.
+
+-- ============================================================================
+-- 1. live_trades — identical schema to paper_trades, physically separate
+-- ============================================================================
+
+CREATE TABLE live_trades (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    ticker TEXT NOT NULL,
+    mode TEXT NOT NULL CHECK (mode IN (
+      'DAY_TRADE', 'SWING_TRADE', 'LONG_TERM',
+      'OPTIONS_PUT', 'OPTIONS_CALL',
+      'EARNINGS_CALENDAR', 'CALENDAR_SPREAD', 'CREDIT_SPREAD',
+      'DAY_PENNY'
+    )),
+    signal TEXT NOT NULL CHECK (signal IN ('BUY', 'SELL')),
+    strategy_source TEXT,
+    strategy_source_url TEXT,
+    strategy_video_id TEXT,
+    strategy_video_heading TEXT,
+    scanner_confidence INT,
+    fa_confidence INT,
+    fa_recommendation TEXT,
+    entry_price NUMERIC,
+    stop_loss NUMERIC,
+    target_price NUMERIC,
+    target_price2 NUMERIC,
+    risk_reward TEXT,
+    quantity INT,
+    position_size NUMERIC,
+    ib_order_id TEXT,
+    ib_parent_order_id TEXT,
+    ib_tp_order_id TEXT,
+    ib_sl_order_id TEXT,
+    status TEXT NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'SUBMITTED', 'FILLED', 'PARTIAL',
+                          'STOPPED', 'TARGET_HIT', 'CLOSED', 'CANCELLED', 'REJECTED')),
+    fill_price NUMERIC,
+    close_price NUMERIC,
+    pnl NUMERIC,
+    pnl_percent NUMERIC,
+    opened_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    filled_at TIMESTAMPTZ,
+    closed_at TIMESTAMPTZ,
+    close_reason TEXT,
+    scanner_reason TEXT,
+    fa_rationale JSONB,
+    notes TEXT,
+    in_play_score NUMERIC,
+    pass1_confidence INT,
+    entry_trigger_type TEXT,
+    r_multiple NUMERIC,
+    market_condition TEXT,
+    pct_distance_sma20_at_entry NUMERIC,
+    macd_histogram_slope_at_entry TEXT,
+    volume_vs_10d_avg_at_entry NUMERIC,
+    regime_alignment_at_entry TEXT,
+    price_peak NUMERIC(12,4),
+    price_peak_date DATE,
+    missing_since TIMESTAMPTZ,
+    -- Options fields
+    option_strike NUMERIC,
+    option_expiry DATE,
+    option_premium NUMERIC,
+    option_contracts INT DEFAULT 1,
+    option_delta NUMERIC,
+    option_iv_rank NUMERIC,
+    option_prob_profit NUMERIC,
+    option_net_price NUMERIC,
+    option_capital_req NUMERIC,
+    option_annual_yield NUMERIC,
+    option_assigned BOOLEAN DEFAULT FALSE,
+    option_close_pct NUMERIC,
+    -- Roll tracking
+    roll_count INT NOT NULL DEFAULT 0,
+    rolled_from_id UUID,
+    -- Credit spread fields
+    spread_type TEXT,
+    spread_short_strike NUMERIC,
+    spread_long_strike NUMERIC,
+    spread_width NUMERIC,
+    spread_net_credit NUMERIC,
+    spread_credit_pct NUMERIC,
+    spread_max_loss NUMERIC,
+    spread_max_gain NUMERIC,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_live_trades_status ON live_trades (status);
+CREATE INDEX idx_live_trades_ticker ON live_trades (ticker);
+CREATE INDEX idx_live_trades_opened ON live_trades (opened_at DESC);
+CREATE INDEX idx_live_trades_strategy_source ON live_trades (strategy_source)
+  WHERE strategy_source IS NOT NULL;
+CREATE INDEX idx_live_trades_rolled_from ON live_trades (rolled_from_id)
+  WHERE rolled_from_id IS NOT NULL;
+CREATE INDEX idx_live_trades_spread_type ON live_trades (spread_type)
+  WHERE spread_type IS NOT NULL;
+
+ALTER TABLE live_trades ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read live trades" ON live_trades FOR SELECT USING (true);
+CREATE POLICY "Anyone can insert live trades" ON live_trades FOR INSERT WITH CHECK (true);
+CREATE POLICY "Anyone can update live trades" ON live_trades FOR UPDATE USING (true);
+CREATE POLICY "Anyone can delete live trades" ON live_trades FOR DELETE USING (true);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON live_trades TO anon;
+
+-- ============================================================================
+-- 2. live_trade_events — identical schema to auto_trade_events
+-- ============================================================================
+
+CREATE TABLE live_trade_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    ticker TEXT NOT NULL,
+    event_type TEXT NOT NULL CHECK (event_type IN ('info', 'success', 'warning', 'error')),
+    action TEXT,
+    source TEXT,
+    mode TEXT,
+    message TEXT NOT NULL,
+    scanner_signal TEXT,
+    scanner_confidence INT,
+    fa_recommendation TEXT,
+    fa_confidence INT,
+    skip_reason TEXT,
+    strategy_source TEXT,
+    strategy_source_url TEXT,
+    strategy_video_id TEXT,
+    strategy_video_heading TEXT,
+    metadata JSONB,
+    candle_patterns TEXT[],
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_live_trade_events_created ON live_trade_events (created_at DESC);
+CREATE INDEX idx_live_trade_events_ticker ON live_trade_events (ticker);
+CREATE INDEX idx_live_trade_events_action ON live_trade_events (action);
+
+ALTER TABLE live_trade_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read live trade events" ON live_trade_events FOR SELECT USING (true);
+CREATE POLICY "Anyone can insert live trade events" ON live_trade_events FOR INSERT WITH CHECK (true);
+
+GRANT SELECT, INSERT ON live_trade_events TO anon;
+
+-- ============================================================================
+-- 3. live_ib_fills — identical schema to ib_fills
+-- ============================================================================
+
+CREATE TABLE live_ib_fills (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  order_id integer NOT NULL,
+  exec_id text,
+  ticker text NOT NULL,
+  side text NOT NULL,
+  quantity numeric NOT NULL,
+  fill_price numeric NOT NULL,
+  commission numeric,
+  realized_pnl numeric,
+  filled_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE live_ib_fills ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "read_live_ib_fills" ON live_ib_fills FOR SELECT USING (true);
+CREATE POLICY "insert_live_ib_fills" ON live_ib_fills FOR INSERT WITH CHECK (true);
+CREATE POLICY "update_live_ib_fills" ON live_ib_fills FOR UPDATE USING (true);
+
+CREATE INDEX idx_live_ib_fills_order_id ON live_ib_fills(order_id);
+CREATE INDEX idx_live_ib_fills_ticker_filled ON live_ib_fills(ticker, filled_at);
+
+-- ============================================================================
+-- 4. live_strategy_streak_state — identical schema to strategy_streak_state
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS live_strategy_streak_state (
+  mode TEXT PRIMARY KEY,
+  is_cold BOOLEAN NOT NULL DEFAULT false,
+  entered_cold_at TIMESTAMPTZ,
+  last_checked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  rolling_win_rate NUMERIC,
+  window_size INT NOT NULL DEFAULT 10
+);
+
+ALTER TABLE live_strategy_streak_state ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read live_strategy_streak_state" ON live_strategy_streak_state FOR SELECT USING (true);
+CREATE POLICY "Anyone can insert live_strategy_streak_state" ON live_strategy_streak_state FOR INSERT WITH CHECK (true);
+CREATE POLICY "Anyone can update live_strategy_streak_state" ON live_strategy_streak_state FOR UPDATE USING (true);
+
+-- Seed DAY_TRADE initially (all modes start on paper, but seed this for when routing is enabled)
+INSERT INTO live_strategy_streak_state (mode, is_cold, window_size)
+VALUES ('DAY_TRADE', false, 10)
+ON CONFLICT (mode) DO NOTHING;
+
+-- ============================================================================
+-- 5. Analytics tables — add account_type discriminator
+-- ============================================================================
+
+-- trade_performance_log: add account_type (all existing rows are paper)
+ALTER TABLE trade_performance_log
+  ADD COLUMN IF NOT EXISTS account_type TEXT NOT NULL DEFAULT 'paper'
+    CHECK (account_type IN ('paper', 'live'));
+
+CREATE INDEX IF NOT EXISTS idx_trade_perf_log_account_type
+  ON trade_performance_log (account_type);
+
+-- Drop FK so trade_performance_log.trade_id can reference both paper_trades and live_trades
+ALTER TABLE trade_performance_log DROP CONSTRAINT IF EXISTS trade_performance_log_trade_id_fkey;
+
+-- portfolio_snapshots: add account_type (all existing rows are paper)
+ALTER TABLE portfolio_snapshots
+  ADD COLUMN IF NOT EXISTS account_type TEXT NOT NULL DEFAULT 'paper'
+    CHECK (account_type IN ('paper', 'live'));
+
+-- Update the unique constraint to include account_type
+ALTER TABLE portfolio_snapshots
+  DROP CONSTRAINT IF EXISTS portfolio_snapshots_snapshot_date_account_id_key;
+
+ALTER TABLE portfolio_snapshots
+  ADD CONSTRAINT portfolio_snapshots_snapshot_date_account_id_account_type_key
+    UNIQUE (snapshot_date, account_id, account_type);
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_snapshots_account_type
+  ON portfolio_snapshots (account_type);
+
+-- ============================================================================
+-- 6. auto_trader_config — mode routing + live account config
+-- ============================================================================
+
+-- Mode routing: maps TradeMode → account_type ('paper' | 'live')
+-- IMPORTANT: All modes default to 'paper' for safety — no live trading until
+-- explicitly enabled by the operator.
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS mode_routing JSONB NOT NULL DEFAULT '{
+    "DAY_TRADE": "paper",
+    "SWING_TRADE": "paper",
+    "OPTIONS_PUT": "paper",
+    "OPTIONS_CALL": "paper",
+    "CALENDAR_SPREAD": "paper",
+    "CREDIT_SPREAD": "paper",
+    "DAY_PENNY": "paper",
+    "LONG_TERM": "paper",
+    "EARNINGS_CALENDAR": "paper"
+  }'::jsonb;
+
+-- Global kill switch: defaults to TRUE (live trading disabled until explicitly enabled)
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS live_kill_switch BOOLEAN NOT NULL DEFAULT true;
+
+-- Hard daily loss limit for live account (dollars)
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS live_daily_loss_limit NUMERIC NOT NULL DEFAULT -500;
+
+-- Live account portfolio value (separate from paper portfolioValue)
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS live_portfolio_value NUMERIC NOT NULL DEFAULT 100000;
+
+-- Live account position sizing overrides (conservative)
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS live_position_size NUMERIC NOT NULL DEFAULT 500;
+
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS live_max_positions INT NOT NULL DEFAULT 2;
+
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS live_max_daily_deployment NUMERIC NOT NULL DEFAULT 5000;


### PR DESCRIPTION
## Summary

Full dual-account (paper + live) trading architecture:

- Two IB Gateway instances, one auto-trader process, mode-based routing
- Physical table isolation (live_trades vs paper_trades) — zero risk of mixing
- Safety-first defaults: all modes paper, kill switch ON
- Frontend account switcher with green/gray badges
- Three-layer kill switch (manual, daily loss, disconnect)

23 files changed across database, auto-trader, shared types, and frontend.

## Test plan

- [ ] Auto-trader starts cleanly with dual connection registry
- [ ] Paper trading continues to work identically (backward compat)
- [ ] Frontend pill switcher renders and toggles
- [ ] Settings tab shows live trading section with kill switch
- [ ] Mode routing defaults all to paper
- [ ] Kill switch defaults to ON
- [ ] Live gateway disconnect auto-engages kill switch


Made with [Cursor](https://cursor.com)