### PR TITLE
fix: rename to Auto-Trading + pill color

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -898,7 +898,7 @@ function AppContent() {
                 )}
               >
                 <Bot className="w-4 h-4" />
-                Paper Trading
+                Auto-Trading
               </NavLink>
             )}
           </div>

--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -86,12 +86,12 @@ export type Tab = 'portfolio' | 'today' | 'smart' | 'strategies' | 'validation' 
 function AccountPill({ value, onChange }: { value: AccountView; onChange: (v: AccountView) => void }) {
   const pills: Array<{ id: AccountView; label: string; activeClass: string }> = [
     { id: 'live',  label: '🟢 Live',  activeClass: 'bg-emerald-600 text-white shadow-md shadow-emerald-500/25' },
-    { id: 'paper', label: 'Paper',    activeClass: 'bg-slate-700 text-white shadow-md' },
+    { id: 'paper', label: 'Paper',    activeClass: 'bg-[hsl(var(--secondary))] text-[hsl(var(--secondary-foreground))] shadow-sm border border-[hsl(var(--border))]' },
     { id: 'all',   label: 'All',      activeClass: 'bg-blue-600 text-white shadow-md shadow-blue-500/25' },
   ];
 
   return (
-    <div className="flex items-center gap-0.5 bg-slate-100 p-0.5 rounded-lg">
+    <div className="flex items-center gap-0.5 bg-[hsl(var(--muted))] p-0.5 rounded-lg">
       {pills.map(p => (
         <button
           key={p.id}
@@ -479,14 +479,14 @@ export function PaperTrading() {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold text-[hsl(var(--foreground))]">
-              {accountView === 'live' ? 'Live Trading' : accountView === 'all' ? 'All Accounts' : 'Paper Trading'}
+              Auto-Trading
             </h1>
             <p className="text-sm text-[hsl(var(--muted-foreground))] mt-1">
               {accountView === 'live'
-                ? 'Live account — real money positions'
+                ? 'Live account — real money'
                 : accountView === 'all'
-                  ? 'Combined view of paper + live accounts'
-                  : 'Auto-execute scanner signals on IB paper account'}
+                  ? 'Combined view — paper + live'
+                  : 'Paper account — testing & validation'}
             </p>
           </div>
           <div className="flex items-center gap-3">


### PR DESCRIPTION
Renames Paper Trading → Auto-Trading, fixes dark Paper pill color to match site theme.

Made with [Cursor](https://cursor.com)