### PR TITLE
Remove 'All' account tab to prevent duplicates with BOTH routing

### DIFF
--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -85,9 +85,8 @@ export type Tab = 'portfolio' | 'today' | 'smart' | 'strategies' | 'validation' 
 
 function AccountPill({ value, onChange }: { value: AccountView; onChange: (v: AccountView) => void }) {
   const pills: Array<{ id: AccountView; label: string; activeClass: string }> = [
-    { id: 'live',  label: '🟢 Live',  activeClass: 'bg-emerald-600 text-white shadow-md shadow-emerald-500/25' },
     { id: 'paper', label: 'Paper',    activeClass: 'bg-[hsl(var(--secondary))] text-[hsl(var(--secondary-foreground))] shadow-sm border border-[hsl(var(--border))]' },
-    { id: 'all',   label: 'All',      activeClass: 'bg-blue-600 text-white shadow-md shadow-blue-500/25' },
+    { id: 'live',  label: '🟢 Live',  activeClass: 'bg-emerald-600 text-white shadow-md shadow-emerald-500/25' },
   ];
 
   return (
@@ -484,9 +483,7 @@ export function PaperTrading() {
             <p className="text-sm text-[hsl(var(--muted-foreground))] mt-1">
               {accountView === 'live'
                 ? 'Live account — real money'
-                : accountView === 'all'
-                  ? 'Combined view — paper + live'
-                  : 'Paper account — testing & validation'}
+                : 'Paper account — testing & validation'}
             </p>
           </div>
           <div className="flex items-center gap-3">

--- a/app/src/components/PaperTrading/tabs/HistoryTab.tsx
+++ b/app/src/components/PaperTrading/tabs/HistoryTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Clock } from 'lucide-react';
-import type { PaperTrade, PendingStrategySignal, PaperTradeWithAccount } from '../../../lib/paperTradesApi';
+import type { PaperTrade, PendingStrategySignal } from '../../../lib/paperTradesApi';
 import type { AccountView } from '../../../contexts/AccountContext';
 import { fmtUsd } from '../utils';
 import { StatusBadge } from '../shared';
@@ -178,7 +178,7 @@ export function HistoryTab({ trades, pendingSignals, accountView }: HistoryTabPr
                 <tr key={trade.id} className={`hover:bg-[hsl(var(--secondary))]/50 ${isActive ? 'bg-blue-50/30' : ''}`}>
                   <td className="px-4 py-3 font-bold">
                     <span className="inline-flex items-center gap-1.5">
-                      {accountView === 'all' && <AccountDot type={(trade as PaperTradeWithAccount)._accountType} />}
+                      {accountView === 'live' && <AccountDot type="live" />}
                       {trade.ticker}
                     </span>
                   </td>

--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -31,7 +31,6 @@ function formatSkipReason(reason: string | null | undefined): string | null {
 }
 
 import type { AccountView } from '../../../contexts/AccountContext';
-import type { AutoTradeEventWithAccount } from '../../../lib/paperTradesApi';
 
 function AccountDot({ type }: { type?: 'paper' | 'live' }) {
   if (!type) return null;
@@ -483,7 +482,7 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
                 <tr key={event.id} className={cn('hover:bg-[hsl(var(--secondary))]/50', (isPositionSync || isAutoClose) && 'bg-slate-50/50')}>
                   <td className="px-4 py-3 font-bold">
                     <span className="inline-flex items-center gap-1.5">
-                      {accountView === 'all' && <AccountDot type={(event as AutoTradeEventWithAccount)._accountType} />}
+                      {accountView === 'live' && <AccountDot type="live" />}
                       {event.ticker}
                     </span>
                   </td>

--- a/app/src/contexts/AccountContext.tsx
+++ b/app/src/contexts/AccountContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, type ReactNode } from 'react';
 
-export type AccountView = 'live' | 'paper' | 'all';
+export type AccountView = 'live' | 'paper';
 
 interface AccountContextValue {
   accountView: AccountView;

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -48,17 +48,6 @@ let _exemptCache: { data: Set<string>; ts: number } | null = null;
 const SHARED_CACHE_TTL = 30_000;
 
 async function getSharedTrades(accountView: AccountView = 'paper'): Promise<PaperTradeWithAccount[]> {
-  if (accountView === 'all') {
-    const [paperResult, liveResult] = await Promise.all([
-      supabase.from('paper_trades').select('*').limit(2000),
-      supabase.from('live_trades').select('*').limit(2000),
-    ]);
-    return [
-      ...(paperResult.data ?? []).map(t => ({ ...t, _accountType: 'paper' as const })),
-      ...(liveResult.data ?? []).map(t => ({ ...t, _accountType: 'live' as const })),
-    ].sort((a, b) => new Date(b.opened_at).getTime() - new Date(a.opened_at).getTime()) as PaperTradeWithAccount[];
-  }
-
   if (accountView === 'live') {
     const { data, error } = await supabase.from('live_trades').select('*').limit(2000);
     if (error) throw new Error(`Failed to fetch live trades: ${error.message}`);
@@ -204,18 +193,6 @@ export async function getActiveTrades(): Promise<PaperTrade[]> {
 
 /** Get all trades (most recent first) */
 export async function getAllTrades(limit = 50, accountView: AccountView = 'paper'): Promise<PaperTradeWithAccount[]> {
-  if (accountView === 'all') {
-    const [paperResult, liveResult] = await Promise.all([
-      supabase.from('paper_trades').select('*').order('opened_at', { ascending: false }).limit(limit),
-      supabase.from('live_trades').select('*').order('opened_at', { ascending: false }).limit(limit),
-    ]);
-    return [
-      ...(paperResult.data ?? []).map(t => ({ ...t, _accountType: 'paper' as const })),
-      ...(liveResult.data ?? []).map(t => ({ ...t, _accountType: 'live' as const })),
-    ].sort((a, b) => new Date(b.opened_at).getTime() - new Date(a.opened_at).getTime())
-      .slice(0, limit) as PaperTradeWithAccount[];
-  }
-
   const table = tradesTableName(accountView);
   const { data, error } = await supabase
     .from(table)
@@ -590,18 +567,6 @@ export async function createAutoTradeEvent(
 export type AutoTradeEventWithAccount = AutoTradeEventRecord & { _accountType?: AccountType };
 
 export async function getAutoTradeEvents(limit = 100, accountView: AccountView = 'paper'): Promise<AutoTradeEventWithAccount[]> {
-  if (accountView === 'all') {
-    const [paperRes, liveRes] = await Promise.all([
-      supabase.from('auto_trade_events').select('*').order('created_at', { ascending: false }).limit(limit),
-      supabase.from('live_trade_events').select('*').order('created_at', { ascending: false }).limit(limit),
-    ]);
-    return [
-      ...(paperRes.data ?? []).map(e => ({ ...e, _accountType: 'paper' as const })),
-      ...(liveRes.data ?? []).map(e => ({ ...e, _accountType: 'live' as const })),
-    ].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
-      .slice(0, limit) as AutoTradeEventWithAccount[];
-  }
-
   const table = eventsTableName(accountView);
   const { data, error } = await supabase
     .from(table)
@@ -674,16 +639,6 @@ export async function getTodaysExecutedEvents(accountView: AccountView = 'paper'
     return result;
   }
 
-  if (accountView === 'all') {
-    const [paper, live] = await Promise.all([
-      fetchForTable('auto_trade_events', 'paper_trades', 'paper'),
-      fetchForTable('live_trade_events', 'live_trades', 'live'),
-    ]);
-    return [...paper, ...live].sort(
-      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-    );
-  }
-
   const evTable = eventsTableName(accountView);
   const trTable = tradesTableName(accountView);
   return (await fetchForTable(evTable, trTable)).sort(
@@ -697,16 +652,10 @@ export async function getAutoTradeEventsByTicker(
   limit = 50,
   accountView: AccountView = 'paper',
 ): Promise<AutoTradeEventWithAccount[]> {
-  if (accountView === 'all') {
-    const [paperRes, liveRes] = await Promise.all([
-      supabase.from('auto_trade_events').select('*').eq('ticker', ticker).order('created_at', { ascending: false }).limit(limit),
-      supabase.from('live_trade_events').select('*').eq('ticker', ticker).order('created_at', { ascending: false }).limit(limit),
-    ]);
-    return [
-      ...(paperRes.data ?? []).map(e => ({ ...e, _accountType: 'paper' as const })),
-      ...(liveRes.data ?? []).map(e => ({ ...e, _accountType: 'live' as const })),
-    ].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
-      .slice(0, limit) as AutoTradeEventWithAccount[];
+  if (accountView === 'live') {
+    const { data, error } = await supabase.from('live_trade_events').select('*').eq('ticker', ticker).order('created_at', { ascending: false }).limit(limit);
+    if (error) throw new Error(`Failed to fetch live events: ${error.message}`);
+    return (data ?? []).map(e => ({ ...e, _accountType: 'live' as const })) as AutoTradeEventWithAccount[];
   }
 
   const table = eventsTableName(accountView);
@@ -781,7 +730,7 @@ export async function getPerformance(): Promise<TradePerformance | null> {
 
 /** Update aggregate performance (recalculate from all trades) */
 export async function recalculatePerformance(accountView: AccountView = 'paper'): Promise<TradePerformance | null> {
-  const table = tradesTableName(accountView === 'all' ? 'paper' : accountView);
+  const table = tradesTableName(accountView);
   const { data: trades, error } = await supabase
     .from(table)
     .select('*')
@@ -935,7 +884,7 @@ export interface PendingStrategySignal {
 export async function recalculatePerformanceByCategory(accountView: AccountView = 'paper'): Promise<CategoryPerformance[]> {
   let trades: PaperTrade[];
   try {
-    trades = await getSharedTrades(accountView === 'all' ? 'paper' : accountView);
+    trades = await getSharedTrades(accountView);
   } catch {
     return [];
   }
@@ -1041,7 +990,7 @@ export async function recalculatePerformanceByStrategySource(accountView: Accoun
   let allTrades: PaperTrade[];
   let exemptSources: Set<string>;
   try {
-    [allTrades, exemptSources] = await Promise.all([getSharedTrades(accountView === 'all' ? 'paper' : accountView), getCachedExemptSources()]);
+    [allTrades, exemptSources] = await Promise.all([getSharedTrades(accountView), getCachedExemptSources()]);
   } catch {
     return [];
   }
@@ -1145,7 +1094,7 @@ export async function recalculatePerformanceByStrategyVideo(accountView: Account
   let allTrades: PaperTrade[];
   let exemptSources: Set<string>;
   try {
-    [allTrades, exemptSources] = await Promise.all([getSharedTrades(accountView === 'all' ? 'paper' : accountView), getCachedExemptSources()]);
+    [allTrades, exemptSources] = await Promise.all([getSharedTrades(accountView), getCachedExemptSources()]);
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
- Removed 'All' option from account pill switcher (now just Paper / Live)
- Cleaned up all dead `accountView === 'all'` code paths in paperTradesApi.ts
- Removed unused imports in HistoryTab and TodayActivityTab
- Updated AccountContext type to `'live' | 'paper'` only

## Test plan
- [ ] Account switcher shows only Paper and Live pills
- [ ] Paper view works as before
- [ ] Live view shows "not connected" placeholder
- [ ] Build passes cleanly

Made with [Cursor](https://cursor.com)