### PR TITLE
Regroup trading modules and make Settings always accessible

### DIFF
--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -555,27 +555,6 @@ export function PaperTrading() {
         )}
       </div>
 
-      {/* Live view gate: show empty state if no live gateway is set up */}
-      {accountView === 'live' && (
-        <div className="flex flex-col items-center justify-center py-16 gap-4 text-center">
-          <div className="w-16 h-16 rounded-full bg-emerald-50 border-2 border-dashed border-emerald-300 flex items-center justify-center">
-            <Wifi className="w-7 h-7 text-emerald-400" />
-          </div>
-          <div>
-            <h3 className="text-lg font-semibold text-[hsl(var(--foreground))]">Live Account Not Connected</h3>
-            <p className="text-sm text-[hsl(var(--muted-foreground))] mt-1 max-w-md">
-              Set up a second IB Gateway on port 4001 with your live account, then disable the kill switch in Settings to start live trading.
-            </p>
-          </div>
-          <button
-            onClick={() => setAccountView('paper')}
-            className="px-4 py-2 text-sm font-medium rounded-lg bg-[hsl(var(--secondary))] text-[hsl(var(--secondary-foreground))] hover:opacity-80 transition-opacity"
-          >
-            Switch to Paper
-          </button>
-        </div>
-      )}
-
       {accountView !== 'live' && <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
         <StatCard
           icon={<Briefcase className="w-4 h-4" />}
@@ -622,8 +601,7 @@ export function PaperTrading() {
         />
       </div>}
 
-      {accountView !== 'live' && <>
-      {/* Tab bar — horizontally scrollable on mobile */}
+      {/* Tab bar — always visible, horizontally scrollable on mobile */}
       <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0" style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
         <div className="flex gap-1 bg-white/60 p-1 rounded-xl border border-[hsl(var(--border))] w-max sm:w-auto min-w-full">
           {[
@@ -669,6 +647,24 @@ export function PaperTrading() {
       ) : tabLoading ? (
         <div className="flex items-center justify-center py-12">
           <Spinner size="md" />
+        </div>
+      ) : accountView === 'live' && ['portfolio', 'today', 'history', 'performance', 'strategies'].includes(tab) ? (
+        <div className="flex flex-col items-center justify-center py-16 gap-4 text-center">
+          <div className="w-16 h-16 rounded-full bg-emerald-50 border-2 border-dashed border-emerald-300 flex items-center justify-center">
+            <Wifi className="w-7 h-7 text-emerald-400" />
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-[hsl(var(--foreground))]">Live Account Not Connected</h3>
+            <p className="text-sm text-[hsl(var(--muted-foreground))] mt-1 max-w-md">
+              Set up a second IB Gateway on port 4001 with your live account, then disable the kill switch in Settings to start live trading.
+            </p>
+          </div>
+          <button
+            onClick={() => setAccountView('paper')}
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-[hsl(var(--secondary))] text-[hsl(var(--secondary-foreground))] hover:opacity-80 transition-opacity"
+          >
+            Switch to Paper
+          </button>
         </div>
       ) : (
         <>
@@ -795,7 +791,6 @@ export function PaperTrading() {
           </div>
         </div>
       )}
-      </>}
     </div>
   );
 }

--- a/app/src/components/PaperTrading/tabs/SettingsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/SettingsTab.tsx
@@ -116,23 +116,14 @@ function TradingModulesSection({
     onUpdate({ modeRouting: { ...routing, [mode]: target } });
   };
 
-  const groups: { title: string; description: string; modes: string[] }[] = [
-    {
-      title: 'Trade Signals',
-      description: 'Day & swing trade scanner — AI + technical analysis',
-      modes: ['DAY_TRADE', 'SWING_TRADE'],
-    },
-    {
-      title: 'Options',
-      description: 'Cash-secured puts, covered calls, and spreads',
-      modes: ['OPTIONS_PUT', 'OPTIONS_CALL', 'CREDIT_SPREAD', 'CALENDAR_SPREAD'],
-    },
-    {
-      title: 'Other Strategies',
-      description: 'Additional scanners and strategies',
-      modes: ['DAY_PENNY', 'LONG_TERM', 'EARNINGS_CALENDAR'],
-    },
-  ];
+  const OPTIONS_MODES = ['OPTIONS_PUT', 'OPTIONS_CALL', 'CREDIT_SPREAD', 'CALENDAR_SPREAD', 'EARNINGS_CALENDAR'];
+  const setAllOptions = (target: RouteTarget) => {
+    const updated = { ...routing };
+    OPTIONS_MODES.forEach(m => { updated[m] = target; });
+    onUpdate({ modeRouting: updated });
+  };
+
+  const optionsValue = (routing['OPTIONS_PUT'] as RouteTarget) ?? 'paper';
 
   return (
     <div className="rounded-lg border border-[hsl(var(--border))] bg-slate-50 p-4 space-y-4">
@@ -143,22 +134,34 @@ function TradingModulesSection({
         </p>
       </div>
 
-      {groups.map(group => (
-        <div key={group.title} className="rounded-md border border-[hsl(var(--border))] bg-white p-3 space-y-2.5">
-          <div>
-            <p className="text-xs font-semibold text-[hsl(var(--foreground))]">{group.title}</p>
-            <p className="text-[10px] text-[hsl(var(--muted-foreground))]">{group.description}</p>
-          </div>
-          {group.modes.map(mode => (
-            <RoutePill
-              key={mode}
-              mode={mode}
-              value={(routing[mode] as RouteTarget) ?? 'paper'}
-              onChange={target => setRoute(mode, target)}
-            />
-          ))}
+      {/* Trade Signals */}
+      <div className="rounded-md border border-[hsl(var(--border))] bg-white p-3 space-y-2.5">
+        <div>
+          <p className="text-xs font-semibold text-[hsl(var(--foreground))]">Trade Signals</p>
+          <p className="text-[10px] text-[hsl(var(--muted-foreground))]">Day &amp; swing trade scanner — AI + technical analysis</p>
         </div>
-      ))}
+        <RoutePill mode="DAY_TRADE" value={(routing['DAY_TRADE'] as RouteTarget) ?? 'paper'} onChange={target => setRoute('DAY_TRADE', target)} />
+        <RoutePill mode="SWING_TRADE" value={(routing['SWING_TRADE'] as RouteTarget) ?? 'paper'} onChange={target => setRoute('SWING_TRADE', target)} />
+        <RoutePill mode="DAY_PENNY" value={(routing['DAY_PENNY'] as RouteTarget) ?? 'paper'} onChange={target => setRoute('DAY_PENNY', target)} />
+      </div>
+
+      {/* Options */}
+      <div className="rounded-md border border-[hsl(var(--border))] bg-white p-3 space-y-2.5">
+        <div>
+          <p className="text-xs font-semibold text-[hsl(var(--foreground))]">Options</p>
+          <p className="text-[10px] text-[hsl(var(--muted-foreground))]">Cash-secured puts, covered calls, spreads, and earnings plays</p>
+        </div>
+        <RoutePill mode="ALL_OPTIONS" value={optionsValue} onChange={setAllOptions} />
+      </div>
+
+      {/* Suggested Finds */}
+      <div className="rounded-md border border-[hsl(var(--border))] bg-white p-3 space-y-2.5">
+        <div>
+          <p className="text-xs font-semibold text-[hsl(var(--foreground))]">Suggested Finds</p>
+          <p className="text-[10px] text-[hsl(var(--muted-foreground))]">Quiet Compounders &amp; Gold Mines — auto-buy long-term positions</p>
+        </div>
+        <RoutePill mode="LONG_TERM" value={(routing['LONG_TERM'] as RouteTarget) ?? 'paper'} onChange={target => setRoute('LONG_TERM', target)} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Regrouped Trading Modules: Trade Signals (Day Trade, Swing Trade, Day Penny), Options (single toggle for all 5 modes), Suggested Finds (Long Term)
- Tab bar always visible regardless of account view
- Settings, System Learning, Smart Trading always accessible
- Data tabs show "not connected" placeholder in Live view

## Test plan
- [ ] Settings shows 3 grouped cards with 5 total rows
- [ ] Options toggle sets all 5 modes at once
- [ ] Switching to Live view still shows tab bar
- [ ] Can access Settings from Live view
- [ ] Data tabs show placeholder in Live view

Made with [Cursor](https://cursor.com)