### PR TITLE
Fix Settings-backend gaps: Influencers, earnings gate, route endpoint

### DIFF
--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -648,7 +648,7 @@ export function PaperTrading() {
         <div className="flex items-center justify-center py-12">
           <Spinner size="md" />
         </div>
-      ) : accountView === 'live' && ['portfolio', 'today', 'history', 'performance', 'strategies'].includes(tab) ? (
+      ) : accountView === 'live' && ['portfolio', 'today', 'history', 'performance'].includes(tab) ? (
         <div className="flex flex-col items-center justify-center py-16 gap-4 text-center">
           <div className="w-16 h-16 rounded-full bg-emerald-50 border-2 border-dashed border-emerald-300 flex items-center justify-center">
             <Wifi className="w-7 h-7 text-emerald-400" />

--- a/auto-trader/src/routes/live.ts
+++ b/auto-trader/src/routes/live.ts
@@ -9,7 +9,7 @@
 import { Router } from 'express';
 import { getLiveConnection, getPaperConnection } from '../ib-connection.js';
 import { loadConfig, saveConfigPartial } from '../lib/supabase.js';
-import type { AccountType } from '../../../shared/trade-types.js';
+import type { RouteTarget } from '../../../shared/trade-types.js';
 
 const router = Router();
 
@@ -72,26 +72,30 @@ router.get('/live/mode-routing', async (_req, res) => {
 
 router.put('/live/mode-routing', async (req, res) => {
   try {
-    const { modeRouting } = req.body as { modeRouting?: Record<string, AccountType> };
+    const { modeRouting } = req.body as { modeRouting?: Record<string, RouteTarget> };
     if (!modeRouting || typeof modeRouting !== 'object') {
       res.status(400).json({ error: 'Missing required object field: modeRouting' });
       return;
     }
 
-    const validModes = ['DAY_TRADE', 'DAY_PENNY', 'SWING_TRADE', 'LONG_TERM', 'OPTIONS_PUT', 'OPTIONS_CALL'];
-    const validAccounts: AccountType[] = ['paper', 'live'];
-    for (const [mode, acct] of Object.entries(modeRouting)) {
+    const validModes = [
+      'DAY_TRADE', 'DAY_PENNY', 'SWING_TRADE', 'LONG_TERM',
+      'OPTIONS_PUT', 'OPTIONS_CALL',
+      'CREDIT_SPREAD', 'CALENDAR_SPREAD', 'EARNINGS_CALENDAR',
+    ];
+    const validTargets: RouteTarget[] = ['off', 'paper', 'live', 'both'];
+    for (const [mode, target] of Object.entries(modeRouting)) {
       if (!validModes.includes(mode)) {
         res.status(400).json({ error: `Invalid mode: ${mode}` });
         return;
       }
-      if (!validAccounts.includes(acct)) {
-        res.status(400).json({ error: `Invalid account type for ${mode}: ${acct}` });
+      if (!validTargets.includes(target)) {
+        res.status(400).json({ error: `Invalid route target for ${mode}: ${target}` });
         return;
       }
     }
 
-    await saveConfigPartial({ modeRouting });
+    await saveConfigPartial({ mode_routing: modeRouting });
     res.json({ ok: true, modeRouting });
   } catch (err) {
     res.status(500).json({ error: err instanceof Error ? err.message : 'unknown' });

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -385,6 +385,8 @@ export function startScheduler(): void {
   // and tomorrow morning's BMO earnings announcements.
   cron.schedule('30 14 * * 1-5', async () => {
     try {
+      const cfg = await loadConfig();
+      if (!isModeEnabled(cfg, 'EARNINGS_CALENDAR')) return;
       await runEarningsScan();
     } catch (err) {
       console.error('[EarningsScan] Scan failed:', err instanceof Error ? err.message : err);


### PR DESCRIPTION
## Summary
- Influencers tab now always accessible (not gated behind live connection check)
- Earnings scanner gated behind `isModeEnabled(config, 'EARNINGS_CALENDAR')` — existing position closes still run
- PUT /api/live/mode-routing updated to validate all 9 modes and accept off/paper/live/both

## Test plan
- [ ] Influencers tab accessible in Live view
- [ ] Settings accessible in Live view
- [ ] Build passes

Made with [Cursor](https://cursor.com)