### PR TITLE
Add centralized Finnhub rate limiter and daily_penny strategy type

### DIFF
--- a/app/src/components/PaperTrading/tabs/StrategyPerformanceTab.tsx
+++ b/app/src/components/PaperTrading/tabs/StrategyPerformanceTab.tsx
@@ -11,7 +11,7 @@ import type {
 import { fetchInfluencerTradePatterns } from '../../../lib/paperTradesApi';
 import {
   fixUnknownSources, assignUnknownToSource, updateStrategyVideoMetadata,
-  reimportSignalsForVideo, KNOWN_SIGNAL_GENERATORS,
+  reimportSignalsForVideo, KNOWN_SIGNAL_GENERATORS, KNOWN_PENNY_GENERATORS,
   extractFromTranscript, cleanupStrategyAssignments, fetchYouTubeTranscript,
   addUrlsToQueue, processQueue, getQueue, type StrategyVideoQueueItem,
   deleteStrategyVideo,
@@ -33,7 +33,7 @@ type StrategyRow = {
   videoId: string | null;
   videoHeading: string;
   platform: 'instagram' | 'twitter' | 'youtube' | null;
-  strategyType: 'daily_signal' | 'generic_strategy' | null;
+  strategyType: 'daily_signal' | 'daily_penny' | 'generic_strategy' | null;
   applicableTimeframes: Array<'DAY_TRADE' | 'SWING_TRADE'> | null;
   totalTrades: number;
   activeTrades: number;
@@ -395,7 +395,7 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
         source_handle: opt.sourceHandle,
         source_name: opt.sourceName,
         video_ids: [videoId],
-        strategy_type: sel.category ? (sel.category as 'daily_signal' | 'generic_strategy') : undefined,
+        strategy_type: sel.category ? (sel.category as 'daily_signal' | 'daily_penny' | 'generic_strategy') : undefined,
       });
       if (assigned > 0) onRefresh();
     } finally {
@@ -414,7 +414,7 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
         source_handle: opt.sourceHandle,
         source_name: opt.sourceName,
         video_ids: [videoId],
-        strategy_type: sel.category ? (sel.category as 'daily_signal' | 'generic_strategy') : undefined,
+        strategy_type: sel.category ? (sel.category as 'daily_signal' | 'daily_penny' | 'generic_strategy') : undefined,
       });
       if (assigned > 0) {
         setChangingSourceVideoId(null);
@@ -425,14 +425,12 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
     }
   };
 
-  const handleCategoryChange = async (videoId: string, strategyType: 'daily_signal' | 'generic_strategy') => {
+  const handleCategoryChange = async (videoId: string, strategyType: 'daily_signal' | 'daily_penny' | 'generic_strategy') => {
     if (!onRefresh) return;
     setUpdatingCategoryVideoId(videoId);
     try {
       await updateStrategyVideoMetadata({ video_id: videoId, strategy_type: strategyType });
-      // When upgrading to daily_signal: purge stale generic signals and re-import
-      // from the transcript so only the analyst's actual tickers are live.
-      if (strategyType === 'daily_signal') {
+      if (strategyType === 'daily_signal' || strategyType === 'daily_penny') {
         await reimportSignalsForVideo(videoId);
       }
       onRefresh();
@@ -1221,8 +1219,9 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
                                                 value={videoAssignSelections[baseKey]?.source ?? ''}
                                                 onChange={(e) => {
                                                   const newSource = e.target.value;
-                                                  // Auto-default to daily_signal for known signal generators
-                                                  const autoCategory = KNOWN_SIGNAL_GENERATORS.has(newSource)
+                                                  const autoCategory = KNOWN_PENNY_GENERATORS.has(newSource)
+                                                    ? 'daily_penny'
+                                                    : KNOWN_SIGNAL_GENERATORS.has(newSource)
                                                     ? 'daily_signal'
                                                     : (videoAssignSelections[baseKey]?.category ?? 'generic_strategy');
                                                   setVideoAssignSelections(prev => ({ ...prev, [baseKey]: { ...prev[baseKey], source: newSource, category: autoCategory } }));
@@ -1242,6 +1241,7 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
                                                 title={KNOWN_SIGNAL_GENERATORS.has(videoAssignSelections[baseKey]?.source ?? '') && (videoAssignSelections[baseKey]?.category ?? '') === 'generic_strategy' ? 'Signal generators like Somesh should be Daily signal — generic will import all scanner tickers instead of just their picks' : undefined}
                                               >
                                                 <option value="daily_signal">Daily signal</option>
+                                                <option value="daily_penny">Daily penny</option>
                                                 <option value="generic_strategy">Generic strategy</option>
                                               </select>
                                               {KNOWN_SIGNAL_GENERATORS.has(videoAssignSelections[baseKey]?.source ?? '') && (videoAssignSelections[baseKey]?.category ?? '') === 'generic_strategy' && (
@@ -1262,7 +1262,7 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
                                               <select
                                                 value={video.strategyType ?? 'generic_strategy'}
                                                 onChange={(e) => {
-                                                  const v = e.target.value as 'daily_signal' | 'generic_strategy';
+                                                  const v = e.target.value as 'daily_signal' | 'daily_penny' | 'generic_strategy';
                                                   if (v) handleCategoryChange(video.videoId!, v);
                                                 }}
                                                 disabled={updatingCategoryVideoId === video.videoId}
@@ -1270,6 +1270,7 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
                                                 title={KNOWN_SIGNAL_GENERATORS.has(sourceName) && (video.strategyType ?? 'generic_strategy') === 'generic_strategy' ? 'Signal generators like Somesh should be Daily signal — changing to daily_signal will re-import only their transcript tickers' : undefined}
                                               >
                                                 <option value="daily_signal">Daily signal</option>
+                                                <option value="daily_penny">Daily penny</option>
                                                 <option value="generic_strategy">Generic strategy</option>
                                               </select>
                                               {KNOWN_SIGNAL_GENERATORS.has(sourceName) && (video.strategyType ?? 'generic_strategy') === 'generic_strategy' && (

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -860,7 +860,7 @@ export interface StrategySignalStatusSummary {
   videoId: string | null;
   videoHeading: string | null;
   platform: 'instagram' | 'twitter' | 'youtube' | null;
-  strategyType: 'daily_signal' | 'generic_strategy' | null;
+  strategyType: 'daily_signal' | 'daily_penny' | 'generic_strategy' | null;
   applicableDate: string | null;
   /** For generic_strategy: DAY_TRADE, SWING_TRADE, or both */
   applicableTimeframes: Array<'DAY_TRADE' | 'SWING_TRADE'> | null;
@@ -1267,7 +1267,7 @@ export async function getStrategySignalStatusSummaries(): Promise<StrategySignal
   const nowMs = Date.now();
 
   const grouped = new Map<string, StrategySignalStatusSummary & { sortKey: string }>();
-  const trackedTypeByKey = new Map<string, 'daily_signal' | 'generic_strategy'>();
+  const trackedTypeByKey = new Map<string, 'daily_signal' | 'daily_penny' | 'generic_strategy'>();
   const trackedTimeframesByKey = new Map<string, Array<'DAY_TRADE' | 'SWING_TRADE'>>();
   for (const row of data as Array<{
     source_name: string | null;
@@ -1346,7 +1346,7 @@ export async function getStrategySignalStatusSummaries(): Promise<StrategySignal
           : (item.canonical_url ?? item.reel_url ?? null);
 
         const key = `${source}::${videoId ?? videoHeading}`;
-        const strategyType = item.strategy_type === 'daily_signal' || item.strategy_type === 'generic_strategy'
+        const strategyType = item.strategy_type === 'daily_signal' || item.strategy_type === 'daily_penny' || item.strategy_type === 'generic_strategy'
           ? item.strategy_type
           : null;
         if (strategyType) {
@@ -1380,7 +1380,7 @@ export async function getStrategySignalStatusSummaries(): Promise<StrategySignal
             videoHeading,
             platform,
             strategyType,
-            applicableDate: strategyType === 'daily_signal' ? (item.trade_date ?? null) : null,
+            applicableDate: strategyType === 'daily_signal' || strategyType === 'daily_penny' ? (item.trade_date ?? null) : null,
             applicableTimeframes: timeframes.length > 0 ? timeframes : null,
             latestSignalStatus: null,
             sortKey: `${item.trade_date ?? ''}|`,

--- a/app/src/lib/strategyVideoQueueApi.ts
+++ b/app/src/lib/strategyVideoQueueApi.ts
@@ -14,7 +14,7 @@ export interface StrategyVideoQueueItem {
   status: 'pending' | 'processing' | 'done' | 'failed';
   error_message: string | null;
   strategy_video_id: string | null;
-  strategy_type: 'daily_signal' | 'generic_strategy' | null;
+  strategy_type: 'daily_signal' | 'daily_penny' | 'generic_strategy' | null;
   created_at: string;
   processed_at: string | null;
 }
@@ -108,7 +108,7 @@ export async function assignUnknownToSource(params: {
   source_handle: string;
   source_name: string;
   video_ids?: string[];
-  strategy_type?: 'daily_signal' | 'generic_strategy';
+  strategy_type?: 'daily_signal' | 'daily_penny' | 'generic_strategy';
 }): Promise<{ assigned: number; video_ids: string[] }> {
   const url = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/assign-strategy-videos-to-source`;
   const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -136,6 +136,14 @@ export async function assignUnknownToSource(params: {
 export const KNOWN_SIGNAL_GENERATORS = new Set([
   'Somesh | Day Trader | Investor',
   'Kay Capitals',
+]);
+
+/**
+ * Known penny stock watchlist creators — their videos default to daily_penny.
+ */
+export const KNOWN_PENNY_GENERATORS = new Set([
+  'Ross Cameron',
+  'Warrior Trading',
 ]);
 
 /**
@@ -180,7 +188,7 @@ export async function updateStrategyVideoMetadata(params: {
   platform?: 'instagram' | 'twitter' | 'youtube';
   source_handle?: string;
   source_name?: string;
-  strategy_type?: 'daily_signal' | 'generic_strategy';
+  strategy_type?: 'daily_signal' | 'daily_penny' | 'generic_strategy';
 }): Promise<{ ok: boolean }> {
   const url = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/update-strategy-video-metadata`;
   const key = import.meta.env.VITE_SUPABASE_ANON_KEY;

--- a/app/src/lib/strategyVideosApi.ts
+++ b/app/src/lib/strategyVideosApi.ts
@@ -14,7 +14,7 @@ export interface StrategyVideoRecord {
   reel_url: string | null;
   canonical_url: string | null;
   video_heading: string | null;
-  strategy_type: 'daily_signal' | 'generic_strategy' | null;
+  strategy_type: 'daily_signal' | 'daily_penny' | 'generic_strategy' | null;
   timeframe: string | null;
   applicable_timeframes: string[] | null;
   execution_window_et: { start?: string; end?: string } | null;
@@ -34,7 +34,7 @@ export interface StrategyVideoNormalized {
   reelUrl?: string;
   canonicalUrl?: string;
   videoHeading?: string;
-  strategyType?: 'daily_signal' | 'generic_strategy';
+  strategyType?: 'daily_signal' | 'daily_penny' | 'generic_strategy';
   timeframe?: string;
   applicableTimeframes?: string[];
   executionWindowEt?: { start?: string; end?: string };

--- a/auto-trader/src/lib/calendar-spread-scanner.ts
+++ b/auto-trader/src/lib/calendar-spread-scanner.ts
@@ -22,10 +22,10 @@ import { getOptionsChain, type OptionGreeks, type OptionsChainSummary } from './
 import { getSupabase, createAutoTradeEvent } from './supabase.js';
 import { ACTIVE_STATUSES } from '../../../shared/trade-status-sets.js';
 import { fetchDailyBars, sma as calcSma } from './yahoo-finance.js';
+import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
 
 // ── Constants ────────────────────────────────────────────
 
-const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
 const MIN_IV_RANK = 40;
 const MAX_BB_WIDTH_PCT = 25;
 const MIN_FRONT_DTE = 14;
@@ -73,16 +73,8 @@ function daysToExpiryFromStr(yyyymmdd: string): number {
   return Math.ceil((new Date(y, m, d).getTime() - Date.now()) / 86_400_000);
 }
 
-async function fetchJson<T>(url: string): Promise<T | null> {
-  try {
-    const res = await fetch(url);
-    if (!res.ok) return null;
-    return await res.json() as T;
-  } catch { return null; }
-}
-
 async function getEarningsDate(ticker: string): Promise<Date | null> {
-  const data = await fetchJson<{ earningsCalendar?: Array<{ date?: string }> }>(
+  const data = await finnhubFetch<{ earningsCalendar?: Array<{ date?: string }> }>(
     `https://finnhub.io/api/v1/calendar/earnings?symbol=${ticker}&token=${FINNHUB_KEY}`
   );
   const entries = data?.earningsCalendar ?? [];

--- a/auto-trader/src/lib/credit-spread-scanner.ts
+++ b/auto-trader/src/lib/credit-spread-scanner.ts
@@ -18,10 +18,9 @@ import { getSupabase, createAutoTradeEvent } from './supabase.js';
 import { ACTIVE_STATUSES } from '../../../shared/trade-status-sets.js';
 import { fetchDailyBars, fetchQuote, sma as calcSma } from './yahoo-finance.js';
 import { isConnected, placeVerticalSpreadOrder, getDefaultAccount } from '../ib-connection.js';
+import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
 
 // ── Constants ────────────────────────────────────────────
-
-const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
 const MIN_CREDIT_PCT = 0.33;           // collect at least 33% of width
 const PREFERRED_CREDIT_PCT = 0.40;     // Tony's sweet spot: 40%+
 const MAX_RISK_PCT = 0.02;             // max 2% of account per trade
@@ -63,16 +62,8 @@ export interface CreditSpreadScanResult {
 
 // ── Helpers ──────────────────────────────────────────────
 
-async function fetchJson<T>(url: string): Promise<T | null> {
-  try {
-    const res = await fetch(url);
-    if (!res.ok) return null;
-    return await res.json() as T;
-  } catch { return null; }
-}
-
 async function getStockQuote(ticker: string): Promise<{ price: number; change: number; pctChange: number } | null> {
-  const data = await fetchJson<{ c: number; d: number; dp: number }>(
+  const data = await finnhubFetch<{ c: number; d: number; dp: number }>(
     `https://finnhub.io/api/v1/quote?symbol=${ticker}&token=${FINNHUB_KEY}`
   );
   if (!data?.c) return null;
@@ -80,7 +71,7 @@ async function getStockQuote(ticker: string): Promise<{ price: number; change: n
 }
 
 async function getEarningsDate(ticker: string): Promise<Date | null> {
-  const data = await fetchJson<{ earningsCalendar?: Array<{ date?: string }> }>(
+  const data = await finnhubFetch<{ earningsCalendar?: Array<{ date?: string }> }>(
     `https://finnhub.io/api/v1/calendar/earnings?symbol=${ticker}&token=${FINNHUB_KEY}`
   );
   const future = (data?.earningsCalendar ?? [])
@@ -282,7 +273,6 @@ export async function runCreditSpreadScan(
       skipped.push({ ticker, reason: `error:${msg.slice(0, 60)}` });
     }
 
-    await new Promise(r => setTimeout(r, 800));
   }
 
   // Sort by credit % descending (best risk-reward first)

--- a/auto-trader/src/lib/dip-watcher.ts
+++ b/auto-trader/src/lib/dip-watcher.ts
@@ -16,8 +16,7 @@
  */
 
 import { getSupabase, createAutoTradeEvent } from './supabase.js';
-
-const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
 const DIP_THRESHOLD_PCT = 5;      // stock down ≥5% from 20-day high = dip entry (cumulative)
 const RED_DAY_THRESHOLD_PCT = 3;  // single-session drop ≥3% = red day entry (same-day IV spike)
 const DIP_LOOKBACK_DAYS = 20;     // measure high over last 20 trading days
@@ -38,16 +37,6 @@ function resetIfNewDay() {
   }
 }
 
-async function fetchJson<T>(url: string): Promise<T | null> {
-  try {
-    const res = await fetch(url);
-    if (!res.ok) return null;
-    return await res.json() as T;
-  } catch {
-    return null;
-  }
-}
-
 interface DipCheckResult {
   ticker: string;
   price: number;
@@ -64,10 +53,10 @@ async function checkDip(ticker: string): Promise<DipCheckResult | null> {
   const from = to - 86400 * (DIP_LOOKBACK_DAYS + 10); // extra buffer
 
   const [candles, quote] = await Promise.all([
-    fetchJson<{ c?: number[]; h?: number[] }>(
+    finnhubFetch<{ c?: number[]; h?: number[] }>(
       `https://finnhub.io/api/v1/stock/candle?symbol=${ticker}&resolution=D&from=${from}&to=${to}&token=${FINNHUB_KEY}`
     ),
-    fetchJson<{ c: number; dp: number }>(
+    finnhubFetch<{ c: number; dp: number }>(
       `https://finnhub.io/api/v1/quote?symbol=${ticker}&token=${FINNHUB_KEY}`
     ),
   ]);
@@ -119,9 +108,6 @@ export async function runDipWatcher(): Promise<void> {
   for (const entry of watchlist as Array<{ ticker: string; notes: string | null }>) {
     // Skip if already alerted today
     if (alertedToday.has(entry.ticker)) continue;
-
-    // Throttle Finnhub calls
-    await new Promise(r => setTimeout(r, 400));
 
     const result = await checkDip(entry.ticker);
     if (!result?.isDip) continue;

--- a/auto-trader/src/lib/discovery.ts
+++ b/auto-trader/src/lib/discovery.ts
@@ -523,7 +523,7 @@ function parseGoldMineCandidates(raw: string): {
 // 52-week high and show signs of stabilization (price > 10-day SMA).
 // AI identifies candidates; Finnhub data verifies drawdown and stabilization.
 
-const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
 
 interface DipCandidate {
   ticker: string;
@@ -533,11 +533,7 @@ interface DipCandidate {
 }
 
 async function finnhubGet<T>(path: string): Promise<T | null> {
-  try {
-    const res = await fetch(`https://finnhub.io/api/v1${path}&token=${FINNHUB_KEY}`);
-    if (!res.ok) return null;
-    return await res.json() as T;
-  } catch { return null; }
+  return finnhubFetch<T>(`https://finnhub.io/api/v1${path}&token=${FINNHUB_KEY}`);
 }
 
 function buildDipCandidatePrompt(): string {

--- a/auto-trader/src/lib/earnings-scanner.ts
+++ b/auto-trader/src/lib/earnings-scanner.ts
@@ -28,8 +28,7 @@
  */
 
 import { getSupabase, createAutoTradeEvent } from './supabase.js';
-
-const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
 
 // ── Screening thresholds ─────────────────────────────────
 const MIN_AVG_VOLUME_30D    = 500_000;   // minimum 30-day avg daily volume
@@ -80,32 +79,11 @@ interface EarningsEvent {
   hour?: string | null;   // 'bmo' | 'amc'
 }
 
-// ── Rate-limited fetch ───────────────────────────────────
-
-let _lastCall = 0;
-const MIN_GAP_MS = 900;
-
-async function fetchJson<T>(url: string): Promise<T | null> {
-  const now = Date.now();
-  const wait = MIN_GAP_MS - (now - _lastCall);
-  if (wait > 0) await new Promise(r => setTimeout(r, wait));
-  _lastCall = Date.now();
-  try {
-    const res = await fetch(url, {
-      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; PortfolioAssistant/1.0)' },
-    });
-    if (!res.ok) return null;
-    return await res.json() as T;
-  } catch {
-    return null;
-  }
-}
-
 // ── Data helpers ─────────────────────────────────────────
 
 /** Fetch upcoming earnings events for a given date from Finnhub. */
 async function getEarningsForDate(dateStr: string): Promise<EarningsEvent[]> {
-  const data = await fetchJson<{ earningsCalendar?: EarningsEvent[] }>(
+  const data = await finnhubFetch<{ earningsCalendar?: EarningsEvent[] }>(
     `https://finnhub.io/api/v1/calendar/earnings?from=${dateStr}&to=${dateStr}&token=${FINNHUB_KEY}`
   );
   return (data?.earningsCalendar ?? []).filter(e => e.symbol && /^[A-Z]{1,5}$/.test(e.symbol));
@@ -119,7 +97,7 @@ async function fetchPriceHistory(ticker: string, days = 40): Promise<{
 } | null> {
   const to   = Math.floor(Date.now() / 1000);
   const from = to - 86_400 * (days + 10); // extra buffer for weekends
-  const data = await fetchJson<{ c?: (number | null)[]; v?: (number | null)[] }>(
+  const data = await finnhubFetch<{ c?: (number | null)[]; v?: (number | null)[] }>(
     `https://finnhub.io/api/v1/stock/candle?symbol=${ticker}&resolution=D&from=${from}&to=${to}&token=${FINNHUB_KEY}`
   );
   if (!data?.c || data.c.length < 10) return null;

--- a/auto-trader/src/lib/econ-calendar.ts
+++ b/auto-trader/src/lib/econ-calendar.ts
@@ -10,7 +10,7 @@
  * then halve day-trade position sizes on those days to reduce risk.
  */
 
-const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
 
 // Events that historically cause outsized intraday volatility.
 // Matched case-insensitively against the Finnhub event description.
@@ -63,12 +63,10 @@ export async function getEconDayProfile(): Promise<EconDayProfile> {
 
   try {
     const url = `https://finnhub.io/api/v1/calendar/economic?from=${dateStr}&to=${dateStr}&token=${FINNHUB_KEY}`;
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`Finnhub econ calendar ${res.status}`);
-
-    const data = await res.json() as {
+    const data = await finnhubFetch<{
       economicCalendar?: Array<{ event: string; time: string; impact?: string }>;
-    };
+    }>(url);
+    if (!data) throw new Error('Finnhub econ calendar: no data');
 
     const events = (data.economicCalendar ?? []).map(e => ({
       event: e.event,

--- a/auto-trader/src/lib/finnhub.ts
+++ b/auto-trader/src/lib/finnhub.ts
@@ -1,0 +1,100 @@
+/**
+ * Centralized Finnhub API client with rate limiting and caching.
+ *
+ * Finnhub free tier allows 60 API calls per minute. This module enforces a
+ * global sliding-window rate limiter (55 calls/60s for headroom) so that ALL
+ * callers across the auto-trader share the same budget. When the limit is hit,
+ * calls wait rather than fail.
+ *
+ * A short-lived response cache (2-min TTL) avoids redundant API calls when
+ * multiple scanners request the same data within a short window.
+ */
+
+export const FINNHUB_BASE = 'https://finnhub.io/api/v1';
+export const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+
+// ── Sliding-window rate limiter ──────────────────────────
+
+const MAX_REQUESTS = 55;
+const WINDOW_MS = 60_000;
+const callTimestamps: number[] = [];
+
+function pruneOldTimestamps(): void {
+  const cutoff = Date.now() - WINDOW_MS;
+  while (callTimestamps.length > 0 && callTimestamps[0]! < cutoff) {
+    callTimestamps.shift();
+  }
+}
+
+async function waitForSlot(): Promise<void> {
+  pruneOldTimestamps();
+  if (callTimestamps.length < MAX_REQUESTS) return;
+
+  const oldestTs = callTimestamps[0]!;
+  const waitMs = oldestTs + WINDOW_MS - Date.now() + 50;
+  if (waitMs > 0) {
+    console.log(
+      `[Finnhub] Rate limit reached (${callTimestamps.length}/${MAX_REQUESTS}), waiting ${waitMs}ms...`,
+    );
+    await new Promise(r => setTimeout(r, waitMs));
+    pruneOldTimestamps();
+  }
+}
+
+// ── Response cache ────────────────────────────────────────
+
+const CACHE_TTL_MS = 2 * 60_000;
+const responseCache = new Map<string, { data: unknown; ts: number }>();
+
+function getCached<T>(url: string): T | undefined {
+  const entry = responseCache.get(url);
+  if (!entry) return undefined;
+  if (Date.now() - entry.ts > CACHE_TTL_MS) {
+    responseCache.delete(url);
+    return undefined;
+  }
+  return entry.data as T;
+}
+
+function setCache(url: string, data: unknown): void {
+  responseCache.set(url, { data, ts: Date.now() });
+
+  if (responseCache.size > 200) {
+    const cutoff = Date.now() - CACHE_TTL_MS;
+    for (const [key, val] of responseCache) {
+      if (val.ts < cutoff) responseCache.delete(key);
+    }
+  }
+}
+
+// ── Public API ────────────────────────────────────────────
+
+/**
+ * Rate-limited, cached Finnhub API fetch.
+ * All Finnhub calls across the auto-trader should go through this function.
+ *
+ * - Enforces a 55-request/60-second sliding window across ALL callers
+ * - Caches responses for 2 minutes to avoid redundant API calls
+ * - Returns null on any failure (network, parse, non-200 status)
+ */
+export async function finnhubFetch<T>(url: string): Promise<T | null> {
+  if (!FINNHUB_KEY) return null;
+
+  const cached = getCached<T>(url);
+  if (cached !== undefined) return cached;
+
+  await waitForSlot();
+  callTimestamps.push(Date.now());
+
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(12_000),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as T;
+    setCache(url, data);
+    return data;
+  } catch {
+    return null;
+  }
+}

--- a/auto-trader/src/lib/fundamental-grader.ts
+++ b/auto-trader/src/lib/fundamental-grader.ts
@@ -4,7 +4,7 @@
  * Results are cached in memory with 24h TTL.
  */
 
-const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
 
 export type FundamentalGrade = 'A' | 'B' | 'C' | 'D' | 'F';
 
@@ -111,17 +111,13 @@ export async function getFundamentalGrade(ticker: string, isIndexEtf = false): P
 
   let metrics: Record<string, number | null> = {};
   try {
-    const wait = 900 - (Date.now() - lastCall);
-    if (wait > 0) await new Promise(r => setTimeout(r, wait));
-    lastCall = Date.now();
-
-    const res = await fetch(`https://finnhub.io/api/v1/stock/metric?symbol=${ticker}&metric=all&token=${FINNHUB_KEY}`);
-    if (res.ok) {
-      const data: FinnhubMetricAll = await res.json();
+    const data = await finnhubFetch<FinnhubMetricAll>(
+      `https://finnhub.io/api/v1/stock/metric?symbol=${ticker}&metric=all&token=${FINNHUB_KEY}`,
+    );
+    if (data) {
       metrics = data.metric ?? {};
     }
   } catch {
-    // API failure → return neutral C grade
     return { grade: 'C', score: 50, breakdown: {} };
   }
 
@@ -148,8 +144,6 @@ export async function getFundamentalGrade(ticker: string, isIndexEtf = false): P
   cache.set(ticker, { result, ts: Date.now() });
   return result;
 }
-
-let lastCall = 0;
 
 export function clearFundamentalCache(): void {
   cache.clear();

--- a/auto-trader/src/lib/morning-brief.ts
+++ b/auto-trader/src/lib/morning-brief.ts
@@ -12,8 +12,7 @@
  */
 
 import { getSupabase } from './supabase.js';
-
-const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
 const SUPABASE_URL = process.env.SUPABASE_URL ?? '';
 const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY ?? '';
 
@@ -33,14 +32,12 @@ function hoursAgoUnix(hours: number): number {
 
 async function fetchMarketNews() {
   try {
-    const from = hoursAgoUnix(14); // slightly wider window to catch overnight
+    const from = hoursAgoUnix(14);
     const url = `https://finnhub.io/api/v1/news?category=general&minId=${from}&token=${FINNHUB_KEY}`;
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`Finnhub news ${res.status}`);
-    const data = await res.json() as Array<{
+    const data = await finnhubFetch<Array<{
       headline: string; summary: string; related: string; datetime: number; source: string;
-    }>;
-    // Keep last 12h, deduplicate by headline
+    }>>(url);
+    if (!data) return [];
     const cutoff = hoursAgoUnix(12);
     const seen = new Set<string>();
     return data
@@ -56,12 +53,10 @@ async function fetchMarketNews() {
 async function fetchEarningsToday(dateStr: string) {
   try {
     const url = `https://finnhub.io/api/v1/calendar/earnings?from=${dateStr}&to=${dateStr}&token=${FINNHUB_KEY}`;
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`Finnhub earnings ${res.status}`);
-    const data = await res.json() as { earningsCalendar?: Array<{
+    const data = await finnhubFetch<{ earningsCalendar?: Array<{
       symbol: string; date: string; epsEstimate?: number; hour?: string;
-    }> };
-    return (data.earningsCalendar ?? []).slice(0, 30);
+    }> }>(url);
+    return (data?.earningsCalendar ?? []).slice(0, 30);
   } catch (err) {
     log(`Earnings fetch failed: ${err}`);
     return [];
@@ -71,12 +66,10 @@ async function fetchEarningsToday(dateStr: string) {
 async function fetchEconomicEventsToday(dateStr: string) {
   try {
     const url = `https://finnhub.io/api/v1/calendar/economic?from=${dateStr}&to=${dateStr}&token=${FINNHUB_KEY}`;
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`Finnhub econ ${res.status}`);
-    const data = await res.json() as { economicCalendar?: Array<{
+    const data = await finnhubFetch<{ economicCalendar?: Array<{
       event: string; time: string; prior?: string; estimate?: string; impact?: string;
-    }> };
-    return (data.economicCalendar ?? []).map(e => ({
+    }> }>(url);
+    return (data?.economicCalendar ?? []).map(e => ({
       event: e.event,
       time: e.time,
       prior: e.prior ?? null,

--- a/auto-trader/src/lib/options-manager.ts
+++ b/auto-trader/src/lib/options-manager.ts
@@ -13,6 +13,7 @@ import { getSupabase, createAutoTradeEvent } from './supabase.js';
 import { ACTIVE_STATUSES, CLOSED_STATUSES, OPTIONS_MODES } from '../../../shared/trade-status-sets.js';
 import { getOptionsAutoTradeConfig, autoTradeOption, type OptionsTradeTicket } from './options-scanner.js';
 import { getOptionsChain } from './options-chain.js';
+import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
 import { isConnected, placeOptionsOrder, getDefaultAccount } from '../ib-connection.js';
 
 import type { AutoTradeEventType } from '../../../shared/auto-trade-events.js';
@@ -414,13 +415,11 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
     // ── Check 2: Get current premium from IB ──
     if (!isConnected()) continue;
 
-    // Get fresh quote for the stock
     let stockPrice: number | null = null;
-    try {
-      const res = await fetch(`https://finnhub.io/api/v1/quote?symbol=${pos.ticker}&token=${process.env.FINNHUB_API_KEY}`);
-      const q = await res.json() as { c?: number };
-      stockPrice = q.c ?? null;
-    } catch { /* skip */ }
+    const q = await finnhubFetch<{ c?: number }>(
+      `https://finnhub.io/api/v1/quote?symbol=${pos.ticker}&token=${FINNHUB_KEY}`,
+    );
+    stockPrice = q?.c ?? null;
 
     if (!stockPrice) continue;
 
@@ -707,13 +706,11 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
 
     if (!isConnected()) continue;
 
-    // Get fresh stock price
     let stockPrice: number | null = null;
-    try {
-      const res = await fetch(`https://finnhub.io/api/v1/quote?symbol=${pos.ticker}&token=${process.env.FINNHUB_API_KEY}`);
-      const q = await res.json() as { c?: number };
-      stockPrice = q.c ?? null;
-    } catch { /* skip */ }
+    const ccQ = await finnhubFetch<{ c?: number }>(
+      `https://finnhub.io/api/v1/quote?symbol=${pos.ticker}&token=${FINNHUB_KEY}`,
+    );
+    stockPrice = ccQ?.c ?? null;
     if (!stockPrice) continue;
 
     // Get current call premium

--- a/auto-trader/src/lib/options-scanner.ts
+++ b/auto-trader/src/lib/options-scanner.ts
@@ -40,9 +40,9 @@ import { isConnected, placeOptionsOrder, getDefaultAccount } from '../ib-connect
 import { fetchDailyBars, fetchQuote, sma as calcSma, estimateHistoricalVol } from './yahoo-finance.js';
 import { getFundamentalGrade } from './fundamental-grader.js';
 
-// ── Constants ────────────────────────────────────────────
+import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
 
-const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+// ── Constants ────────────────────────────────────────────
 const MIN_STOCK_PRICE = 20;
 const MIN_PREMIUM_YIELD_PCT = 1.5;        // at least 1.5% of strike per 30 days (regular stocks)
 const MIN_PREMIUM_YIELD_INDEX_ETF = 1.2;  // index ETFs (VPU/VYM/VIG): lower floor — assignment is a feature
@@ -221,27 +221,8 @@ const MAX_POSITIONS_SAME_EXPIRY_WEEK = 3;
 
 // ── Finnhub Helpers ──────────────────────────────────────
 
-// Finnhub free tier = 60 calls/min. Rate-limit to ~50/min (1200ms gap) with
-// a simple queue so bursts don't exhaust the quota mid-scan.
-let _lastFinnhubCall = 0;
-const FINNHUB_MIN_GAP_MS = 800;
-
-async function fetchJson<T>(url: string): Promise<T | null> {
-  try {
-    const now = Date.now();
-    const wait = FINNHUB_MIN_GAP_MS - (now - _lastFinnhubCall);
-    if (wait > 0) await new Promise(r => setTimeout(r, wait));
-    _lastFinnhubCall = Date.now();
-    const res = await fetch(url);
-    if (!res.ok) return null;
-    return await res.json() as T;
-  } catch {
-    return null;
-  }
-}
-
 async function getStockQuote(ticker: string): Promise<{ price: number; change: number; pctChange: number } | null> {
-  const data = await fetchJson<{ c: number; d: number; dp: number }>(
+  const data = await finnhubFetch<{ c: number; d: number; dp: number }>(
     `https://finnhub.io/api/v1/quote?symbol=${ticker}&token=${FINNHUB_KEY}`
   );
   if (!data?.c) return null;
@@ -249,7 +230,7 @@ async function getStockQuote(ticker: string): Promise<{ price: number; change: n
 }
 
 async function getRSI(ticker: string): Promise<{ rsi: number; prevRsi: number } | null> {
-  const basic = await fetchJson<{ rsi?: number[] }>(
+  const basic = await finnhubFetch<{ rsi?: number[] }>(
     `https://finnhub.io/api/v1/indicator?symbol=${ticker}&resolution=D&from=${Math.floor(Date.now() / 1000) - 86400 * 60}&to=${Math.floor(Date.now() / 1000)}&indicator=rsi&timeperiod=14&token=${FINNHUB_KEY}`
   );
   if (!basic?.rsi || basic.rsi.length < 2) return null;
@@ -259,7 +240,7 @@ async function getRSI(ticker: string): Promise<{ rsi: number; prevRsi: number } 
 }
 
 async function getEarningsDate(ticker: string): Promise<Date | null> {
-  const data = await fetchJson<{ earningsCalendar?: Array<{ date?: string }> }>(
+  const data = await finnhubFetch<{ earningsCalendar?: Array<{ date?: string }> }>(
     `https://finnhub.io/api/v1/calendar/earnings?symbol=${ticker}&token=${FINNHUB_KEY}`
   );
   const entries = data?.earningsCalendar ?? [];
@@ -271,7 +252,7 @@ async function getEarningsDate(ticker: string): Promise<Date | null> {
 }
 
 async function getVix(): Promise<number> {
-  const data = await fetchJson<{ c: number }>(
+  const data = await finnhubFetch<{ c: number }>(
     `https://finnhub.io/api/v1/quote?symbol=VIX&token=${FINNHUB_KEY}`
   );
   return data?.c ?? 20;
@@ -368,11 +349,11 @@ async function getNewsSentiment(ticker: string): Promise<NewsSentimentResult> {
   const from = new Date(Date.now() - NEWS_LOOKBACK_DAYS * 86400_000).toISOString().slice(0, 10);
 
   const [sentiment, news] = await Promise.all([
-    fetchJson<{
+    finnhubFetch<{
       sentiment?: { bullishPercent?: number; bearishPercent?: number };
       buzz?: { articlesInLastWeek?: number };
     }>(`https://finnhub.io/api/v1/news-sentiment?symbol=${ticker}&token=${FINNHUB_KEY}`),
-    fetchJson<Array<{ headline?: string; summary?: string }>>(
+    finnhubFetch<Array<{ headline?: string; summary?: string }>>(
       `https://finnhub.io/api/v1/company-news?symbol=${ticker}&from=${from}&to=${to}&token=${FINNHUB_KEY}`
     ),
   ]);
@@ -408,7 +389,7 @@ const sectorCache = new Map<string, string>();
 
 async function getStockSector(ticker: string): Promise<string> {
   if (sectorCache.has(ticker)) return sectorCache.get(ticker)!;
-  const data = await fetchJson<{ finnhubIndustry?: string }>(
+  const data = await finnhubFetch<{ finnhubIndustry?: string }>(
     `https://finnhub.io/api/v1/stock/profile2?symbol=${ticker}&token=${FINNHUB_KEY}`
   );
   const sector = data?.finnhubIndustry ?? 'Unknown';

--- a/auto-trader/src/lib/penny-scanner.ts
+++ b/auto-trader/src/lib/penny-scanner.ts
@@ -55,7 +55,8 @@ interface PennyEntrySignal {
 
 // ── Constants ────────────────────────────────────────────
 
-const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
+
 const YAHOO_HEADERS = {
   'User-Agent': 'Mozilla/5.0 (compatible; PortfolioAssistant/1.0)',
   Accept: 'application/json',
@@ -71,26 +72,9 @@ const MAX_FLOAT_MILLIONS = 10;
 const MIN_RR = 2.0;
 const MAX_PULLBACKS = 2;
 
-// ── Rate-limited Finnhub fetch ───────────────────────────
+// ── Finnhub fetch alias ──────────────────────────────────
 
-let _lastFinnhubCall = 0;
-const FINNHUB_GAP_MS = 900;
-
-async function fetchFinnhub<T>(url: string): Promise<T | null> {
-  const wait = FINNHUB_GAP_MS - (Date.now() - _lastFinnhubCall);
-  if (wait > 0) await new Promise(r => setTimeout(r, wait));
-  _lastFinnhubCall = Date.now();
-  try {
-    const res = await fetch(url, {
-      headers: YAHOO_HEADERS,
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-    });
-    if (!res.ok) return null;
-    return await res.json() as T;
-  } catch {
-    return null;
-  }
-}
+const fetchFinnhub = finnhubFetch;
 
 // ── Session State ────────────────────────────────────────
 

--- a/auto-trader/src/lib/tradePerformanceLog.ts
+++ b/auto-trader/src/lib/tradePerformanceLog.ts
@@ -6,6 +6,7 @@
 import { getSupabase } from './supabase.js';
 import type { PaperTrade } from './supabase.js';
 import type { AccountType } from '../../../shared/trade-types.js';
+import { finnhubFetch } from './finnhub.js';
 
 // ── Regime helper (SPY SMA50/SMA200 + VIX, cached per day) ─────────────────
 
@@ -40,17 +41,12 @@ async function fetchYahooBars(symbol: string): Promise<{ closes: number[] } | nu
 }
 
 async function fetchVix(): Promise<number | null> {
-  const FINNHUB_BASE = 'https://finnhub.io/api/v1';
   const key = process.env.FINNHUB_API_KEY ?? '';
   if (!key) return null;
-  try {
-    const res = await fetch(`${FINNHUB_BASE}/quote?symbol=VIX&token=${key}`);
-    if (!res.ok) return null;
-    const data = (await res.json()) as { c?: number };
-    return data.c != null && data.c > 0 ? data.c : null;
-  } catch {
-    return null;
-  }
+  const data = await finnhubFetch<{ c?: number }>(
+    `https://finnhub.io/api/v1/quote?symbol=VIX&token=${key}`,
+  );
+  return data?.c != null && data.c > 0 ? data.c : null;
 }
 
 function vixToBucket(vix: number | null): RegimeSnapshot['vix_bucket'] {

--- a/auto-trader/src/lib/watchlist-screener.ts
+++ b/auto-trader/src/lib/watchlist-screener.ts
@@ -23,8 +23,7 @@
  */
 
 import { getSupabase, createAutoTradeEvent } from './supabase.js';
-
-const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
+import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
 
 // Curated universe of S&P 500 / Nasdaq 100 candidates beyond what's already on the watchlist.
 // Covers dividend aristocrats, large-cap tech, quality growth, and high-IV momentum names.
@@ -65,19 +64,7 @@ interface FinnhubProfile {
   exchange?: string;
 }
 
-let _lastCall = 0;
-async function fetchJson<T>(url: string): Promise<T | null> {
-  try {
-    const wait = 900 - (Date.now() - _lastCall);
-    if (wait > 0) await new Promise(r => setTimeout(r, wait));
-    _lastCall = Date.now();
-    const res = await fetch(url);
-    if (!res.ok) return null;
-    return res.json() as Promise<T>;
-  } catch {
-    return null;
-  }
-}
+const fetchJson = finnhubFetch;
 
 function assignTier(beta: number): 'STABLE' | 'GROWTH' | 'HIGH_VOL' {
   if (beta < 0.9) return 'STABLE';

--- a/auto-trader/src/routes/market-data.ts
+++ b/auto-trader/src/routes/market-data.ts
@@ -8,6 +8,7 @@
  */
 
 import { Router } from 'express';
+import { finnhubFetch, FINNHUB_KEY, FINNHUB_BASE } from '../lib/finnhub.js';
 
 const router = Router();
 
@@ -58,9 +59,6 @@ router.get('/regime/spy', async (_req, res) => {
   }
 });
 
-const FINNHUB_BASE = 'https://finnhub.io/api/v1';
-const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
-
 // ── Sector lookup via Finnhub company profile ──
 
 router.get('/sector/:symbol', async (req, res) => {
@@ -69,16 +67,14 @@ router.get('/sector/:symbol', async (req, res) => {
   if (!FINNHUB_KEY) return res.status(500).json({ error: 'FINNHUB_API_KEY not configured' });
 
   try {
-    const url = `${FINNHUB_BASE}/stock/profile2?symbol=${symbol}&token=${FINNHUB_KEY}`;
-    const response = await fetch(url);
-    if (!response.ok) {
-      return res.status(404).json({ error: `Could not fetch profile for ${symbol}` });
-    }
-    const data = await response.json() as {
+    const data = await finnhubFetch<{
       finnhubIndustry?: string;
       name?: string;
       ticker?: string;
-    };
+    }>(`${FINNHUB_BASE}/stock/profile2?symbol=${symbol}&token=${FINNHUB_KEY}`);
+    if (!data) {
+      return res.status(404).json({ error: `Could not fetch profile for ${symbol}` });
+    }
 
     res.json({
       symbol,
@@ -100,19 +96,13 @@ router.get('/earnings/:symbol', async (req, res) => {
   if (!FINNHUB_KEY) return res.status(500).json({ error: 'FINNHUB_API_KEY not configured' });
 
   try {
-    // Search for next earnings within 30 days
     const from = new Date().toISOString().slice(0, 10);
     const to = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-    const url = `${FINNHUB_BASE}/calendar/earnings?symbol=${symbol}&from=${from}&to=${to}&token=${FINNHUB_KEY}`;
-    const response = await fetch(url);
-    if (!response.ok) {
-      return res.json({ symbol, earningsDate: null });
-    }
-    const data = await response.json() as {
+    const data = await finnhubFetch<{
       earningsCalendar?: Array<{ date?: string; symbol?: string }>;
-    };
+    }>(`${FINNHUB_BASE}/calendar/earnings?symbol=${symbol}&from=${from}&to=${to}&token=${FINNHUB_KEY}`);
 
-    const calendar = data.earningsCalendar ?? [];
+    const calendar = data?.earningsCalendar ?? [];
     const nextEarnings = calendar.find(e => e.symbol === symbol);
 
     res.json({
@@ -121,7 +111,7 @@ router.get('/earnings/:symbol', async (req, res) => {
     });
   } catch (err) {
     console.error(`[Route: earnings] ${symbol}:`, err);
-    res.json({ symbol, earningsDate: null }); // fail open
+    res.json({ symbol, earningsDate: null });
   }
 });
 

--- a/auto-trader/src/routes/positions.ts
+++ b/auto-trader/src/routes/positions.ts
@@ -7,17 +7,14 @@
 
 import { Router } from 'express';
 import { requestPositions } from '../ib-connection.js';
+import { finnhubFetch, FINNHUB_KEY, FINNHUB_BASE } from '../lib/finnhub.js';
 
 const router = Router();
 
-const FINNHUB_BASE = 'https://finnhub.io/api/v1';
-const FINNHUB_KEY = process.env.FINNHUB_API_KEY ?? '';
-
 /** In-memory price cache: symbol → { price, fetchedAt } */
 const priceCache = new Map<string, { price: number | null; fetchedAt: number }>();
-const CACHE_TTL_MS = 5 * 60_000; // 5-minute TTL — re-fetch at most once per 5 minutes
+const CACHE_TTL_MS = 5 * 60_000;
 
-/** Fetch current price for a ticker from Finnhub. Returns null on failure. */
 async function getQuotePrice(symbol: string): Promise<number | null> {
   if (!FINNHUB_KEY) return null;
 
@@ -26,18 +23,12 @@ async function getQuotePrice(symbol: string): Promise<number | null> {
     return cached.price;
   }
 
-  try {
-    const res = await fetch(
-      `${FINNHUB_BASE}/quote?symbol=${symbol.toUpperCase()}&token=${FINNHUB_KEY}`
-    );
-    if (!res.ok) return null;
-    const data = await res.json() as { c?: number };
-    const price = data.c && data.c > 0 ? data.c : null;
-    priceCache.set(symbol, { price, fetchedAt: Date.now() });
-    return price;
-  } catch {
-    return null;
-  }
+  const data = await finnhubFetch<{ c?: number }>(
+    `${FINNHUB_BASE}/quote?symbol=${symbol.toUpperCase()}&token=${FINNHUB_KEY}`,
+  );
+  const price = data?.c && data.c > 0 ? data.c : null;
+  priceCache.set(symbol, { price, fetchedAt: Date.now() });
+  return price;
 }
 
 const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms));

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -97,6 +97,7 @@ import { evaluateVwapAlignment, detectVwapReclaim } from './lib/vwap.js';
 import { checkTrendFilter } from './lib/trend-filter.js';
 import { getStreakMultiplier } from './lib/streak-tracker.js';
 import { getEconDayProfile } from './lib/econ-calendar.js';
+import { finnhubFetch } from './lib/finnhub.js';
 import { warmPositionPriceCache } from './routes/positions.js';
 import { generateMorningBrief } from './lib/morning-brief.js';
 import { validateOrder } from './lib/validateOrder.js';
@@ -188,7 +189,7 @@ interface StrategyVideoRecord {
   reelUrl?: string;
   canonicalUrl?: string;
   videoHeading?: string;
-  strategyType?: 'daily_signal' | 'generic_strategy';
+  strategyType?: 'daily_signal' | 'daily_penny' | 'generic_strategy';
   timeframe?: 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM';
   applicableTimeframes?: Array<'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM'>;
   executionWindowEt?: {
@@ -1544,7 +1545,7 @@ async function loadStrategyVideos(): Promise<StrategyVideoRecord[]> {
     reelUrl: r.reel_url ?? undefined,
     canonicalUrl: r.canonical_url ?? undefined,
     videoHeading: r.video_heading ?? undefined,
-    strategyType: (r.strategy_type === 'daily_signal' || r.strategy_type === 'generic_strategy' ? r.strategy_type : undefined) as StrategyVideoRecord['strategyType'],
+    strategyType: (r.strategy_type === 'daily_signal' || r.strategy_type === 'daily_penny' || r.strategy_type === 'generic_strategy' ? r.strategy_type : undefined) as StrategyVideoRecord['strategyType'],
     timeframe: (r.timeframe === 'DAY_TRADE' || r.timeframe === 'SWING_TRADE' || r.timeframe === 'LONG_TERM' ? r.timeframe : undefined) as StrategyVideoRecord['timeframe'],
     applicableTimeframes: (() => {
       const arr = r.applicable_timeframes ?? [];
@@ -1559,9 +1560,9 @@ async function loadStrategyVideos(): Promise<StrategyVideoRecord[]> {
     status: 'tracked',
   }));
 
-  // daily_signal videos expire after their trade date; generic_strategy are ongoing
+  // daily_signal / daily_penny videos expire after their trade date; generic_strategy are ongoing
   return mapped.filter(v => {
-    if (v.strategyType === 'daily_signal' && v.tradeDate) {
+    if ((v.strategyType === 'daily_signal' || v.strategyType === 'daily_penny') && v.tradeDate) {
       const tradeDate = normalizeDateToEtIso(v.tradeDate);
       if (tradeDate && tradeDate < todayET) return false; // expired
     }
@@ -1573,7 +1574,7 @@ async function autoQueueDailySignalsFromTrackedVideos(): Promise<void> {
   const todayET = getETDateString();
   const videos = await loadStrategyVideos();
   const dailyVideos = videos.filter(v =>
-    v.strategyType === 'daily_signal' &&
+    (v.strategyType === 'daily_signal' || v.strategyType === 'daily_penny') &&
     normalizeDateToEtIso(v.tradeDate) === todayET &&
     Array.isArray(v.extractedSignals) &&
     (v.extractedSignals?.length ?? 0) > 0
@@ -2055,14 +2056,10 @@ async function shouldMarkStrategyX(signal: ExternalStrategySignal): Promise<{
 
 async function getQuotePrice(symbol: string): Promise<number | null> {
   if (!FINNHUB_KEY) return null;
-  try {
-    const res = await fetch(
-      `${FINNHUB_BASE}/quote?symbol=${symbol.toUpperCase()}&token=${FINNHUB_KEY}`
-    );
-    if (!res.ok) return null;
-    const data = await res.json() as { c?: number };
-    return data.c && data.c > 0 ? data.c : null;
-  } catch { return null; }
+  const data = await finnhubFetch<{ c?: number }>(
+    `${FINNHUB_BASE}/quote?symbol=${symbol.toUpperCase()}&token=${FINNHUB_KEY}`,
+  );
+  return data?.c && data.c > 0 ? data.c : null;
 }
 
 // ── Swing entry log (post-trade metrics — collect only) ──
@@ -2774,18 +2771,14 @@ async function getTickerSector(ticker: string): Promise<string | null> {
   const cached = _sectorCache.get(ticker.toUpperCase());
   if (cached) return cached;
   if (!FINNHUB_KEY) return null;
-  try {
-    const res = await fetch(
-      `${FINNHUB_BASE}/stock/profile2?symbol=${ticker.toUpperCase()}&token=${FINNHUB_KEY}`
-    );
-    if (!res.ok) return null;
-    const data = await res.json() as { finnhubIndustry?: string };
-    if (data.finnhubIndustry) {
-      _sectorCache.set(ticker.toUpperCase(), data.finnhubIndustry);
-      return data.finnhubIndustry;
-    }
-    return null;
-  } catch { return null; }
+  const data = await finnhubFetch<{ finnhubIndustry?: string }>(
+    `${FINNHUB_BASE}/stock/profile2?symbol=${ticker.toUpperCase()}&token=${FINNHUB_KEY}`,
+  );
+  if (data?.finnhubIndustry) {
+    _sectorCache.set(ticker.toUpperCase(), data.finnhubIndustry);
+    return data.finnhubIndustry;
+  }
+  return null;
 }
 
 async function checkSectorExposure(
@@ -2818,13 +2811,12 @@ async function checkEarningsBlackout(
   try {
     const from = new Date().toISOString().slice(0, 10);
     const to = new Date(Date.now() + 30 * 86400000).toISOString().slice(0, 10);
-    const res = await fetch(
-      `${FINNHUB_BASE}/calendar/earnings?symbol=${ticker.toUpperCase()}&from=${from}&to=${to}&token=${FINNHUB_KEY}`
-    );
-    if (!res.ok) return true;
-    const data = await res.json() as {
+    const data = await finnhubFetch<{
       earningsCalendar?: { date?: string; symbol?: string }[];
-    };
+    }>(
+      `${FINNHUB_BASE}/calendar/earnings?symbol=${ticker.toUpperCase()}&from=${from}&to=${to}&token=${FINNHUB_KEY}`,
+    );
+    if (!data) return true;
     const next = data.earningsCalendar?.find(e => e.symbol === ticker.toUpperCase());
     if (next?.date) {
       const daysUntil = (new Date(next.date).getTime() - Date.now()) / 86400000;

--- a/supabase/functions/assign-strategy-videos-to-source/index.ts
+++ b/supabase/functions/assign-strategy-videos-to-source/index.ts
@@ -183,7 +183,7 @@ Deno.serve(async (req) => {
     source_name: sourceName,
     updated_at: new Date().toISOString(),
   };
-  if (body.strategy_type === 'daily_signal' || body.strategy_type === 'generic_strategy') {
+  if (body.strategy_type === 'daily_signal' || body.strategy_type === 'daily_penny' || body.strategy_type === 'generic_strategy') {
     updatePayload.strategy_type = body.strategy_type;
   }
   const { error: updateErr } = await supabase

--- a/supabase/functions/extract-strategy-metadata-from-transcript/index.ts
+++ b/supabase/functions/extract-strategy-metadata-from-transcript/index.ts
@@ -30,7 +30,7 @@ Return a single JSON object (no markdown, no code block) with these fields. Use 
 {
   "source_name": "Display name of creator/channel (e.g. 'Somesh | Day Trader | Investor', 'Casper Clipping')",
   "source_handle": "Instagram/Twitter handle if mentioned (e.g. 'kaycapitals', 'casperclipping'). Lowercase, no @.",
-  "strategy_type": "daily_signal" | "generic_strategy",
+  "strategy_type": "daily_signal" | "daily_penny" | "generic_strategy",
   "video_heading": "Short title summarizing the strategy (e.g. '4 stocks day-trading gameplan for Thursday')",
   "trade_date": "YYYY-MM-DD if date-specific (daily_signal), else null",
   "timeframe": "DAY_TRADE" | "SWING_TRADE" | "LONG_TERM" | null,
@@ -43,6 +43,7 @@ Return a single JSON object (no markdown, no code block) with these fields. Use 
 
 Rules:
 - daily_signal: video gives concrete levels (entry, stop, target) for specific stocks today. Use extracted_signals.
+- daily_penny: video discusses a penny stock / small-cap watchlist for the day — stocks typically $2-$20, low float, momentum/gap plays. Creators like Ross Cameron / Warrior Trading. Use extracted_signals for the tickers mentioned as watchlist candidates (set longTriggerAbove to the current price or breakout level if given, targets optional). Key difference from daily_signal: these are low-priced, speculative momentum names — not large-cap level-based setups.
 - generic_strategy: general rules, patterns, SMC concepts (no specific levels). extracted_signals = [].
 - source_name: from intro ("Hey it's Somesh from Kay Capitals"), outro, or channel branding. Humanize (e.g. "Kay Capitals" → "Somesh | Day Trader | Investor" if known).
 - source_handle: Instagram handle if mentioned. Infer from source_name (e.g. "Casper Clipping" → "casperclipping").
@@ -50,7 +51,7 @@ Rules:
 - longTriggerAbove / shortTriggerBelow / longTargets / shortTargets: MUST be actual dollar prices, NOT percentages. META trades near $600, TSLA near $300-$500, NVDA near $100-$200, SPY near $500-$700, QQQ near $400-$600. If the numbers you extracted are in single digits or look like percentages (e.g. 5.96, 6.1), you made an error — re-read the transcript and extract the real dollar price. A number like "6.1" for META means nothing; the real level would be something like $610 or $608.
 - ATH / all-time-high language: if the transcript says "above ATH" or "new all-time high" for the long trigger without giving a specific number, set longTriggerAbove = shortTriggerBelow (use the short trigger level as a proxy). If shortTriggerBelow is also missing, use shortTargets[0]. Never leave BOTH longTriggerAbove and shortTriggerBelow null when the transcript gives any price levels for that ticker.
 - "below X" always maps to shortTriggerBelow=X. "above X" always maps to longTriggerAbove=X. Extract these directly from the transcript — do not leave them null if a number is present.
-- trade_date: only for daily_signal when date is explicit (e.g. "for Thursday", "today's levels").
+- trade_date: for daily_signal or daily_penny when date is explicit (e.g. "for Thursday", "today's levels", "Monday morning watchlist").
 - execution_window_et: only if time window is specified (e.g. "9:30-9:35 levels", "first candle rule").
 - setup_type: how the influencer intends execution:
     "breakout"     — enter when price breaks above/below a pre-market high/low with volume (most common for daily signals with trigger levels)
@@ -186,11 +187,16 @@ Deno.serve(async (req) => {
 
   // ── Step 2: LLM extraction — transcript already saved, so failures are non-fatal ──
   const todayEt = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' }); // YYYY-MM-DD
+  const PENNY_CREATOR_NAMES = ['Ross Cameron', 'Warrior Trading'];
+  const PENNY_CREATOR_HANDLES = ['warrior_trading', 'warriortrading', 'rosscameron'];
+  const isPennyCreator = (uploaderName && PENNY_CREATOR_NAMES.some(n => uploaderName.includes(n)))
+    || (uploaderHandle && PENNY_CREATOR_HANDLES.includes(uploaderHandle.toLowerCase()));
   const contextLines = [
     `Today's date (ET): ${todayEt}`,
     uploaderName ? `Creator name (from platform metadata, authoritative): ${uploaderName}` : null,
     uploaderHandle ? `Creator handle (from platform metadata, authoritative): @${uploaderHandle}` : null,
     videoDescription ? `Video caption/description: ${videoDescription}` : null,
+    isPennyCreator ? `HINT: This creator is a known penny stock / small-cap momentum trader. Use strategy_type = "daily_penny" if the video discusses a watchlist or specific penny stock tickers. Only use "generic_strategy" if the video is purely educational with no ticker mentions.` : null,
   ].filter(Boolean).join('\n');
   const tomorrowEtForPrompt = (() => {
     const d = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
@@ -253,8 +259,9 @@ Deno.serve(async (req) => {
     }
   }
 
-  const extractedStrategyType = extracted.strategy_type === 'daily_signal' || extracted.strategy_type === 'generic_strategy'
-    ? extracted.strategy_type : null;
+  const VALID_STRATEGY_TYPES = ['daily_signal', 'daily_penny', 'generic_strategy'] as const;
+  const extractedStrategyType = VALID_STRATEGY_TYPES.includes(extracted.strategy_type as typeof VALID_STRATEGY_TYPES[number])
+    ? (extracted.strategy_type as string) : null;
   let strategy_type = extractedStrategyType;
   const video_heading = extracted.video_heading ? String(extracted.video_heading).trim() : null;
   // Only accept ISO date strings — reject relative values like "Friday", "tomorrow", etc.
@@ -264,7 +271,7 @@ Deno.serve(async (req) => {
   // Creators often upload the next trading day's gameplan the night before (pre-market), so a
   // date 1 calendar day in the future is valid and should NOT be clamped. Anything further is
   // an LLM inference error.
-  if (trade_date && extractedStrategyType === 'daily_signal') {
+  if (trade_date && (extractedStrategyType === 'daily_signal' || extractedStrategyType === 'daily_penny')) {
     const tomorrowEt = new Date(
       new Date().toLocaleString('en-US', { timeZone: 'America/New_York' })
     );
@@ -329,8 +336,15 @@ Deno.serve(async (req) => {
   if (strategy_type === 'generic_strategy' && extracted_signals.some((s: Record<string, unknown>) =>
     s.longTriggerAbove != null || s.shortTriggerBelow != null
   )) {
-    console.warn(`[extract] Overriding strategy_type: generic_strategy → daily_signal (video has concrete price levels)`);
-    strategy_type = 'daily_signal';
+    const overrideTo = isPennyCreator ? 'daily_penny' : 'daily_signal';
+    console.warn(`[extract] Overriding strategy_type: generic_strategy → ${overrideTo} (video has concrete price levels)`);
+    strategy_type = overrideTo;
+  }
+
+  // Known penny creators: if LLM returned daily_signal instead of daily_penny, correct it
+  if (isPennyCreator && strategy_type === 'daily_signal') {
+    console.warn(`[extract] Overriding strategy_type: daily_signal → daily_penny (known penny creator)`);
+    strategy_type = 'daily_penny';
   }
 
   const summary = extracted.summary ? String(extracted.summary).trim() : null;
@@ -374,7 +388,7 @@ Deno.serve(async (req) => {
 
   // For daily_signal videos with extracted signals: auto-import into external_strategy_signals
   // so the auto-trader picks them up on trade_date. Fire-and-forget (non-blocking).
-  if (strategy_type === 'daily_signal' && extracted_signals.length > 0) {
+  if ((strategy_type === 'daily_signal' || strategy_type === 'daily_penny') && extracted_signals.length > 0) {
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
     const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
     fetch(`${supabaseUrl}/functions/v1/import-strategy-signals`, {

--- a/supabase/functions/import-strategy-signals/index.ts
+++ b/supabase/functions/import-strategy-signals/index.ts
@@ -112,12 +112,14 @@ Deno.serve(async (req) => {
     });
   }
 
-  if (video.strategy_type !== 'daily_signal') {
+  if (video.strategy_type !== 'daily_signal' && video.strategy_type !== 'daily_penny') {
     return new Response(
-      JSON.stringify({ ok: true, skipped: true, reason: 'Not a daily_signal — no signals to import' }),
+      JSON.stringify({ ok: true, skipped: true, reason: 'Not a daily_signal or daily_penny — no signals to import' }),
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
+
+  const isPenny = video.strategy_type === 'daily_penny';
 
   const signals = (Array.isArray(video.extracted_signals) ? video.extracted_signals : []) as ExtractedSignal[];
   if (signals.length === 0) {
@@ -154,12 +156,14 @@ Deno.serve(async (req) => {
   // Determine mode from timeframe / applicable_timeframes
   const applicableTimeframes = Array.isArray(video.applicable_timeframes) ? video.applicable_timeframes : [];
   const timeframe = (video.timeframe as string | null) ?? null;
-  const primaryMode: 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM' =
-    applicableTimeframes.includes('DAY_TRADE') || timeframe === 'DAY_TRADE'
+  const primaryMode: 'DAY_TRADE' | 'SWING_TRADE' | 'LONG_TERM' | 'DAY_PENNY' =
+    isPenny
+      ? 'DAY_PENNY'
+      : applicableTimeframes.includes('DAY_TRADE') || timeframe === 'DAY_TRADE'
       ? 'DAY_TRADE'
       : applicableTimeframes.includes('SWING_TRADE') || timeframe === 'SWING_TRADE'
       ? 'SWING_TRADE'
-      : 'DAY_TRADE'; // default to day trade for daily signals
+      : 'DAY_TRADE';
 
   // Build execute_at / expires_at from execution_window_et.
   // Influencer pre-market setups have different timing needs per setup type.
@@ -181,13 +185,19 @@ Deno.serve(async (req) => {
     expiresAt = toUtcTimestamp(tradeDate, executionWindow.end);
   }
 
-  if (primaryMode === 'DAY_TRADE') {
+  if (primaryMode === 'DAY_PENNY') {
+    // Penny momentum window: 7:00 AM pre-market scan through 10:00 AM ET
     if (!executeAt) {
-      executeAt = toUtcTimestamp(tradeDate, '09:35'); // skip opening 5 min chaos
+      executeAt = toUtcTimestamp(tradeDate, '09:35');
     }
     if (!expiresAt) {
-      // Expiry depends on setup type — tighter for breakout (thesis fails quickly),
-      // wider for pullback/range plays that need time to develop
+      expiresAt = toUtcTimestamp(tradeDate, '10:00');
+    }
+  } else if (primaryMode === 'DAY_TRADE') {
+    if (!executeAt) {
+      executeAt = toUtcTimestamp(tradeDate, '09:35');
+    }
+    if (!expiresAt) {
       const expiryBySetup: Record<string, string> = {
         breakout:      '11:00',
         momentum:      '12:00',

--- a/supabase/functions/process-strategy-video-queue/index.ts
+++ b/supabase/functions/process-strategy-video-queue/index.ts
@@ -55,9 +55,26 @@ const KNOWN_SIGNAL_HANDLES = new Set([
   'kaycapitals',
 ]);
 
+const KNOWN_PENNY_GENERATORS = new Set([
+  'Ross Cameron',
+  'Warrior Trading',
+]);
+
+const KNOWN_PENNY_HANDLES = new Set([
+  'warrior_trading',
+  'warriortrading',
+  'rosscameron',
+]);
+
 function isKnownSignalGenerator(sourceName: string, sourceHandle: string | null): boolean {
   if (KNOWN_SIGNAL_GENERATORS.has(sourceName)) return true;
   if (sourceHandle && KNOWN_SIGNAL_HANDLES.has(sourceHandle.toLowerCase())) return true;
+  return false;
+}
+
+function isKnownPennyGenerator(sourceName: string, sourceHandle: string | null): boolean {
+  if (KNOWN_PENNY_GENERATORS.has(sourceName)) return true;
+  if (sourceHandle && KNOWN_PENNY_HANDLES.has(sourceHandle.toLowerCase())) return true;
   return false;
 }
 
@@ -184,7 +201,9 @@ Deno.serve(async (req) => {
       reel_url: parsed.platform === 'instagram' ? item.url : null,
       canonical_url: parsed.platform !== 'instagram' ? item.url : null,
       video_heading: null,
-      strategy_type: isKnownSignalGenerator(sourceName, sourceHandle) ? 'daily_signal' : null,
+      strategy_type: isKnownPennyGenerator(sourceName, sourceHandle)
+        ? 'daily_penny'
+        : isKnownSignalGenerator(sourceName, sourceHandle) ? 'daily_signal' : null,
       timeframe: null,
       applicable_timeframes: [],
       status: 'tracked',

--- a/supabase/functions/update-strategy-video-metadata/index.ts
+++ b/supabase/functions/update-strategy-video-metadata/index.ts
@@ -55,7 +55,7 @@ Deno.serve(async (req) => {
   if (sourceName) updates.source_name = sourceName;
 
   const strategyType = body.strategy_type;
-  if (strategyType === 'daily_signal' || strategyType === 'generic_strategy') {
+  if (strategyType === 'daily_signal' || strategyType === 'daily_penny' || strategyType === 'generic_strategy') {
     updates.strategy_type = strategyType;
   }
 

--- a/supabase/functions/upsert-strategy-video/index.ts
+++ b/supabase/functions/upsert-strategy-video/index.ts
@@ -18,7 +18,7 @@ interface UpsertPayload {
   reel_url?: string;
   canonical_url?: string;
   video_heading?: string;
-  strategy_type?: 'daily_signal' | 'generic_strategy';
+  strategy_type?: 'daily_signal' | 'daily_penny' | 'generic_strategy';
   timeframe?: string;
   applicable_timeframes?: string[];
   execution_window_et?: { start?: string; end?: string };

--- a/supabase/migrations/20260518000001_daily_penny_strategy_type.sql
+++ b/supabase/migrations/20260518000001_daily_penny_strategy_type.sql
@@ -1,0 +1,20 @@
+-- Add daily_penny as a strategy_type for penny stock watchlist videos
+-- (e.g. Ross Cameron / Warrior Trading daily watchlist recaps).
+-- Also extend external_strategy_signals.mode to accept DAY_PENNY so
+-- penny watchlist signals can flow through the same import pipeline.
+
+-- 1. strategy_videos: extend strategy_type CHECK
+ALTER TABLE strategy_videos
+  DROP CONSTRAINT IF EXISTS strategy_videos_strategy_type_check;
+
+ALTER TABLE strategy_videos
+  ADD CONSTRAINT strategy_videos_strategy_type_check
+    CHECK (strategy_type IN ('daily_signal', 'generic_strategy', 'daily_penny'));
+
+-- 2. external_strategy_signals: extend mode CHECK to include DAY_PENNY
+ALTER TABLE external_strategy_signals
+  DROP CONSTRAINT IF EXISTS external_strategy_signals_mode_check;
+
+ALTER TABLE external_strategy_signals
+  ADD CONSTRAINT external_strategy_signals_mode_check
+    CHECK (mode IN ('DAY_TRADE', 'SWING_TRADE', 'LONG_TERM', 'DAY_PENNY'));


### PR DESCRIPTION
## Summary

- Introduces `auto-trader/src/lib/finnhub.ts` — a centralized Finnhub API client with a sliding-window rate limiter (55 req/60s headroom) and 2-min response cache, so all scanners share one API budget and avoid redundant calls.
- Migrates all direct `fetch(finnhub...)` call sites across 15 scanner/route modules to use `finnhubFetch()`, eliminating scattered rate-limit 429 errors.
- Adds `daily_penny` strategy type end-to-end (DB migration, edge functions, scheduler, frontend) to support penny-stock daily watchlist videos (e.g. Warrior Trading).

## Test plan

- [x] `npm run build` passes cleanly in `app/`
- [x] Auto-trader already rebuilt and restarted with these changes
- [ ] Verify Finnhub rate-limit log messages appear under load instead of 429 errors
- [ ] Confirm daily_penny videos display correctly in Strategy Performance tab


Made with [Cursor](https://cursor.com)