### PR TITLE
Fix IB gateway stale session: auto-reconnect after consecutive code-200 rejections

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -169,6 +169,9 @@ export class IBConnection {
   private _activeRequests = 0;
   private _requestQueue: Array<() => void> = [];
 
+  private _consecutiveCode200 = 0;
+  private static readonly CODE_200_RECONNECT_THRESHOLD = 3;
+
   private get tag(): string { return `[IB:${this.label}]`; }
 
   constructor(label: AccountType, port: number, clientId: number) {
@@ -299,6 +302,20 @@ export class IBConnection {
         const msg = `IB order ${reqId} (${pending.symbol}) rejected: code=${code} ${err.message}`;
         console.error(`${this.tag} ${msg}`);
         pending.reject(new Error(msg));
+
+        if (code === 200) {
+          this._consecutiveCode200++;
+          if (this._consecutiveCode200 >= IBConnection.CODE_200_RECONNECT_THRESHOLD) {
+            console.error(`${this.tag} ⚠️ ${this._consecutiveCode200} consecutive code-200 rejections — gateway session likely degraded, forcing reconnect`);
+            this._consecutiveCode200 = 0;
+            this._connected = false;
+            this.connectionListeners.forEach(fn => fn(false));
+            try { this.ib?.disconnect(); } catch { /* ignore */ }
+            this.scheduleReconnect();
+          }
+        } else {
+          this._consecutiveCode200 = 0;
+        }
         return;
       }
 
@@ -346,6 +363,7 @@ export class IBConnection {
     ) => {
       if (status === 'Filled' && avgFillPrice > 0) {
         this._orderFillPrices.set(orderId, avgFillPrice);
+        this._consecutiveCode200 = 0;
         console.log(`${this.tag} Order ${orderId} filled @ $${avgFillPrice.toFixed(4)}`);
 
         if (this._pendingOrderCallbacks.has(orderId)) {
@@ -794,7 +812,7 @@ export class IBConnection {
 
       try {
         this.ib.placeOrder(orderId, contract, order);
-        console.log(`${this.tag} Options order dispatched: SELL ${contracts}x ${symbol} $${strike}${right} ${expiry} @ $${limitPrice} (orderId=${orderId}) — awaiting fill...`);
+        console.log(`${this.tag} Options order dispatched: SELL ${contracts}x ${symbol} $${strike}${right} ${expiry} @ $${limitPrice} (orderId=${orderId}, contract=${JSON.stringify(contract)}) — awaiting fill...`);
       } catch (err) {
         clearTimeout(timer);
         this._pendingOrderCallbacks.delete(orderId);


### PR DESCRIPTION
## Summary
- When the IB gateway session degrades, contract lookups fail with code-200 ("No security definition has been found"). This adds auto-reconnect logic: after **3 consecutive code-200 rejections**, the connection is torn down and reconnected automatically.
- The consecutive counter resets on any successful order fill or any non-200 error code, so isolated code-200 errors don't trigger unnecessary reconnects.
- Adds contract JSON to options order dispatch log lines for easier debugging of contract-related failures.

## Test plan
- [x] Auto-trader rebuilt and restarted with new code
- [ ] Monitor logs for code-200 reconnect behavior during next trading session
- [ ] Verify normal order flow is unaffected (counter resets on fills)


Made with [Cursor](https://cursor.com)