### PR TITLE
Fix Phase 2: IB close execution for options/spreads, bracket cancellation, and P&L display

### DIFF
--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -441,9 +441,10 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
               const AUTO_CLOSE_SOURCES = new Set(['lt_auto_sell', 'swing_expiry', 'capital_pressure']);
               const isAutoClose = AUTO_CLOSE_SOURCES.has(event.source ?? '');
               const metaPnl = isPositionSync && event.metadata ? (event.metadata as { pnl?: number }).pnl : undefined;
-              const eventPnl = metaPnl ?? matched?.pnl;
-              const pnl = eventPnl ?? null;
               const terminalStatuses = [...CLOSED_STATUSES, ...EXCLUDED_STATUSES] as string[];
+              const isRealizedClose = matched?.close_price != null || terminalStatuses.includes(matched?.status ?? '');
+              const eventPnl = metaPnl ?? (isRealizedClose ? matched?.pnl : undefined);
+              const pnl = eventPnl ?? null;
               const isClosed = isPositionSync || isAutoClose || (matched?.close_price != null) || terminalStatuses.includes(matched?.status ?? '');
               const isActive = !isClosed && matched && ['FILLED', 'PARTIAL'].includes(matched.status);
               const msg = event.message;

--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -97,6 +97,7 @@ export interface OptionsOrderParams {
   contracts: number;
   limitPrice: number;
   account?: string;
+  action?: 'BUY' | 'SELL';
 }
 
 export interface OptionsOrderResult {
@@ -129,6 +130,7 @@ export interface VerticalSpreadOrderParams {
   contracts: number;
   limitPrice: number;
   account?: string;
+  action?: 'BUY' | 'SELL';
 }
 
 export interface VerticalSpreadOrderResult {
@@ -791,8 +793,10 @@ export class IBConnection {
 
       const orderId = this.getNextOrderId();
 
+      const orderAction = params.action === 'BUY' ? OrderAction.BUY : OrderAction.SELL;
+
       const order: Order = {
-        action: OrderAction.SELL,
+        action: orderAction,
         orderType: OrderType.LMT,
         totalQuantity: contracts,
         lmtPrice: limitPrice,
@@ -810,9 +814,10 @@ export class IBConnection {
 
       this._pendingOrderCallbacks.set(orderId, { resolve, reject, timer, symbol });
 
+      const actionLabel = params.action === 'BUY' ? 'BUY' : 'SELL';
       try {
         this.ib.placeOrder(orderId, contract, order);
-        console.log(`${this.tag} Options order dispatched: SELL ${contracts}x ${symbol} $${strike}${right} ${expiry} @ $${limitPrice} (orderId=${orderId}, contract=${JSON.stringify(contract)}) — awaiting fill...`);
+        console.log(`${this.tag} Options order dispatched: ${actionLabel} ${contracts}x ${symbol} $${strike}${right} ${expiry} @ $${limitPrice} (orderId=${orderId}) — awaiting fill...`);
       } catch (err) {
         clearTimeout(timer);
         this._pendingOrderCallbacks.delete(orderId);
@@ -960,8 +965,12 @@ export class IBConnection {
 
     const orderId = this.getNextOrderId();
 
+    const spreadAction = params.action === 'BUY' ? OrderAction.BUY : OrderAction.SELL;
+    const spreadActionLabel = params.action === 'BUY' ? 'BUY' : 'SELL';
+    const creditDebitLabel = params.action === 'BUY' ? 'net debit' : 'net credit';
+
     const order: Order = {
-      action: OrderAction.SELL,
+      action: spreadAction,
       orderType: OrderType.LMT,
       totalQuantity: contracts,
       lmtPrice: limitPrice,
@@ -972,7 +981,7 @@ export class IBConnection {
 
     try {
       this.ib.placeOrder(orderId, contract, order);
-      console.log(`${this.tag} Credit spread placed: SELL ${contracts}x ${symbol} ${sellStrike}/${buyStrike}${right} ${expiry} @ $${limitPrice} net credit (orderId=${orderId})`);
+      console.log(`${this.tag} Credit spread placed: ${spreadActionLabel} ${contracts}x ${symbol} ${sellStrike}/${buyStrike}${right} ${expiry} @ $${limitPrice} ${creditDebitLabel} (orderId=${orderId})`);
       return { orderId };
     } catch (err) {
       throw err;

--- a/auto-trader/src/lib/credit-spread-scanner.ts
+++ b/auto-trader/src/lib/credit-spread-scanner.ts
@@ -473,6 +473,44 @@ export async function manageCreditSpreadPositions(): Promise<void> {
       if (closeReason) {
         console.log(`[Credit Spread Manager] ${pos.ticker} → ${closeReason} (P&L: $${pnlTotal.toFixed(0)}, ${pnlPctOfMaxGain.toFixed(0)}% of max gain, ${dte} DTE)`);
 
+        // Place IB buy-to-close spread order before marking CLOSED
+        let ibCloseOrderId: number | null = null;
+        if (isConnected() && pos.spread_short_strike && pos.spread_long_strike && pos.option_expiry) {
+          const spreadRight = pos.spread_type === 'BULL_PUT' ? 'P' as const : 'C' as const;
+          const spreadExpiry = pos.option_expiry.replace(/-/g, '');
+          const closeLimit = Math.max(0.01, currentSpreadValue * 1.05);
+          try {
+            const closeResult = await placeVerticalSpreadOrder({
+              symbol: pos.ticker,
+              right: spreadRight,
+              sellStrike: pos.spread_short_strike,
+              buyStrike: pos.spread_long_strike,
+              expiry: spreadExpiry,
+              contracts: contracts,
+              limitPrice: closeLimit,
+              action: 'BUY',
+              account: getDefaultAccount() ?? undefined,
+            });
+            ibCloseOrderId = closeResult.orderId;
+            console.log(`[Credit Spread Manager] IB buy-to-close dispatched for ${pos.ticker} (order #${ibCloseOrderId})`);
+          } catch (ibErr) {
+            console.warn(`[Credit Spread Manager] IB buy-to-close FAILED for ${pos.ticker}: ${ibErr instanceof Error ? ibErr.message : ibErr}`);
+          }
+        }
+
+        if (!ibCloseOrderId && isConnected()) {
+          console.warn(`[Credit Spread Manager] ${pos.ticker} — close trigger ${closeReason} but IB close order failed, leaving position open for retry`);
+          await createAutoTradeEvent({
+            ticker: pos.ticker,
+            mode: 'CREDIT_SPREAD',
+            event_type: 'warning',
+            action: 'skipped',
+            message: `${pos.ticker} ${closeReason} triggered but IB buy-to-close failed — position left open for retry`,
+            metadata: { closeReason, pnl: pnlTotal, dte, pnlPctOfMaxGain },
+          });
+          continue;
+        }
+
         await sb.from('paper_trades').update({
           status: 'CLOSED',
           close_reason: closeReason,
@@ -482,13 +520,14 @@ export async function manageCreditSpreadPositions(): Promise<void> {
           closed_at: new Date().toISOString(),
         }).eq('id', pos.id);
 
+        const ibTag = ibCloseOrderId ? ` (IB #${ibCloseOrderId})` : ' (model-based, IB disconnected)';
         await createAutoTradeEvent({
           ticker: pos.ticker,
           mode: 'CREDIT_SPREAD',
           event_type: pnlTotal >= 0 ? 'success' : 'warning',
           action: 'closed',
-          message: `Closed ${pos.spread_type}: ${pos.spread_short_strike}/${pos.spread_long_strike} | ${closeReason} | P&L $${pnlTotal.toFixed(0)} (${pnlPctOfMaxGain.toFixed(0)}% of max)`,
-          metadata: { closeReason, pnl: pnlTotal, dte, pnlPctOfMaxGain },
+          message: `Closed ${pos.spread_type}: ${pos.spread_short_strike}/${pos.spread_long_strike} | ${closeReason} | P&L $${pnlTotal.toFixed(0)} (${pnlPctOfMaxGain.toFixed(0)}% of max)${ibTag}`,
+          metadata: { closeReason, pnl: pnlTotal, dte, pnlPctOfMaxGain, ibCloseOrderId },
         });
       }
     } catch (err) {

--- a/auto-trader/src/lib/options-manager.ts
+++ b/auto-trader/src/lib/options-manager.ts
@@ -149,17 +149,27 @@ async function evaluateAndRollPut(
   }
 
   // ── Execute the roll ─────────────────────────────────────
-  const pnl = (premiumCollected - currentPremium) * 100;
 
-  // 1. Close the current leg
+  // 1. Close the current leg via IB buy-to-close
+  const ibCloseOldPut = await ibBuyToCloseOption(pos.ticker, 'P', pos.option_strike, pos.option_expiry, currentPremium);
+  if (!ibCloseOldPut) {
+    return {
+      rolled: false,
+      reason: 'ib_close_failed',
+      logLine: `${pos.ticker}: IB buy-to-close failed for old put leg $${pos.option_strike}P — roll aborted`,
+    };
+  }
+  const rollClosePremium = ibCloseOldPut.avgFillPrice;
+  const pnl = (premiumCollected - rollClosePremium) * 100;
+
   await sb.from('paper_trades').update({
     status: 'CLOSED',
-    close_price: currentPremium,
+    close_price: rollClosePremium,
     pnl,
     pnl_percent: (pnl / capital) * 100,
     closed_at: new Date().toISOString(),
     close_reason: 'rolled',
-    option_close_pct: Math.max(0, (1 - currentPremium / premiumCollected) * 100),
+    option_close_pct: Math.max(0, (1 - rollClosePremium / premiumCollected) * 100),
   }).eq('id', pos.id);
 
   // 2. Open the new leg — record in DB (+ IB order if connected)
@@ -262,6 +272,39 @@ async function getCurrentCallPremium(
     return chain.bestCall.mid;
   }
   return null;
+}
+
+/**
+ * Place an IB buy-to-close order for a short option position.
+ * Returns the fill result, or null if IB is disconnected or the order fails/times out.
+ * The limit is set 5% above currentPremium (the mid) to improve fill probability;
+ * the actual fill price (avgFillPrice) is what gets used for P&L.
+ */
+async function ibBuyToCloseOption(
+  ticker: string,
+  right: 'P' | 'C',
+  strike: number,
+  expiryISO: string,
+  currentPremium: number,
+): Promise<{ orderId: number; avgFillPrice: number; filledQty: number } | null> {
+  if (!isConnected()) return null;
+  const expiry = expiryISO.replace(/-/g, '');
+  const buyLimit = Math.max(0.01, currentPremium * 1.05);
+  try {
+    return await placeOptionsOrder({
+      symbol: ticker,
+      right,
+      strike,
+      expiry,
+      contracts: 1,
+      limitPrice: buyLimit,
+      action: 'BUY',
+      account: getDefaultAccount() ?? undefined,
+    });
+  } catch (err) {
+    console.warn(`[Options Manager] IB buy-to-close FAILED for ${ticker} $${strike}${right}: ${err instanceof Error ? err.message : err}`);
+    return null;
+  }
 }
 
 // ── Load Open Positions ──────────────────────────────────
@@ -442,21 +485,32 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
     const stopLossMultiplierBreached = currentPremium > premiumCollected * stopLossMultiplier;
     const stockBelowStrike = stockPrice < pos.option_strike;
     if (stopLossMultiplierBreached && stockBelowStrike) {
-      const lossAmount = Math.abs(pnl);
+      const ibClose = await ibBuyToCloseOption(pos.ticker, 'P', pos.option_strike, pos.option_expiry, currentPremium);
+      if (!ibClose) {
+        persistEvent(pos.ticker, 'warning',
+          `⚠️ ${pos.ticker} $${pos.option_strike}P stop-loss triggered but IB buy-to-close failed — position left open for retry`,
+          { action: 'skipped', source: 'options', metadata: { reason: 'ib_close_failed', trigger: 'stop_loss', currentPremium, premiumCollected } }
+        );
+        continue;
+      }
+      const closePremium = ibClose.avgFillPrice;
+      const closePnl = (premiumCollected - closePremium) * 100;
+      const closeProfitPct = premiumCollected > 0 ? Math.max(0, (1 - closePremium / premiumCollected) * 100) : 0;
+      const lossAmount = Math.abs(closePnl);
       await sb.from('paper_trades').update({
         status: 'CLOSED',
-        close_price: currentPremium,
-        pnl,
-        pnl_percent: (pnl / (pos.option_capital_req ?? pos.option_strike * 100)) * 100,
+        close_price: closePremium,
+        pnl: closePnl,
+        pnl_percent: (closePnl / (pos.option_capital_req ?? pos.option_strike * 100)) * 100,
         closed_at: new Date().toISOString(),
         close_reason: 'stop_loss',
-        option_close_pct: profitCapturePct,
+        option_close_pct: closeProfitPct,
       }).eq('id', pos.id);
 
-      console.log(`[Options Manager] STOP-LOSS: ${pos.ticker} $${pos.option_strike}P — stock $${stockPrice.toFixed(2)} below strike + premium ${stopLossMultiplier}×+ original, closing for -$${lossAmount.toFixed(0)}`);
+      console.log(`[Options Manager] STOP-LOSS: ${pos.ticker} $${pos.option_strike}P — stock $${stockPrice.toFixed(2)} below strike + premium ${stopLossMultiplier}×+ original, closing for -$${lossAmount.toFixed(0)} (IB fill @ $${closePremium.toFixed(4)})`);
       persistEvent(pos.ticker, 'error',
-        `🛑 ${pos.ticker} $${pos.option_strike} put stopped — stock at $${stockPrice.toFixed(2)} (below strike) and premium blew past ${stopLossMultiplier}× ($${currentPremium.toFixed(2)} vs collected $${premiumCollected.toFixed(2)}), taking -$${lossAmount.toFixed(0)} loss`,
-        { action: 'closed', source: 'options', metadata: { reason: 'stop_loss', pnl, currentPremium, premiumCollected, stopLossMultiplier, stockPrice } }
+        `🛑 ${pos.ticker} $${pos.option_strike} put stopped — stock at $${stockPrice.toFixed(2)} (below strike) and premium blew past ${stopLossMultiplier}× ($${closePremium.toFixed(2)} vs collected $${premiumCollected.toFixed(2)}), taking -$${lossAmount.toFixed(0)} loss`,
+        { action: 'closed', source: 'options', metadata: { reason: 'stop_loss', pnl: closePnl, closePremium, premiumCollected, stopLossMultiplier, stockPrice, ibOrderId: ibClose.orderId } }
       );
       result.stopLossAlerts.push(pos.ticker);
       continue;
@@ -466,20 +520,31 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
     // profitClosePct is auto-tuned by Rule G (default 50%).
     // close_reason stays '50pct_profit' so Rule G's close-reason analysis works correctly.
     if (profitCapturePct >= profitClosePct) {
+      const ibClose = await ibBuyToCloseOption(pos.ticker, 'P', pos.option_strike, pos.option_expiry, currentPremium);
+      if (!ibClose) {
+        persistEvent(pos.ticker, 'warning',
+          `⚠️ ${pos.ticker} $${pos.option_strike}P profit target hit but IB buy-to-close failed — position left open for retry`,
+          { action: 'skipped', source: 'options', metadata: { reason: 'ib_close_failed', trigger: '50pct_profit', currentPremium, premiumCollected } }
+        );
+        continue;
+      }
+      const closePremium = ibClose.avgFillPrice;
+      const closePnl = (premiumCollected - closePremium) * 100;
+      const closeProfitPct = premiumCollected > 0 ? Math.max(0, (1 - closePremium / premiumCollected) * 100) : 0;
       await sb.from('paper_trades').update({
         status: 'CLOSED',
-        close_price: currentPremium,
-        pnl,
-        pnl_percent: (pnl / (pos.option_capital_req ?? pos.option_strike * 100)) * 100,
+        close_price: closePremium,
+        pnl: closePnl,
+        pnl_percent: (closePnl / (pos.option_capital_req ?? pos.option_strike * 100)) * 100,
         closed_at: new Date().toISOString(),
         close_reason: '50pct_profit',
-        option_close_pct: profitCapturePct,
+        option_close_pct: closeProfitPct,
       }).eq('id', pos.id);
 
       result.closed50Pct.push(pos.ticker);
       persistEvent(pos.ticker, 'success',
-        `💰 ${pos.ticker} $${pos.option_strike} put closed at ${profitCapturePct.toFixed(0)}% profit (target ${profitClosePct}%) — captured $${pnl.toFixed(0)}`,
-        { action: 'closed', source: 'options', metadata: { reason: '50pct_profit', pnl, profitCapturePct, profitClosePct } }
+        `💰 ${pos.ticker} $${pos.option_strike} put closed at ${closeProfitPct.toFixed(0)}% profit (target ${profitClosePct}%) — captured $${closePnl.toFixed(0)} (IB fill @ $${closePremium.toFixed(4)})`,
+        { action: 'closed', source: 'options', metadata: { reason: '50pct_profit', pnl: closePnl, closeProfitPct, profitClosePct, ibOrderId: ibClose.orderId } }
       );
       continue;
     }
@@ -522,16 +587,26 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
       const isDeepLoser = pnl < 0 && Math.abs(pnl) > premiumInDollars;
 
       if (isWinner) {
-        // Winner at 21 DTE — close to lock in profit
+        const ibClose = await ibBuyToCloseOption(pos.ticker, 'P', pos.option_strike, pos.option_expiry, currentPremium);
+        if (!ibClose) {
+          persistEvent(pos.ticker, 'warning',
+            `⚠️ ${pos.ticker} $${pos.option_strike}P 21 DTE winner close triggered but IB buy-to-close failed — position left open for retry`,
+            { action: 'skipped', source: 'options', metadata: { reason: 'ib_close_failed', trigger: '21dte_profit', currentPremium, premiumCollected } }
+          );
+          continue;
+        }
+        const closePremium = ibClose.avgFillPrice;
+        const closePnl = (premiumCollected - closePremium) * 100;
+        const closeProfitPct = premiumCollected > 0 ? Math.max(0, (1 - closePremium / premiumCollected) * 100) : 0;
         const closeReason = '21dte_profit';
         const { error: closeError } = await sb.from('paper_trades').update({
           status: 'CLOSED',
-          close_price: currentPremium,
-          pnl,
-          pnl_percent: (pnl / (pos.option_capital_req ?? pos.option_strike * 100)) * 100,
+          close_price: closePremium,
+          pnl: closePnl,
+          pnl_percent: (closePnl / (pos.option_capital_req ?? pos.option_strike * 100)) * 100,
           closed_at: new Date().toISOString(),
           close_reason: closeReason,
-          option_close_pct: profitCapturePct,
+          option_close_pct: closeProfitPct,
         }).eq('id', pos.id).eq('status', 'FILLED');
 
         if (closeError) {
@@ -540,10 +615,10 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
         }
 
         result.rollAlerts.push(pos.ticker);
-        console.log(`[Options Manager] 21 DTE CLOSE (winner): ${pos.ticker} $${pos.option_strike}P — profit +$${pnl.toFixed(0)} (${dte}d left)`);
+        console.log(`[Options Manager] 21 DTE CLOSE (winner): ${pos.ticker} $${pos.option_strike}P — profit +$${closePnl.toFixed(0)} (${dte}d left, IB fill @ $${closePremium.toFixed(4)})`);
         persistEvent(pos.ticker, 'success',
-          `⏱️ ${pos.ticker} $${pos.option_strike} put closed at 21 DTE — locked in +$${pnl.toFixed(0)} with ${dte} days remaining`,
-          { action: 'closed', source: 'options', metadata: { reason: closeReason, dte, pnl, profitCapturePct } }
+          `⏱️ ${pos.ticker} $${pos.option_strike} put closed at 21 DTE — locked in +$${closePnl.toFixed(0)} with ${dte} days remaining`,
+          { action: 'closed', source: 'options', metadata: { reason: closeReason, dte, pnl: closePnl, closeProfitPct, ibOrderId: ibClose.orderId } }
         );
         continue;
       }
@@ -565,16 +640,27 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
           console.log(`[Options Manager] 21 DTE roll declined (${rollResult.reason}) — closing deep loser ${pos.ticker}`);
         }
 
-        // Hard close deep loser
+        // Hard close deep loser — place IB buy-to-close first
+        const ibCloseDeep = await ibBuyToCloseOption(pos.ticker, 'P', pos.option_strike, pos.option_expiry, currentPremium);
+        if (!ibCloseDeep) {
+          persistEvent(pos.ticker, 'warning',
+            `⚠️ ${pos.ticker} $${pos.option_strike}P 21 DTE deep loser close triggered but IB buy-to-close failed — position left open for retry`,
+            { action: 'skipped', source: 'options', metadata: { reason: 'ib_close_failed', trigger: '21dte_close', currentPremium, premiumCollected } }
+          );
+          continue;
+        }
+        const deepClosePremium = ibCloseDeep.avgFillPrice;
+        const deepClosePnl = (premiumCollected - deepClosePremium) * 100;
+        const deepCloseProfitPct = premiumCollected > 0 ? Math.max(0, (1 - deepClosePremium / premiumCollected) * 100) : 0;
         const closeReason = '21dte_close';
         const { error: closeError } = await sb.from('paper_trades').update({
           status: 'CLOSED',
-          close_price: currentPremium,
-          pnl,
-          pnl_percent: (pnl / (pos.option_capital_req ?? pos.option_strike * 100)) * 100,
+          close_price: deepClosePremium,
+          pnl: deepClosePnl,
+          pnl_percent: (deepClosePnl / (pos.option_capital_req ?? pos.option_strike * 100)) * 100,
           closed_at: new Date().toISOString(),
           close_reason: closeReason,
-          option_close_pct: profitCapturePct,
+          option_close_pct: deepCloseProfitPct,
         }).eq('id', pos.id).eq('status', 'FILLED');
 
         if (closeError) {
@@ -583,10 +669,10 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
         }
 
         result.rollAlerts.push(pos.ticker);
-        console.log(`[Options Manager] 21 DTE CLOSE (deep loser): ${pos.ticker} $${pos.option_strike}P — loss -$${Math.abs(pnl).toFixed(0)} exceeds premium $${premiumInDollars.toFixed(0)} (${dte}d left)`);
+        console.log(`[Options Manager] 21 DTE CLOSE (deep loser): ${pos.ticker} $${pos.option_strike}P — loss -$${Math.abs(deepClosePnl).toFixed(0)} exceeds premium $${premiumInDollars.toFixed(0)} (${dte}d left, IB fill @ $${deepClosePremium.toFixed(4)})`);
         persistEvent(pos.ticker, 'warning',
-          `⚠️ ${pos.ticker} $${pos.option_strike} put closed at 21 DTE — cut deep loss at -$${Math.abs(pnl).toFixed(0)} (>${premiumInDollars.toFixed(0)} premium) with ${dte} days remaining`,
-          { action: 'closed', source: 'options', metadata: { reason: closeReason, dte, pnl, profitCapturePct } }
+          `⚠️ ${pos.ticker} $${pos.option_strike} put closed at 21 DTE — cut deep loss at -$${Math.abs(deepClosePnl).toFixed(0)} (>${premiumInDollars.toFixed(0)} premium) with ${dte} days remaining`,
+          { action: 'closed', source: 'options', metadata: { reason: closeReason, dte, pnl: deepClosePnl, deepCloseProfitPct, ibOrderId: ibCloseDeep.orderId } }
         );
         continue;
       }
@@ -725,18 +811,29 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
 
     // Check B: Profit capture threshold — auto close when target % reached (same as puts)
     if (profitCapturePct >= profitClosePct) {
+      const ibCloseCall = await ibBuyToCloseOption(pos.ticker, 'C', pos.option_strike, pos.option_expiry, currentCallPremium);
+      if (!ibCloseCall) {
+        persistEvent(pos.ticker, 'warning',
+          `⚠️ ${pos.ticker} $${pos.option_strike}C profit target hit but IB buy-to-close failed — position left open for retry`,
+          { action: 'skipped', source: 'options', metadata: { reason: 'ib_close_failed', trigger: '50pct_profit', currentCallPremium, premiumCollected } }
+        );
+        continue;
+      }
+      const callClosePremium = ibCloseCall.avgFillPrice;
+      const callClosePnl = (premiumCollected - callClosePremium) * 100;
+      const callCloseProfitPct = premiumCollected > 0 ? Math.max(0, (1 - callClosePremium / premiumCollected) * 100) : 0;
       await sb.from('paper_trades').update({
         status: 'CLOSED',
-        close_price: currentCallPremium,
-        pnl,
+        close_price: callClosePremium,
+        pnl: callClosePnl,
         closed_at: new Date().toISOString(),
         close_reason: '50pct_profit',
-        option_close_pct: profitCapturePct,
+        option_close_pct: callCloseProfitPct,
       }).eq('id', pos.id);
       result.closed50Pct.push(pos.ticker);
       persistEvent(pos.ticker, 'success',
-        `💰 ${pos.ticker} $${pos.option_strike} covered call closed at ${profitCapturePct.toFixed(0)}% profit (target ${profitClosePct}%) — captured $${pnl.toFixed(0)}`,
-        { action: 'closed', source: 'options', metadata: { reason: '50pct_profit', pnl, profitCapturePct, profitClosePct } }
+        `💰 ${pos.ticker} $${pos.option_strike} covered call closed at ${callCloseProfitPct.toFixed(0)}% profit (target ${profitClosePct}%) — captured $${callClosePnl.toFixed(0)} (IB fill @ $${callClosePremium.toFixed(4)})`,
+        { action: 'closed', source: 'options', metadata: { reason: '50pct_profit', pnl: callClosePnl, callCloseProfitPct, profitClosePct, ibOrderId: ibCloseCall.orderId } }
       );
       continue;
     }
@@ -745,17 +842,28 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
     // Mirrors the put 21 DTE rule: free up capital once theta has done most of its work
     // and the remaining time value isn't worth the assignment risk into expiry.
     if (dte <= 21 && stockPrice < pos.option_strike * 0.90) {
+      const ibCloseCall21 = await ibBuyToCloseOption(pos.ticker, 'C', pos.option_strike, pos.option_expiry, currentCallPremium);
+      if (!ibCloseCall21) {
+        persistEvent(pos.ticker, 'warning',
+          `⚠️ ${pos.ticker} $${pos.option_strike}C 21 DTE close triggered but IB buy-to-close failed — position left open for retry`,
+          { action: 'skipped', source: 'options', metadata: { reason: 'ib_close_failed', trigger: '21dte_close', currentCallPremium, premiumCollected } }
+        );
+        continue;
+      }
+      const call21ClosePremium = ibCloseCall21.avgFillPrice;
+      const call21ClosePnl = (premiumCollected - call21ClosePremium) * 100;
+      const call21CloseProfitPct = premiumCollected > 0 ? Math.max(0, (1 - call21ClosePremium / premiumCollected) * 100) : 0;
       await sb.from('paper_trades').update({
         status: 'CLOSED',
-        close_price: currentCallPremium,
-        pnl,
+        close_price: call21ClosePremium,
+        pnl: call21ClosePnl,
         closed_at: new Date().toISOString(),
         close_reason: '21dte_close',
-        option_close_pct: profitCapturePct,
+        option_close_pct: call21CloseProfitPct,
       }).eq('id', pos.id);
       persistEvent(pos.ticker, 'success',
-        `📅 ${pos.ticker} $${pos.option_strike} covered call closed at 21 DTE — captured $${pnl.toFixed(0)} (${profitCapturePct.toFixed(0)}% of premium)`,
-        { action: 'closed', source: 'options', metadata: { reason: '21dte_close', pnl, dte, profitCapturePct } }
+        `📅 ${pos.ticker} $${pos.option_strike} covered call closed at 21 DTE — captured $${call21ClosePnl.toFixed(0)} (${call21CloseProfitPct.toFixed(0)}% of premium, IB fill @ $${call21ClosePremium.toFixed(4)})`,
+        { action: 'closed', source: 'options', metadata: { reason: '21dte_close', pnl: call21ClosePnl, dte, call21CloseProfitPct, ibOrderId: ibCloseCall21.orderId } }
       );
       continue;
     }
@@ -764,17 +872,28 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
     // At 2× collected we've lost as much in the buyback as we originally collected — cut it.
     const callStopMultiplier = 2.0;
     if (currentCallPremium > premiumCollected * callStopMultiplier && stockPrice > pos.option_strike) {
+      const ibCloseCallStop = await ibBuyToCloseOption(pos.ticker, 'C', pos.option_strike, pos.option_expiry, currentCallPremium);
+      if (!ibCloseCallStop) {
+        persistEvent(pos.ticker, 'warning',
+          `⚠️ ${pos.ticker} $${pos.option_strike}C stop-loss triggered but IB buy-to-close failed — position left open for retry`,
+          { action: 'skipped', source: 'options', metadata: { reason: 'ib_close_failed', trigger: 'call_stop', currentCallPremium, premiumCollected } }
+        );
+        continue;
+      }
+      const callStopClosePremium = ibCloseCallStop.avgFillPrice;
+      const callStopClosePnl = (premiumCollected - callStopClosePremium) * 100;
+      const callStopCloseProfitPct = premiumCollected > 0 ? Math.max(0, (1 - callStopClosePremium / premiumCollected) * 100) : 0;
       await sb.from('paper_trades').update({
         status: 'CLOSED',
-        close_price: currentCallPremium,
-        pnl,
+        close_price: callStopClosePremium,
+        pnl: callStopClosePnl,
         closed_at: new Date().toISOString(),
         close_reason: 'stop_loss',
-        option_close_pct: profitCapturePct,
+        option_close_pct: callStopCloseProfitPct,
       }).eq('id', pos.id);
       persistEvent(pos.ticker, 'warning',
-        `🛑 ${pos.ticker} $${pos.option_strike} covered call stopped — buyback $${currentCallPremium.toFixed(2)} > ${callStopMultiplier}× collected $${premiumCollected.toFixed(2)}, P&L $${pnl.toFixed(0)}`,
-        { action: 'closed', source: 'options', metadata: { reason: 'call_stop', pnl, dte, currentCallPremium, premiumCollected } }
+        `🛑 ${pos.ticker} $${pos.option_strike} covered call stopped — buyback $${callStopClosePremium.toFixed(2)} > ${callStopMultiplier}× collected $${premiumCollected.toFixed(2)}, P&L $${callStopClosePnl.toFixed(0)} (IB fill @ $${callStopClosePremium.toFixed(4)})`,
+        { action: 'closed', source: 'options', metadata: { reason: 'call_stop', pnl: callStopClosePnl, dte, callStopClosePremium, premiumCollected, ibOrderId: ibCloseCallStop.orderId } }
       );
       continue;
     }
@@ -888,17 +1007,27 @@ async function evaluateAndRollCall(
   }
 
   // ── Execute the roll ─────────────────────────────────────
-  const pnl = (premiumCollected - currentCallPremium) * 100;
 
-  // 1. Close current call leg
+  // 1. Close current call leg via IB buy-to-close
+  const ibCloseOldCall = await ibBuyToCloseOption(pos.ticker, 'C', pos.option_strike, pos.option_expiry, currentCallPremium);
+  if (!ibCloseOldCall) {
+    return {
+      rolled: false,
+      reason: 'ib_close_failed',
+      logLine: `${pos.ticker}: IB buy-to-close failed for old call leg $${pos.option_strike}C — roll aborted`,
+    };
+  }
+  const rollCallClosePremium = ibCloseOldCall.avgFillPrice;
+  const pnl = (premiumCollected - rollCallClosePremium) * 100;
+
   await sb.from('paper_trades').update({
     status: 'CLOSED',
-    close_price: currentCallPremium,
+    close_price: rollCallClosePremium,
     pnl,
     pnl_percent: (pnl / capital) * 100,
     closed_at: new Date().toISOString(),
     close_reason: 'rolled',
-    option_close_pct: Math.max(0, (1 - currentCallPremium / premiumCollected) * 100),
+    option_close_pct: Math.max(0, (1 - rollCallClosePremium / premiumCollected) * 100),
   }).eq('id', pos.id);
 
   // 2. Open new call leg

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -676,6 +676,16 @@ async function closeAllDayTrades(config: AutoTraderConfig): Promise<void> {
           continue;
         }
 
+        // Cancel bracket TP/SL orders to prevent duplicate sells during hard close
+        if (trade.ib_tp_order_id) {
+          try { conn.cancelOrder(parseInt(trade.ib_tp_order_id, 10)); log(`${trade.ticker}: EOD — cancelled bracket TP #${trade.ib_tp_order_id}`); }
+          catch (e) { log(`${trade.ticker}: EOD — cancel TP #${trade.ib_tp_order_id} failed: ${e instanceof Error ? e.message : 'unknown'}`); }
+        }
+        if (trade.ib_sl_order_id) {
+          try { conn.cancelOrder(parseInt(trade.ib_sl_order_id, 10)); log(`${trade.ticker}: EOD — cancelled bracket SL #${trade.ib_sl_order_id}`); }
+          catch (e) { log(`${trade.ticker}: EOD — cancel SL #${trade.ib_sl_order_id} failed: ${e instanceof Error ? e.message : 'unknown'}`); }
+        }
+
         let fillResult: { avgFillPrice: number } | null = null;
         try {
           fillResult = await conn.placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });
@@ -762,6 +772,16 @@ async function softCloseDayTrades(positions: EnrichedPosition[]): Promise<void> 
       const closeSide = isBuy ? 'SELL' : 'BUY';
       const qty       = trade.quantity ?? 0;
       if (qty <= 0) continue;
+
+      // Cancel bracket TP/SL orders to prevent duplicate sells during soft close
+      if (trade.ib_tp_order_id) {
+        try { conn.cancelOrder(parseInt(trade.ib_tp_order_id, 10)); log(`${trade.ticker}: [SoftClose] cancelled bracket TP #${trade.ib_tp_order_id}`); }
+        catch (e) { log(`${trade.ticker}: [SoftClose] cancel TP #${trade.ib_tp_order_id} failed: ${e instanceof Error ? e.message : 'unknown'}`); }
+      }
+      if (trade.ib_sl_order_id) {
+        try { conn.cancelOrder(parseInt(trade.ib_sl_order_id, 10)); log(`${trade.ticker}: [SoftClose] cancelled bracket SL #${trade.ib_sl_order_id}`); }
+        catch (e) { log(`${trade.ticker}: [SoftClose] cancel SL #${trade.ib_sl_order_id} failed: ${e instanceof Error ? e.message : 'unknown'}`); }
+      }
 
       try {
         let fillResult: { avgFillPrice: number } | null = null;
@@ -5553,6 +5573,16 @@ async function checkDayTradeTrailingStops(
       const closeSide = isBuy ? 'SELL' : 'BUY';
       const qty       = trade.quantity ?? 0;
       if (qty <= 0) continue;
+
+      // Cancel bracket TP/SL orders to prevent duplicate sells
+      if (trade.ib_tp_order_id) {
+        try { conn.cancelOrder(parseInt(trade.ib_tp_order_id, 10)); log(`${trade.ticker}: trailing stop — cancelled bracket TP #${trade.ib_tp_order_id}`); }
+        catch (e) { log(`${trade.ticker}: trailing stop — cancel TP #${trade.ib_tp_order_id} failed: ${e instanceof Error ? e.message : 'unknown'}`); }
+      }
+      if (trade.ib_sl_order_id) {
+        try { conn.cancelOrder(parseInt(trade.ib_sl_order_id, 10)); log(`${trade.ticker}: trailing stop — cancelled bracket SL #${trade.ib_sl_order_id}`); }
+        catch (e) { log(`${trade.ticker}: trailing stop — cancel SL #${trade.ib_sl_order_id} failed: ${e instanceof Error ? e.message : 'unknown'}`); }
+      }
 
       try {
         const { avgFillPrice } = await conn.placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });


### PR DESCRIPTION
## Summary

- **Options/credit spread IB close execution**: All option close paths (profit take, 21 DTE, stop-loss, rolls) and credit spread close paths now place real IB buy-to-close orders instead of only updating the DB with model-based mid prices. If the IB close order fails, the position is left open for retry on the next cycle rather than being marked CLOSED with no actual IB execution.
- **Bracket order cancellation**: EOD hard close, soft close, and trailing stop sell paths now cancel any outstanding bracket TP/SL orders before placing the market sell, preventing duplicate/phantom sells that create accidental short positions.
- **Frontend P&L display fix**: Active (still-open) trades in the Today's Activity table no longer show unrealized P&L values — only realized closes display P&L.

## Files changed

- `auto-trader/src/ib-connection.ts` — Added `action` param (BUY/SELL) to options and vertical spread order interfaces
- `auto-trader/src/lib/options-manager.ts` — Added `ibBuyToCloseOption()` helper; all close/roll paths use real IB fills
- `auto-trader/src/lib/credit-spread-scanner.ts` — IB buy-to-close spread order before marking CLOSED
- `auto-trader/src/scheduler.ts` — Cancel bracket TP/SL orders before EOD/soft/trailing-stop closes
- `app/src/components/PaperTrading/tabs/TodayActivityTab.tsx` — Only show P&L for realized closes

## Test plan

- [x] Auto-trader already rebuilt and restarted with these changes
- [x] Frontend builds cleanly (`npm run build`)
- [ ] Monitor next trading session for correct IB close execution on options/spreads
- [ ] Verify no phantom positions from bracket order race conditions during EOD close
- [ ] Confirm Today's Activity shows P&L only for closed trades


Made with [Cursor](https://cursor.com)