### PR TITLE
Stop unrealized P&L pollution in paper_trades

### DIFF
--- a/app/src/components/PaperTrading/tabs/HistoryTab.tsx
+++ b/app/src/components/PaperTrading/tabs/HistoryTab.tsx
@@ -71,9 +71,10 @@ export function HistoryTab({ trades, pendingSignals, accountView }: HistoryTabPr
 
   const activeTrades = trades.filter(t => ['SUBMITTED', 'FILLED', 'PARTIAL', 'PENDING'].includes(t.status));
   const totalPendingLike = activeTrades.length + pendingSignals.length;
-  const totalPnl = trades.reduce((s, t) => s + (t.pnl ?? 0), 0);
-  const wins = trades.filter(t => (t.pnl ?? 0) > 0).length;
-  const losses = trades.filter(t => (t.pnl ?? 0) < 0).length;
+  const confirmedPnl = (t: typeof trades[0]) => t.pnl_source != null ? t.pnl : null;
+  const totalPnl = trades.reduce((s, t) => s + (confirmedPnl(t) ?? 0), 0);
+  const wins = trades.filter(t => (confirmedPnl(t) ?? 0) > 0).length;
+  const losses = trades.filter(t => (confirmedPnl(t) ?? 0) < 0).length;
 
   return (
     <div className="space-y-3">
@@ -196,8 +197,8 @@ export function HistoryTab({ trades, pendingSignals, accountView }: HistoryTabPr
                   <td className="px-4 py-3 text-right tabular-nums">
                     {trade.close_price ? `$${trade.close_price.toFixed(2)}` : '—'}
                   </td>
-                  <td className={`px-4 py-3 text-right tabular-nums font-semibold ${(trade.pnl ?? 0) > 0 ? 'text-emerald-600' : (trade.pnl ?? 0) < 0 ? 'text-red-600' : ''}`}>
-                    {trade.pnl != null ? fmtUsd(trade.pnl, 2, true) : '—'}
+                  <td className={`px-4 py-3 text-right tabular-nums font-semibold ${(confirmedPnl(trade) ?? 0) > 0 ? 'text-emerald-600' : (confirmedPnl(trade) ?? 0) < 0 ? 'text-red-600' : ''}`}>
+                    {confirmedPnl(trade) != null ? fmtUsd(confirmedPnl(trade)!, 2, true) : '—'}
                   </td>
                   <td className="px-4 py-3">
                     <StatusBadge status={trade.status} />

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -4460,26 +4460,9 @@ async function _syncPositionsForAccount(
         log(`${trade.ticker}: Filled @ $${fillPrice.toFixed(2)}`);
       }
 
-      if (trade.status === 'FILLED' && ibPos.mktPrice > 0 && trade.fill_price) {
-        const qty = trade.quantity ?? 1;
-        const isLong = trade.signal === 'BUY';
-
-        // For a SELL that reduced a long position (partial profit take), P&L is realized:
-        // (sell_price - avg_cost) × qty. Using short-position formula gives wrong results
-        // when the stock rises after the sale.
-        const isSellIntoLong = !isLong && ibPos.position > 0 && ibPos.avgCost > 0;
-        const unrealizedPnl = isSellIntoLong
-          ? (trade.fill_price - ibPos.avgCost) * qty
-          : isLong
-            ? (ibPos.mktPrice - trade.fill_price) * qty
-            : (trade.fill_price - ibPos.mktPrice) * qty;
-        const costBasis = isSellIntoLong ? ibPos.avgCost * qty : trade.fill_price * qty;
-
-        await updatePaperTrade(trade.id, {
-          pnl: parseFloat(unrealizedPnl.toFixed(2)),
-          pnl_percent: parseFloat(((unrealizedPnl / costBasis) * 100).toFixed(2)),
-        }, syncAcct);
-      }
+      // Unrealized P&L for open trades is computed on-the-fly by the frontend.
+      // Do NOT write it to the pnl field — that field is reserved for realized P&L
+      // set by recordTradeClose() with a confirmed pnl_source.
     } else if (trade.status === 'FILLED') {
       // Position gone — closed by bracket TP/SL or manual action.
       // 2-cycle guard: don't auto-close on first detection. Set missing_since,


### PR DESCRIPTION
## Summary
- Removed the sync loop code that wrote unrealized P&L to `paper_trades.pnl` for open FILLED trades
- Trade History tab now only shows P&L where `pnl_source` is set (confirmed by `recordTradeClose()`)
- Cleared stale unrealized P&L from all currently open trades in DB

This was causing RKLB (+$93.24) and XOM (-$5.89) to show fake P&L in Trade History even though they were never sold.

## Root cause
The `_syncPositionsForAccount` function wrote `ibPos.mktPrice`-based unrealized P&L to the same `pnl` field used for realized P&L, without setting `pnl_source`. Every view that read `pnl` then displayed unrealized values as if they were real.

Made with [Cursor](https://cursor.com)