### PR TITLE
Fix pnl_source gaps + loss-cut/auto-sell race condition

### DIFF
--- a/auto-trader/cleanup-orphans.mjs
+++ b/auto-trader/cleanup-orphans.mjs
@@ -1,0 +1,259 @@
+/**
+ * cleanup-orphans.mjs — Liquidate orphaned long positions in IB paper account.
+ *
+ * These positions were created by the auto-trader but their paper_trade records
+ * were incorrectly marked CLOSED while IB still held the shares.
+ *
+ * Usage:
+ *   node cleanup-orphans.mjs            # DRY RUN — logs what it would do
+ *   node cleanup-orphans.mjs --execute  # LIVE — actually places sell orders
+ *
+ * Must be run during market hours (9:30 AM – 4:00 PM ET).
+ */
+
+import { IBApi, EventName, OrderAction, OrderType, SecType, TimeInForce } from '@stoqey/ib';
+
+const IB_HOST = '127.0.0.1';
+const IB_PORT = 4002;
+const CLIENT_ID = 99; // unique clientId to avoid conflict with running auto-trader (clientId=1)
+
+const EXECUTE = process.argv.includes('--execute');
+const ORDER_TIMEOUT_MS = 30_000;
+
+const ORPHANED_POSITIONS = {
+  SNDK: 6,
+  INTC: 45,
+  DIA: 10,
+  MCW: 2842,
+  TSLA: 26,
+  STX: 7,
+  WMT: 38,
+  NFLX: 219,
+  HOOD: 65,
+  GOOGL: 12,
+  QQQ: 21,
+  SPY: 41,
+  BE: 34,
+  DNTH: 14,
+  NXPI: 17,
+};
+
+function log(msg) {
+  const ts = new Date().toLocaleString('en-US', { timeZone: 'America/New_York' });
+  console.log(`[${ts}] ${msg}`);
+}
+
+function isMarketOpen() {
+  const now = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
+  const day = now.getDay();
+  if (day === 0 || day === 6) return false;
+  const mins = now.getHours() * 60 + now.getMinutes();
+  return mins >= 9 * 60 + 30 && mins < 16 * 60;
+}
+
+async function main() {
+  log('=== Orphaned Position Cleanup Script ===');
+  log(`Mode: ${EXECUTE ? '🔴 LIVE — orders WILL be placed' : '🟡 DRY RUN — no orders will be placed'}`);
+  log(`Tickers to liquidate: ${Object.keys(ORPHANED_POSITIONS).join(', ')}`);
+  log('');
+
+  if (EXECUTE && !isMarketOpen()) {
+    log('❌ Market is closed. Cannot place orders outside 9:30 AM – 4:00 PM ET.');
+    log('   Re-run during market hours.');
+    process.exit(1);
+  }
+
+  const ib = new IBApi({ host: IB_HOST, port: IB_PORT, clientId: CLIENT_ID });
+  let nextOrderId = 0;
+  let connected = false;
+
+  // Wait for connection + nextValidId
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('Connection timeout (15s)')), 15_000);
+
+    ib.on(EventName.connected, () => {
+      connected = true;
+      log('✓ Connected to IB Gateway');
+      ib.reqIds();
+    });
+
+    ib.on(EventName.nextValidId, (orderId) => {
+      nextOrderId = orderId;
+      log(`✓ Next valid order ID: ${nextOrderId}`);
+      clearTimeout(timeout);
+      resolve();
+    });
+
+    ib.on(EventName.error, (err, code) => {
+      const infoOnly = code && [2104, 2106, 2108, 2158].includes(code);
+      if (infoOnly) return;
+      if (!connected) {
+        clearTimeout(timeout);
+        reject(new Error(`Connection error (code=${code}): ${err.message}`));
+      }
+    });
+
+    log(`Connecting to ${IB_HOST}:${IB_PORT} (clientId=${CLIENT_ID})...`);
+    ib.connect();
+  });
+
+  // Request all positions
+  log('');
+  log('Fetching current IB positions...');
+  const positions = await new Promise((resolve) => {
+    const result = [];
+    const timeout = setTimeout(() => resolve(result), 10_000);
+
+    ib.on(EventName.position, (_account, contract, pos, avgCost) => {
+      if (pos !== 0) {
+        result.push({ symbol: contract.symbol, secType: contract.secType, position: pos, avgCost });
+      }
+    });
+
+    ib.on(EventName.positionEnd, () => {
+      clearTimeout(timeout);
+      resolve(result);
+    });
+
+    ib.reqPositions();
+  });
+
+  log(`Found ${positions.length} non-zero positions in IB`);
+  log('');
+
+  // Build lookup of IB positions (STK only)
+  const ibPositions = new Map();
+  for (const p of positions) {
+    if (p.secType === 'STK' || p.secType === SecType.STK) {
+      ibPositions.set(p.symbol, p);
+    }
+  }
+
+  // Verify and process each orphan
+  const results = [];
+  let ordersFilled = 0;
+  let ordersSkipped = 0;
+  let ordersFailed = 0;
+
+  for (const [ticker, expectedQty] of Object.entries(ORPHANED_POSITIONS)) {
+    const ibPos = ibPositions.get(ticker);
+
+    if (!ibPos) {
+      log(`⚠️  ${ticker}: NOT found in IB — already liquidated or never existed. Skipping.`);
+      results.push({ ticker, status: 'NOT_IN_IB', detail: 'Position not found' });
+      ordersSkipped++;
+      continue;
+    }
+
+    if (ibPos.position <= 0) {
+      log(`⚠️  ${ticker}: IB position is ${ibPos.position} (not long). Skipping.`);
+      results.push({ ticker, status: 'NOT_LONG', detail: `Position=${ibPos.position}` });
+      ordersSkipped++;
+      continue;
+    }
+
+    if (ibPos.position !== expectedQty) {
+      log(`⚠️  ${ticker}: IB qty=${ibPos.position} but expected=${expectedQty}. QUANTITY MISMATCH — skipping for safety.`);
+      results.push({ ticker, status: 'QTY_MISMATCH', detail: `IB=${ibPos.position}, expected=${expectedQty}` });
+      ordersSkipped++;
+      continue;
+    }
+
+    // Position verified
+    const avgCost = ibPos.avgCost.toFixed(2);
+    const notional = (ibPos.position * ibPos.avgCost).toFixed(2);
+
+    if (!EXECUTE) {
+      log(`✓ ${ticker}: WOULD SELL ${expectedQty} shares (avgCost=$${avgCost}, notional=$${notional})`);
+      results.push({ ticker, status: 'DRY_RUN', detail: `${expectedQty} shares @ $${avgCost}` });
+      continue;
+    }
+
+    // Place market sell order
+    log(`→ ${ticker}: Selling ${expectedQty} shares (avgCost=$${avgCost})...`);
+
+    const orderId = nextOrderId++;
+    const contract = {
+      symbol: ticker,
+      secType: SecType.STK,
+      exchange: 'SMART',
+      currency: 'USD',
+    };
+    const order = {
+      action: OrderAction.SELL,
+      orderType: OrderType.MKT,
+      totalQuantity: expectedQty,
+      tif: TimeInForce.DAY,
+      transmit: true,
+    };
+
+    try {
+      const fillResult = await new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          reject(new Error(`Order ${orderId} timed out after ${ORDER_TIMEOUT_MS / 1000}s`));
+        }, ORDER_TIMEOUT_MS);
+
+        const statusHandler = (oid, status, filled, _remaining, avgFillPrice) => {
+          if (oid !== orderId) return;
+          if (status === 'Filled') {
+            clearTimeout(timer);
+            ib.off(EventName.orderStatus, statusHandler);
+            resolve({ orderId: oid, avgFillPrice, filledQty: filled });
+          } else if (status === 'Cancelled' || status === 'Inactive') {
+            clearTimeout(timer);
+            ib.off(EventName.orderStatus, statusHandler);
+            reject(new Error(`Order ${oid} ${status}`));
+          }
+        };
+
+        ib.on(EventName.orderStatus, statusHandler);
+        ib.placeOrder(orderId, contract, order);
+      });
+
+      log(`  ✓ ${ticker}: FILLED ${fillResult.filledQty} shares @ $${fillResult.avgFillPrice.toFixed(4)} (orderId=${fillResult.orderId})`);
+      results.push({ ticker, status: 'FILLED', detail: `${fillResult.filledQty} @ $${fillResult.avgFillPrice.toFixed(4)}` });
+      ordersFilled++;
+    } catch (err) {
+      log(`  ❌ ${ticker}: FAILED — ${err.message}`);
+      results.push({ ticker, status: 'FAILED', detail: err.message });
+      ordersFailed++;
+    }
+
+    // Small delay between orders to avoid overwhelming the gateway
+    await new Promise(r => setTimeout(r, 500));
+  }
+
+  // Summary
+  log('');
+  log('=== SUMMARY ===');
+  log(`Total orphans:  ${Object.keys(ORPHANED_POSITIONS).length}`);
+  if (EXECUTE) {
+    log(`Filled:         ${ordersFilled}`);
+    log(`Failed:         ${ordersFailed}`);
+    log(`Skipped:        ${ordersSkipped}`);
+  } else {
+    log(`Would sell:     ${results.filter(r => r.status === 'DRY_RUN').length}`);
+    log(`Skipped:        ${ordersSkipped}`);
+    log('');
+    log('To execute for real, run:  node cleanup-orphans.mjs --execute');
+  }
+
+  log('');
+  log('Results:');
+  for (const r of results) {
+    log(`  ${r.ticker.padEnd(6)} ${r.status.padEnd(14)} ${r.detail}`);
+  }
+
+  // Disconnect
+  log('');
+  log('Disconnecting from IB...');
+  try { ib.disconnect(); } catch { /* ignore */ }
+  log('Done.');
+
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err.message);
+  process.exit(1);
+});

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -1083,6 +1083,7 @@ export async function reconcileIBShorts(): Promise<{ closed: string[]; errors: s
           close_price: avgFillPrice,
           pnl: coverPnl,
           pnl_percent: pos.avgCost > 0 ? parseFloat(((coverPnl / (pos.avgCost * qty)) * 100).toFixed(2)) : null,
+          pnl_source: 'ib_fill_calculated',
           ib_order_id: String(coverOrderId),
           notes: `Cover orderId=${coverOrderId} filled @ $${avgFillPrice.toFixed(2)} by reconcileIBShorts at ${new Date().toISOString()}`,
         }).eq('id', orphan.id);
@@ -4613,6 +4614,7 @@ async function _syncPositionsForAccount(
                 close_reason: closeReason,
                 pnl: parseFloat(pnl.toFixed(2)),
                 pnl_percent: originalFillPrice > 0 ? parseFloat(((pnl / (originalFillPrice * qty)) * 100).toFixed(2)) : null,
+                pnl_source: 'ib_fill_calculated',
                 closed_at: closedAt,
               }, syncAcct);
               log(`${trade.ticker}: SELL closed immediately — fill @ $${fillPrice}, P&L $${pnl.toFixed(2)}`);
@@ -5444,6 +5446,7 @@ async function checkProfitTakeOpportunities(
           status: 'CLOSED',
           ib_order_id: String(orderId),
           pnl: realizedPnl,
+          pnl_source: 'ib_fill_calculated',
           close_reason: 'profit_take',
           closed_at: new Date().toISOString(),
           notes: `Profit take ${triggered.label} at +${gainPct.toFixed(1)}%`,
@@ -5577,8 +5580,9 @@ async function checkDayTradeTrailingStops(
 async function checkLossCutOpportunities(
   config: AutoTraderConfig,
   positions: EnrichedPosition[],
-): Promise<void> {
-  if (!config.lossCutEnabled || !config.accountId) return;
+): Promise<Set<string>> {
+  const actedTickers = new Set<string>();
+  if (!config.lossCutEnabled || !config.accountId) return actedTickers;
 
   // Loss cuts may apply to both paper and live accounts
   for (const acctType of ['paper', 'live'] as AccountType[]) {
@@ -5661,6 +5665,7 @@ async function checkLossCutOpportunities(
           }, acctType);
         }
 
+        actedTickers.add(trade.ticker.toUpperCase());
         const realizedLoss = ibPos.position > 0
           ? sellQty * (ibPos.avgCost - ibPos.mktPrice)
           : sellQty * (ibPos.mktPrice - ibPos.avgCost);
@@ -5674,6 +5679,7 @@ async function checkLossCutOpportunities(
       }
     }
   }
+  return actedTickers;
 }
 
 // ── Portfolio Snapshot ───────────────────────────────────
@@ -6167,9 +6173,10 @@ async function runSchedulerCycle(): Promise<void> {
     await checkDayTradeTrailingStops(config, positions);       // software trailing stop for day trades in profit (+1R)
     await checkDipBuyOpportunities(config, positions);
     const trimmedTickers = await checkProfitTakeOpportunities(config, positions);
-    await checkLossCutOpportunities(config, positions);
+    const lossCutTickers = await checkLossCutOpportunities(config, positions);
     await checkSwingHoldExpiry(config, positions);     // free capital from stale swing trades
-    await checkLongTermAutoSell(config, positions, trimmedTickers);
+    const skipTickers = new Set([...trimmedTickers, ...lossCutTickers]);
+    await checkLongTermAutoSell(config, positions, skipTickers);
 
     // ── New entries below — only run when auto-trading is enabled ─────────────
     if (!newEntriesEnabled) {


### PR DESCRIPTION
## Summary
- Add `pnl_source` to 3 remaining close paths that wrote P&L without it (SUBMITTED SELL sync, profit-take trim, orphan short cover)
- Fix race condition where `checkLossCutOpportunities()` and `checkLongTermAutoSell()` could both sell the same ticker in one cycle — root cause of the HUBB orphaned short
- Add `cleanup-orphans.mjs` to liquidate 15 accumulated phantom IB positions (dry-run by default)

## Test plan
- [ ] Verify auto-trader starts cleanly after rebuild
- [ ] Run `node cleanup-orphans.mjs` dry-run during market hours to confirm position quantities
- [ ] Run `node cleanup-orphans.mjs --execute` to liquidate orphans
- [ ] Monitor next profit-take and loss-cut cycles for correct skipTickers behavior

Made with [Cursor](https://cursor.com)