### PR TITLE
Gate dip buys on LONG_TERM mode routing

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -4887,6 +4887,7 @@ async function checkDipBuyOpportunities(
   positions: EnrichedPosition[],
 ): Promise<void> {
   if (!config.dipBuyEnabled || !config.accountId) return;
+  if (!isModeEnabled(config, 'LONG_TERM')) return;
   // Resolve LONG_TERM routing for dip buys
   let dipConnections: RoutedConnection[];
   try {


### PR DESCRIPTION
Dip buys now respect mode routing OFF state. Position management functions unchanged.

Made with [Cursor](https://cursor.com)