### PR TITLE
Options signal pipeline for pocket trading influencers

### DIFF
--- a/app/src/components/PaperTrading/tabs/StrategyPerformanceTab.tsx
+++ b/app/src/components/PaperTrading/tabs/StrategyPerformanceTab.tsx
@@ -33,7 +33,7 @@ type StrategyRow = {
   videoId: string | null;
   videoHeading: string;
   platform: 'instagram' | 'twitter' | 'youtube' | null;
-  strategyType: 'daily_signal' | 'daily_penny' | 'generic_strategy' | null;
+  strategyType: 'daily_signal' | 'daily_penny' | 'generic_strategy' | 'options_signal' | null;
   applicableTimeframes: Array<'DAY_TRADE' | 'SWING_TRADE'> | null;
   totalTrades: number;
   activeTrades: number;
@@ -395,7 +395,7 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
         source_handle: opt.sourceHandle,
         source_name: opt.sourceName,
         video_ids: [videoId],
-        strategy_type: sel.category ? (sel.category as 'daily_signal' | 'daily_penny' | 'generic_strategy') : undefined,
+        strategy_type: sel.category ? (sel.category as 'daily_signal' | 'daily_penny' | 'generic_strategy' | 'options_signal') : undefined,
       });
       if (assigned > 0) onRefresh();
     } finally {
@@ -414,7 +414,7 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
         source_handle: opt.sourceHandle,
         source_name: opt.sourceName,
         video_ids: [videoId],
-        strategy_type: sel.category ? (sel.category as 'daily_signal' | 'daily_penny' | 'generic_strategy') : undefined,
+        strategy_type: sel.category ? (sel.category as 'daily_signal' | 'daily_penny' | 'generic_strategy' | 'options_signal') : undefined,
       });
       if (assigned > 0) {
         setChangingSourceVideoId(null);
@@ -425,7 +425,7 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
     }
   };
 
-  const handleCategoryChange = async (videoId: string, strategyType: 'daily_signal' | 'daily_penny' | 'generic_strategy') => {
+  const handleCategoryChange = async (videoId: string, strategyType: 'daily_signal' | 'daily_penny' | 'generic_strategy' | 'options_signal') => {
     if (!onRefresh) return;
     setUpdatingCategoryVideoId(videoId);
     try {
@@ -992,6 +992,9 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
                                                 </button>
                                               </span>
                                             )}
+                                            {video.strategyType === 'options_signal' && (
+                                              <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-purple-100 text-purple-800 shrink-0" title="Options: conditional entry signals">options</span>
+                                            )}
                                             {video.strategyType === 'generic_strategy' && (
                                               <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-slate-100 text-slate-700 shrink-0" title="Ongoing: applies across dates">
                                                 generic
@@ -1194,7 +1197,7 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
                                                 )}>3</span>
                                                 <span className="text-[hsl(var(--muted-foreground))]">Metadata:</span>
                                                 {video.ingestStatus === 'done' && video.strategyType ? (
-                                                  <span className="text-emerald-600 font-medium">Extracted ({video.strategyType === 'daily_signal' ? 'daily' : 'generic'})</span>
+                                                  <span className="text-emerald-600 font-medium">Extracted ({video.strategyType === 'daily_signal' ? 'daily' : video.strategyType === 'options_signal' ? 'options' : video.strategyType === 'daily_penny' ? 'penny' : 'generic'})</span>
                                                 ) : video.ingestStatus === 'done' ? (
                                                   <div className="flex items-center gap-1.5">
                                                     <span className="text-amber-600 font-medium">Not extracted</span>
@@ -1242,6 +1245,7 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
                                               >
                                                 <option value="daily_signal">Daily signal</option>
                                                 <option value="daily_penny">Daily penny</option>
+                                                <option value="options_signal">Options signal</option>
                                                 <option value="generic_strategy">Generic strategy</option>
                                               </select>
                                               {KNOWN_SIGNAL_GENERATORS.has(videoAssignSelections[baseKey]?.source ?? '') && (videoAssignSelections[baseKey]?.category ?? '') === 'generic_strategy' && (
@@ -1271,6 +1275,7 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
                                               >
                                                 <option value="daily_signal">Daily signal</option>
                                                 <option value="daily_penny">Daily penny</option>
+                                                <option value="options_signal">Options signal</option>
                                                 <option value="generic_strategy">Generic strategy</option>
                                               </select>
                                               {KNOWN_SIGNAL_GENERATORS.has(sourceName) && (video.strategyType ?? 'generic_strategy') === 'generic_strategy' && (

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -860,7 +860,7 @@ export interface StrategySignalStatusSummary {
   videoId: string | null;
   videoHeading: string | null;
   platform: 'instagram' | 'twitter' | 'youtube' | null;
-  strategyType: 'daily_signal' | 'daily_penny' | 'generic_strategy' | null;
+  strategyType: 'daily_signal' | 'daily_penny' | 'generic_strategy' | 'options_signal' | null;
   applicableDate: string | null;
   /** For generic_strategy: DAY_TRADE, SWING_TRADE, or both */
   applicableTimeframes: Array<'DAY_TRADE' | 'SWING_TRADE'> | null;
@@ -1267,7 +1267,7 @@ export async function getStrategySignalStatusSummaries(): Promise<StrategySignal
   const nowMs = Date.now();
 
   const grouped = new Map<string, StrategySignalStatusSummary & { sortKey: string }>();
-  const trackedTypeByKey = new Map<string, 'daily_signal' | 'daily_penny' | 'generic_strategy'>();
+  const trackedTypeByKey = new Map<string, 'daily_signal' | 'daily_penny' | 'generic_strategy' | 'options_signal'>();
   const trackedTimeframesByKey = new Map<string, Array<'DAY_TRADE' | 'SWING_TRADE'>>();
   for (const row of data as Array<{
     source_name: string | null;
@@ -1346,7 +1346,7 @@ export async function getStrategySignalStatusSummaries(): Promise<StrategySignal
           : (item.canonical_url ?? item.reel_url ?? null);
 
         const key = `${source}::${videoId ?? videoHeading}`;
-        const strategyType = item.strategy_type === 'daily_signal' || item.strategy_type === 'daily_penny' || item.strategy_type === 'generic_strategy'
+        const strategyType = item.strategy_type === 'daily_signal' || item.strategy_type === 'daily_penny' || item.strategy_type === 'generic_strategy' || item.strategy_type === 'options_signal'
           ? item.strategy_type
           : null;
         if (strategyType) {

--- a/app/src/lib/strategyVideoQueueApi.ts
+++ b/app/src/lib/strategyVideoQueueApi.ts
@@ -14,7 +14,7 @@ export interface StrategyVideoQueueItem {
   status: 'pending' | 'processing' | 'done' | 'failed';
   error_message: string | null;
   strategy_video_id: string | null;
-  strategy_type: 'daily_signal' | 'daily_penny' | 'generic_strategy' | null;
+  strategy_type: 'daily_signal' | 'daily_penny' | 'generic_strategy' | 'options_signal' | null;
   created_at: string;
   processed_at: string | null;
 }
@@ -108,7 +108,7 @@ export async function assignUnknownToSource(params: {
   source_handle: string;
   source_name: string;
   video_ids?: string[];
-  strategy_type?: 'daily_signal' | 'daily_penny' | 'generic_strategy';
+  strategy_type?: 'daily_signal' | 'daily_penny' | 'generic_strategy' | 'options_signal';
 }): Promise<{ assigned: number; video_ids: string[] }> {
   const url = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/assign-strategy-videos-to-source`;
   const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -188,7 +188,7 @@ export async function updateStrategyVideoMetadata(params: {
   platform?: 'instagram' | 'twitter' | 'youtube';
   source_handle?: string;
   source_name?: string;
-  strategy_type?: 'daily_signal' | 'daily_penny' | 'generic_strategy';
+  strategy_type?: 'daily_signal' | 'daily_penny' | 'generic_strategy' | 'options_signal';
 }): Promise<{ ok: boolean }> {
   const url = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/update-strategy-video-metadata`;
   const key = import.meta.env.VITE_SUPABASE_ANON_KEY;

--- a/app/src/lib/strategyVideosApi.ts
+++ b/app/src/lib/strategyVideosApi.ts
@@ -14,7 +14,7 @@ export interface StrategyVideoRecord {
   reel_url: string | null;
   canonical_url: string | null;
   video_heading: string | null;
-  strategy_type: 'daily_signal' | 'daily_penny' | 'generic_strategy' | null;
+  strategy_type: 'daily_signal' | 'daily_penny' | 'generic_strategy' | 'options_signal' | null;
   timeframe: string | null;
   applicable_timeframes: string[] | null;
   execution_window_et: { start?: string; end?: string } | null;
@@ -34,7 +34,7 @@ export interface StrategyVideoNormalized {
   reelUrl?: string;
   canonicalUrl?: string;
   videoHeading?: string;
-  strategyType?: 'daily_signal' | 'daily_penny' | 'generic_strategy';
+  strategyType?: 'daily_signal' | 'daily_penny' | 'generic_strategy' | 'options_signal';
   timeframe?: string;
   applicableTimeframes?: string[];
   executionWindowEt?: { start?: string; end?: string };

--- a/auto-trader/src/routes/strategies.ts
+++ b/auto-trader/src/routes/strategies.ts
@@ -17,7 +17,7 @@ import {
 const router = Router();
 
 const VALID_SIGNALS = new Set(['BUY', 'SELL']);
-const VALID_MODES = new Set(['DAY_TRADE', 'DAY_PENNY', 'SWING_TRADE', 'LONG_TERM']);
+const VALID_MODES = new Set(['DAY_TRADE', 'DAY_PENNY', 'SWING_TRADE', 'LONG_TERM', 'OPTIONS_CALL', 'OPTIONS_PUT']);
 const VALID_STATUSES = new Set(['PENDING', 'EXECUTED', 'FAILED', 'SKIPPED', 'EXPIRED', 'CANCELLED']);
 
 function parseOptionalNumber(value: unknown): number | null {

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -26,6 +26,8 @@ import {
   getPaperConnection,
   getLiveConnection,
   getConnectionForAccount,
+  placeOptionsOrder,
+  getDefaultAccount,
   type PositionData,
   type IBConnection,
 } from './ib-connection.js';
@@ -87,6 +89,7 @@ import { recordTradeClose } from './lib/trade-closer.js';
 import { generateSuggestedFinds, discoverDipStocks } from './lib/discovery.js';
 import { fetchRecentDailyCandles, detectCandlePatterns } from './lib/candle-patterns.js';
 import { runOptionsScan, autoTradeOption, getOptionsAutoTradeConfig } from './lib/options-scanner.js';
+import { getOptionsChain } from './lib/options-chain.js';
 import { runEarningsScan, closeExpiredEarningsPositions } from './lib/earnings-scanner.js';
 import { runWatchlistScreener } from './lib/watchlist-screener.js';
 import { runOptionsManageCycle } from './lib/options-manager.js';
@@ -3898,7 +3901,15 @@ async function executeExternalStrategySignal(
   }
 
   if (effectiveEntryPrice != null && quote != null && !skipConfirmationGates) {
-    if (signal.signal === 'BUY' && quote < effectiveEntryPrice) {
+    // OPTIONS_PUT: entry_price is a breakdown level — trigger when price drops BELOW it
+    if (signal.mode === 'OPTIONS_PUT' && quote > effectiveEntryPrice) {
+      const reason = `Entry trigger not reached: price $${quote.toFixed(2)} above put breakdown level $${effectiveEntryPrice.toFixed(2)}`;
+      summaryLog(`${ticker}: waiting — ${reason}`);
+      await updateExternalStrategySignal(signal.id, { failure_reason: reason });
+      return 'waiting';
+    }
+    // OPTIONS_CALL / stock BUY: entry_price is a breakout level — trigger when price rises ABOVE it
+    if (signal.mode !== 'OPTIONS_PUT' && signal.signal === 'BUY' && quote < effectiveEntryPrice) {
       const reason = `Entry trigger not reached: price $${quote.toFixed(2)} below ${isInfluencerSignal ? 'influencer' : ''} entry $${effectiveEntryPrice.toFixed(2)}`;
       summaryLog(`${ticker}: waiting — ${reason}`);
       await updateExternalStrategySignal(signal.id, { failure_reason: reason });
@@ -4093,6 +4104,16 @@ async function executeExternalStrategySignal(
     log(`${ticker}: order validation OK — ${orderCheck.reason}`);
   }
 
+  // ── OPTIONS path: buy a call or put when signal mode is OPTIONS_CALL/OPTIONS_PUT ──
+  if (signal.mode === 'OPTIONS_CALL' || signal.mode === 'OPTIONS_PUT') {
+    return executeExternalOptionsSignal(signal, ticker, referencePrice, extConnections, resolvedSource, {
+      effectiveEntryPrice,
+      effectiveTargetPrice,
+      allocationSplit,
+      allocationIndex,
+    });
+  }
+
   let primaryResult: 'executed' | 'failed' | undefined;
   for (const { connection: extConnection, accountType: acctType } of extConnections) {
     if (!extConnection.isConnected()) {
@@ -4233,6 +4254,207 @@ async function executeExternalStrategySignal(
     }
   }
   return primaryResult ?? 'failed';
+}
+
+/**
+ * Execute an external strategy signal as an options BUY order (long call or long put).
+ *
+ * Flow:
+ *   1. Select strike: ATM or slightly ITM via options chain
+ *   2. Select expiry: nearest Friday 10-20 days out
+ *   3. Place a limit BUY order for 1 contract at the ask price
+ *   4. Record the paper_trade with options metadata
+ */
+async function executeExternalOptionsSignal(
+  signal: ExternalStrategySignal,
+  ticker: string,
+  stockPrice: number,
+  extConnections: RoutedConnection[],
+  resolvedSource: AutoTradeSource,
+  context: {
+    effectiveEntryPrice: number | null;
+    effectiveTargetPrice: number | null;
+    allocationSplit: number;
+    allocationIndex: number;
+  },
+): Promise<'executed' | 'failed'> {
+  const right: 'C' | 'P' = signal.mode === 'OPTIONS_CALL' ? 'C' : 'P';
+  const rightLabel = right === 'C' ? 'call' : 'put';
+  const splitLabel = context.allocationSplit > 1
+    ? ` | allocation ${context.allocationIndex}/${context.allocationSplit}`
+    : '';
+
+  log(`${ticker}: OPTIONS ${rightLabel.toUpperCase()} signal — selecting strike/expiry (stock $${stockPrice.toFixed(2)})`);
+
+  // Select strike: for BUY calls, ATM or slightly ITM (strike at/below price).
+  // For BUY puts, ATM or slightly ITM (strike at/above price).
+  // Use getOptionsChain with a 0.50 delta target (ATM) for directional long options.
+  const chain = await getOptionsChain(ticker, stockPrice, null, 0.50, 14).catch((err) => {
+    log(`${ticker}: options chain fetch failed — ${err instanceof Error ? err.message : err}`);
+    return null;
+  });
+
+  let strike: number;
+  let expiry: string; // YYYYMMDD
+  let limitPrice: number;
+
+  if (right === 'C' && chain?.bestCall) {
+    strike = chain.bestCall.strike;
+    expiry = chain.bestCall.expiry;
+    limitPrice = chain.bestCall.ask > 0 ? chain.bestCall.ask : chain.bestCall.mid;
+    log(`${ticker}: chain found — $${strike}C exp ${expiry}, ask $${limitPrice.toFixed(2)}`);
+  } else if (right === 'P' && chain?.bestPut) {
+    strike = chain.bestPut.strike;
+    expiry = chain.bestPut.expiry;
+    limitPrice = chain.bestPut.ask > 0 ? chain.bestPut.ask : chain.bestPut.mid;
+    log(`${ticker}: chain found — $${strike}P exp ${expiry}, ask $${limitPrice.toFixed(2)}`);
+  } else {
+    // Fallback: synthesize ATM strike and ~2 week Friday expiry
+    const interval = stockPrice < 25 ? 1 : stockPrice < 200 ? 2.5 : 5;
+    if (right === 'C') {
+      strike = Math.floor(stockPrice / interval) * interval;
+    } else {
+      strike = Math.ceil(stockPrice / interval) * interval;
+    }
+    expiry = getNextFridayExpiry(14);
+    // Estimate limit using rough 2% of stock price for ATM with ~2 weeks DTE
+    limitPrice = stockPrice * 0.025;
+    log(`${ticker}: no chain available — using fallback strike $${strike}${right} exp ${expiry}, est. premium $${limitPrice.toFixed(2)}`);
+  }
+
+  if (limitPrice <= 0) {
+    await updateExternalStrategySignal(signal.id, { status: 'FAILED', failure_reason: 'Options premium is zero or negative' });
+    return 'failed';
+  }
+
+  const contracts = 1;
+  const positionSize = limitPrice * 100 * contracts;
+
+  // Execute on first available connection
+  let primaryResult: 'executed' | 'failed' | undefined;
+  for (const { connection: extConnection, accountType: acctType } of extConnections) {
+    if (!extConnection.isConnected()) {
+      if (primaryResult) { log(`${ticker}: [${acctType}] connection down — skipping options`); continue; }
+      await updateExternalStrategySignal(signal.id, { status: 'FAILED', failure_reason: 'IB Gateway not connected' });
+      return 'failed';
+    }
+
+    try {
+      const orderResult = await placeOptionsOrder({
+        symbol: ticker,
+        right,
+        strike,
+        expiry,
+        contracts,
+        limitPrice,
+        action: 'BUY',
+        account: getDefaultAccount() ?? undefined,
+      });
+
+      log(`${ticker}: OPTIONS ${rightLabel} order FILLED — IB#${orderResult.orderId}, ${orderResult.filledQty} contracts @ $${orderResult.avgFillPrice.toFixed(2)}`);
+
+      const fillPremium = orderResult.avgFillPrice;
+      const expiryISO = `${expiry.slice(0, 4)}-${expiry.slice(4, 6)}-${expiry.slice(6, 8)}`;
+
+      const trade = await createPaperTrade({
+        ticker,
+        mode: signal.mode,
+        signal: 'BUY',
+        strategy_source: signal.source_name,
+        strategy_source_url: signal.source_url,
+        strategy_video_id: signal.strategy_video_id,
+        strategy_video_heading: signal.strategy_video_heading,
+        scanner_confidence: signal.confidence,
+        entry_price: stockPrice,
+        fill_price: fillPremium,
+        target_price: context.effectiveTargetPrice,
+        quantity: contracts,
+        position_size: positionSize,
+        status: 'FILLED',
+        filled_at: new Date().toISOString(),
+        opened_at: new Date().toISOString(),
+        entry_trigger_type: 'external_options_signal',
+        ib_order_id: String(orderResult.orderId),
+        option_strike: strike,
+        option_expiry: expiryISO,
+        option_premium: fillPremium,
+        option_contracts: contracts,
+        option_capital_req: positionSize,
+        scanner_reason: `External options signal from ${signal.source_name}`,
+        notes: signal.notes
+          ? `External ${rightLabel} signal${splitLabel} | strike $${strike} exp ${expiryISO} | ${signal.notes}`
+          : `External ${rightLabel} signal${splitLabel} | strike $${strike} exp ${expiryISO}`,
+      }, acctType);
+
+      if (!primaryResult) {
+        await updateExternalStrategySignal(signal.id, {
+          status: 'EXECUTED',
+          executed_trade_id: trade.id,
+          executed_at: new Date().toISOString(),
+          failure_reason: null,
+        });
+      }
+
+      persistEvent(ticker, 'success', `External options ${rightLabel} executed [${acctType}]: BUY ${contracts}x $${strike}${right} @ $${fillPremium.toFixed(2)}`, {
+        action: 'executed',
+        source: resolvedSource,
+        mode: signal.mode,
+        strategy_source: signal.source_name,
+        strategy_source_url: signal.source_url,
+        strategy_video_id: signal.strategy_video_id,
+        strategy_video_heading: signal.strategy_video_heading,
+        metadata: {
+          external_signal_id: signal.id,
+          strike,
+          expiry: expiryISO,
+          premium: fillPremium,
+          contracts,
+          right,
+          allocation_split: context.allocationSplit,
+          allocation_index: context.allocationIndex,
+        },
+      }, acctType);
+      if (!primaryResult) primaryResult = 'executed';
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'unknown';
+      log(`${ticker}: OPTIONS ${rightLabel} order FAILED — ${message}`);
+      if (!primaryResult) {
+        await updateExternalStrategySignal(signal.id, { status: 'FAILED', failure_reason: message });
+      }
+      persistEvent(ticker, 'error', `External options ${rightLabel} failed [${acctType}]: ${message}`, {
+        action: 'failed',
+        source: resolvedSource,
+        mode: signal.mode,
+        strategy_source: signal.source_name,
+        strategy_source_url: signal.source_url,
+        strategy_video_id: signal.strategy_video_id,
+        strategy_video_heading: signal.strategy_video_heading,
+        metadata: { external_signal_id: signal.id, strike, expiry, right },
+      }, acctType);
+      if (!primaryResult) primaryResult = 'failed';
+    }
+  }
+  return primaryResult ?? 'failed';
+}
+
+/** Find the nearest Friday expiry that is at least `minDays` out. */
+function getNextFridayExpiry(minDays: number): string {
+  const now = new Date();
+  const target = new Date(now.getTime() + minDays * 86_400_000);
+  // Move to the next Friday (day 5)
+  const day = target.getDay();
+  const daysUntilFriday = (5 - day + 7) % 7 || 7;
+  const friday = new Date(target.getTime() + daysUntilFriday * 86_400_000);
+  // If the computed Friday is less than minDays away (can happen when target IS Friday),
+  // use the following Friday
+  const daysFromNow = Math.ceil((friday.getTime() - now.getTime()) / 86_400_000);
+  if (daysFromNow < minDays) {
+    friday.setDate(friday.getDate() + 7);
+  }
+  const y = friday.getFullYear();
+  const m = String(friday.getMonth() + 1).padStart(2, '0');
+  const d = String(friday.getDate()).padStart(2, '0');
+  return `${y}${m}${d}`;
 }
 
 async function processExternalStrategySignals(

--- a/auto-trader/strategy-sources.json
+++ b/auto-trader/strategy-sources.json
@@ -22,5 +22,14 @@
     "sourceUrl": "https://www.instagram.com/caspersmcwisdom/",
     "firstSeenAt": "2026-02-19",
     "notes": "Shared reel: https://www.instagram.com/reel/DU53Z_nEcZh/?igsh=MXAyN3V3bHRnamtiYQ%3D%3D"
+  },
+  {
+    "platform": "unknown",
+    "sourceName": "Pocket Trader",
+    "handle": "pocket_trader",
+    "sourceUrl": null,
+    "strategyType": "options_signal",
+    "firstSeenAt": "2026-05-19",
+    "notes": "Daily chart pocket/consolidation breakout setups — trades with options (calls/puts). Handle and URL TBD — update once confirmed."
   }
 ]

--- a/supabase/functions/extract-strategy-metadata-from-transcript/index.ts
+++ b/supabase/functions/extract-strategy-metadata-from-transcript/index.ts
@@ -30,13 +30,13 @@ Return a single JSON object (no markdown, no code block) with these fields. Use 
 {
   "source_name": "Display name of creator/channel (e.g. 'Somesh | Day Trader | Investor', 'Casper Clipping')",
   "source_handle": "Instagram/Twitter handle if mentioned (e.g. 'kaycapitals', 'casperclipping'). Lowercase, no @.",
-  "strategy_type": "daily_signal" | "daily_penny" | "generic_strategy",
+  "strategy_type": "daily_signal" | "daily_penny" | "options_signal" | "generic_strategy",
   "video_heading": "Short title summarizing the strategy (e.g. '4 stocks day-trading gameplan for Thursday')",
-  "trade_date": "YYYY-MM-DD if date-specific (daily_signal), else null",
+  "trade_date": "YYYY-MM-DD if date-specific (daily_signal/options_signal), else null",
   "timeframe": "DAY_TRADE" | "SWING_TRADE" | "LONG_TERM" | null,
   "applicable_timeframes": ["DAY_TRADE"] | ["SWING_TRADE"] | ["DAY_TRADE","SWING_TRADE"] | [],
   "execution_window_et": {"start":"09:35","end":"10:30"} | null,
-  "setup_type": "breakout" | "momentum" | "pullback_vwap" | "range" | null,
+  "setup_type": "breakout" | "momentum" | "pullback_vwap" | "range" | "pocket_pivot" | "bullish_engulfing" | "volume_breakout" | null,
   "extracted_signals": [{"ticker":"TSLA","longTriggerAbove":414,"longTargets":[416.9,420],"shortTriggerBelow":409,"shortTargets":[405.3,402.65]}] | [],
   "summary": "1-2 sentence summary of the strategy"
 }
@@ -44,6 +44,7 @@ Return a single JSON object (no markdown, no code block) with these fields. Use 
 Rules:
 - daily_signal: video gives concrete levels (entry, stop, target) for specific stocks today. Use extracted_signals.
 - daily_penny: video discusses a penny stock / small-cap watchlist for the day — stocks typically $2-$20, low float, momentum/gap plays. Creators like Ross Cameron / Warrior Trading. Use extracted_signals for the tickers mentioned as watchlist candidates (set longTriggerAbove to the current price or breakout level if given, targets optional). Key difference from daily_signal: these are low-priced, speculative momentum names — not large-cap level-based setups.
+- options_signal: video identifies daily chart "pocket" setups (consolidation breakouts) and the creator trades them with OPTIONS (calls for bullish, puts for bearish). Look for phrases like "pocket", "pocket pivot", "consolidation breakout", "daily breakout", "looking for calls", "buying puts". These videos give a list of tickers with entry conditions (e.g. "above today's high", "above $25.58") and target prices, intending to buy call or put options. Use extracted_signals with the OPTIONS format described below.
 - generic_strategy: general rules, patterns, SMC concepts (no specific levels). extracted_signals = [].
 - source_name: from intro ("Hey it's Somesh from Kay Capitals"), outro, or channel branding. Humanize (e.g. "Kay Capitals" → "Somesh | Day Trader | Investor" if known).
 - source_handle: Instagram handle if mentioned. Infer from source_name (e.g. "Casper Clipping" → "casperclipping").
@@ -54,11 +55,28 @@ Rules:
 - trade_date: for daily_signal or daily_penny when date is explicit (e.g. "for Thursday", "today's levels", "Monday morning watchlist").
 - execution_window_et: only if time window is specified (e.g. "9:30-9:35 levels", "first candle rule").
 - setup_type: how the influencer intends execution:
-    "breakout"     — enter when price breaks above/below a pre-market high/low with volume (most common for daily signals with trigger levels)
-    "momentum"     — buy/short the directional move in the first hour, market order or aggressive limit
-    "pullback_vwap"— wait for a pullback to VWAP or a support level before entering (patient entry)
-    "range"        — stock is in a range; play the bounce off support or rejection at resistance
-    null           — unclear or generic strategy with no specific setup type`;
+    "breakout"         — enter when price breaks above/below a pre-market high/low with volume (most common for daily signals with trigger levels)
+    "momentum"         — buy/short the directional move in the first hour, market order or aggressive limit
+    "pullback_vwap"    — wait for a pullback to VWAP or a support level before entering (patient entry)
+    "range"            — stock is in a range; play the bounce off support or rejection at resistance
+    "pocket_pivot"     — daily chart consolidation "pocket" breakout — price compressing in a tight range, then breaking out on volume
+    "bullish_engulfing"— bullish engulfing candle or strong reversal pattern on daily chart
+    "volume_breakout"  — already broke out on above-average volume, continuation expected
+    null               — unclear or generic strategy with no specific setup type
+
+OPTIONS SIGNAL FORMAT (for strategy_type = "options_signal"):
+When the video discusses pocket/breakout setups where the creator buys calls or puts, use this format for extracted_signals:
+  {"ticker":"SNOW","signal":"BUY_CALL","entry_context":"above_todays_high","trigger_price":null,"targets":[170,175],"setup_type":"pocket_pivot"}
+  {"ticker":"OSCR","signal":"BUY_CALL","entry_context":"above_level","trigger_price":25.58,"targets":[28,29.70],"setup_type":"volume_breakout"}
+  {"ticker":"XYZ","signal":"BUY_PUT","entry_context":"below_todays_low","trigger_price":null,"targets":[45,43],"setup_type":"breakout"}
+
+Fields:
+  - signal: "BUY_CALL" (bullish — buying calls) or "BUY_PUT" (bearish — buying puts)
+  - entry_context: "above_todays_high" (trigger when price exceeds today's high), "above_level" (trigger above a specific price), "below_todays_low" (trigger below today's low), "below_level" (trigger below a specific price)
+  - trigger_price: the specific dollar price to trigger entry (e.g. 25.58). null when entry_context is "above_todays_high" or "below_todays_low" (resolved at runtime)
+  - targets: array of target prices for the underlying stock [26, 27]
+  - setup_type: "pocket_pivot", "breakout", "bullish_engulfing", or "volume_breakout"
+Do NOT use the longTriggerAbove/shortTriggerBelow format for options_signal videos. Use the format above.`;
 
 async function callGroq(apiKey: string, systemPrompt: string, userPrompt: string): Promise<string> {
   const res = await fetch(GROQ_URL, {
@@ -259,7 +277,7 @@ Deno.serve(async (req) => {
     }
   }
 
-  const VALID_STRATEGY_TYPES = ['daily_signal', 'daily_penny', 'generic_strategy'] as const;
+  const VALID_STRATEGY_TYPES = ['daily_signal', 'daily_penny', 'options_signal', 'generic_strategy'] as const;
   const extractedStrategyType = VALID_STRATEGY_TYPES.includes(extracted.strategy_type as typeof VALID_STRATEGY_TYPES[number])
     ? (extracted.strategy_type as string) : null;
   let strategy_type = extractedStrategyType;
@@ -348,7 +366,7 @@ Deno.serve(async (req) => {
   }
 
   const summary = extracted.summary ? String(extracted.summary).trim() : null;
-  const VALID_SETUP_TYPES = ['breakout', 'momentum', 'pullback_vwap', 'range'] as const;
+  const VALID_SETUP_TYPES = ['breakout', 'momentum', 'pullback_vwap', 'range', 'pocket_pivot', 'bullish_engulfing', 'volume_breakout'] as const;
   const setup_type = VALID_SETUP_TYPES.includes(extracted.setup_type as typeof VALID_SETUP_TYPES[number])
     ? (extracted.setup_type as string)
     : null;
@@ -388,7 +406,7 @@ Deno.serve(async (req) => {
 
   // For daily_signal videos with extracted signals: auto-import into external_strategy_signals
   // so the auto-trader picks them up on trade_date. Fire-and-forget (non-blocking).
-  if ((strategy_type === 'daily_signal' || strategy_type === 'daily_penny') && extracted_signals.length > 0) {
+  if ((strategy_type === 'daily_signal' || strategy_type === 'daily_penny' || strategy_type === 'options_signal') && extracted_signals.length > 0) {
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
     const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
     fetch(`${supabaseUrl}/functions/v1/import-strategy-signals`, {

--- a/supabase/functions/import-strategy-signals/index.ts
+++ b/supabase/functions/import-strategy-signals/index.ts
@@ -29,6 +29,12 @@ interface ExtractedSignal {
   shortTargets?: number[];
   stopLoss?: number | null;
   notes?: string | null;
+  // Options signal fields (from options_signal strategy_type)
+  signal?: 'BUY_CALL' | 'BUY_PUT';
+  entry_context?: 'above_todays_high' | 'above_level' | 'below_todays_low' | 'below_level';
+  trigger_price?: number | null;
+  targets?: number[];
+  setup_type?: string | null;
 }
 
 interface ExecutionWindow {
@@ -112,14 +118,15 @@ Deno.serve(async (req) => {
     });
   }
 
-  if (video.strategy_type !== 'daily_signal' && video.strategy_type !== 'daily_penny') {
+  if (video.strategy_type !== 'daily_signal' && video.strategy_type !== 'daily_penny' && video.strategy_type !== 'options_signal') {
     return new Response(
-      JSON.stringify({ ok: true, skipped: true, reason: 'Not a daily_signal or daily_penny — no signals to import' }),
+      JSON.stringify({ ok: true, skipped: true, reason: 'Not a daily_signal, daily_penny, or options_signal — no signals to import' }),
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
   const isPenny = video.strategy_type === 'daily_penny';
+  const isOptionsSignal = video.strategy_type === 'options_signal';
 
   const signals = (Array.isArray(video.extracted_signals) ? video.extracted_signals : []) as ExtractedSignal[];
   if (signals.length === 0) {
@@ -238,6 +245,31 @@ Deno.serve(async (req) => {
     }
   }
 
+  /** Fetch Finnhub quote for a ticker — returns { c: current, h: high, l: low, pc: prevClose } or null */
+  async function getFinnhubQuote(ticker: string): Promise<{ c: number; h: number; l: number; pc: number } | null> {
+    if (!finnhubApiKey) return null;
+    try {
+      const res = await fetch(
+        `https://finnhub.io/api/v1/quote?symbol=${encodeURIComponent(ticker)}&token=${finnhubApiKey}`,
+        { signal: AbortSignal.timeout(5_000) }
+      );
+      if (!res.ok) return null;
+      const data = await res.json() as Record<string, unknown>;
+      if (!data?.c || data.c === 0) return null;
+      return data as unknown as { c: number; h: number; l: number; pc: number };
+    } catch {
+      return null;
+    }
+  }
+
+  /** Compute next trading day after tradeDate (skips weekends) */
+  function nextTradingDay(dateStr: string): string {
+    const d = new Date(`${dateStr}T12:00:00Z`);
+    d.setUTCDate(d.getUTCDate() + 1);
+    while (d.getUTCDay() === 0 || d.getUTCDay() === 6) d.setUTCDate(d.getUTCDate() + 1);
+    return d.toISOString().split('T')[0];
+  }
+
   const toInsert: Record<string, unknown>[] = [];
 
   for (const sig of signals) {
@@ -261,6 +293,7 @@ Deno.serve(async (req) => {
     const allPriceLevels = [
       sig.longTriggerAbove, sig.shortTriggerBelow,
       ...(sig.longTargets ?? []), ...(sig.shortTargets ?? []),
+      sig.trigger_price, ...(sig.targets ?? []),
     ].filter((p): p is number => p != null);
     if (priceFloor && allPriceLevels.some(p => p < priceFloor)) {
       console.warn(`[import-strategy-signals] Skipping ${ticker} — price levels ${JSON.stringify(allPriceLevels)} below minimum $${priceFloor} (likely extraction error)`);
@@ -269,6 +302,74 @@ Deno.serve(async (req) => {
 
     const stopLoss = sig.stopLoss ?? null;
     const noteText = sig.notes ?? null;
+
+    // Options signal path (BUY_CALL / BUY_PUT from pocket/breakout setups)
+    if (isOptionsSignal && (sig.signal === 'BUY_CALL' || sig.signal === 'BUY_PUT')) {
+      const isCall = sig.signal === 'BUY_CALL';
+      const mode = isCall ? 'OPTIONS_CALL' : 'OPTIONS_PUT';
+      const targets = sig.targets ?? [];
+      const primaryTarget = targets[0] ?? null;
+      const targetSummary = targets.length > 0
+        ? targets.map((t, i) => `T${i + 1}: ${t}`).join(', ')
+        : null;
+
+      let entryPrice = sig.trigger_price ?? null;
+      const entryCtx = sig.entry_context ?? 'above_level';
+
+      // Resolve "above_todays_high" / "below_todays_low" using Finnhub quote
+      if (entryPrice == null && (entryCtx === 'above_todays_high' || entryCtx === 'below_todays_low')) {
+        const quote = await getFinnhubQuote(ticker);
+        if (quote) {
+          // Pre-market: use previous close as proxy; during market hours: use day high/low
+          const nowHourET = new Date().toLocaleString('en-US', { timeZone: 'America/New_York', hour: 'numeric', hour12: false });
+          const hourET = parseInt(nowHourET);
+          if (entryCtx === 'above_todays_high') {
+            const raw = (hourET >= 10 && hourET < 16 && quote.h > 0) ? quote.h : quote.pc;
+            entryPrice = Math.round(raw * 1.002 * 100) / 100; // +0.2% buffer
+          } else {
+            const raw = (hourET >= 10 && hourET < 16 && quote.l > 0) ? quote.l : quote.pc;
+            entryPrice = Math.round(raw * 0.998 * 100) / 100; // -0.2% buffer
+          }
+          console.log(`[import-strategy-signals] ${ticker}: resolved ${entryCtx} → $${entryPrice} (from Finnhub ${hourET >= 10 ? 'intraday' : 'prevClose'})`);
+        } else {
+          console.warn(`[import-strategy-signals] ${ticker}: could not resolve ${entryCtx} — no Finnhub quote, skipping`);
+          continue;
+        }
+      }
+
+      // Options signals expire at end of next trading day (generous window for breakout triggers)
+      const optionsExpiresAt = toUtcTimestamp(nextTradingDay(tradeDate), '16:00');
+      const optionsExecuteAt = toUtcTimestamp(tradeDate, '09:35');
+
+      const setupLabel = sig.setup_type ?? setupType ?? 'breakout';
+      const notesParts = [
+        `${isCall ? 'Call' : 'Put'} — ${setupLabel}`,
+        entryCtx === 'above_todays_high' ? 'above today\'s high' :
+          entryCtx === 'below_todays_low' ? 'below today\'s low' :
+          entryPrice != null ? `${isCall ? 'above' : 'below'} $${entryPrice}` : null,
+        targetSummary ? `targets: ${targetSummary}` : null,
+      ].filter(Boolean).join(' | ');
+
+      toInsert.push({
+        source_name: video.source_name,
+        source_url: sourceUrl,
+        ticker,
+        signal: 'BUY',
+        mode,
+        confidence: 7,
+        entry_price: entryPrice,
+        stop_loss: null,
+        target_price: primaryTarget,
+        execute_on_date: tradeDate,
+        execute_at: optionsExecuteAt,
+        expires_at: optionsExpiresAt,
+        notes: notesParts,
+        status: 'PENDING',
+        strategy_video_id: videoId,
+        strategy_video_heading: video.video_heading ?? null,
+      });
+      continue;
+    }
 
     // Long (BUY) signal — one row per entry level (unique constraint is on ticker+signal+entry_price+date).
     // Use the first target as primary; additional targets go into notes for human reference.


### PR DESCRIPTION
## Summary
- Full pipeline: video ingestion → Groq extraction → signal import → options order execution
- Supports conditional entries (above today's high, above specific level)
- Routes BUY_CALL → OPTIONS_CALL mode, BUY_PUT → OPTIONS_PUT mode
- v1: 1 contract, ATM strike, ~14 DTE, BUY limit at ask

## Test plan
- [ ] Submit a pocket trading video and verify extraction
- [ ] Verify signals appear as OPTIONS_CALL/OPTIONS_PUT in UI
- [ ] Verify options_signal category appears in Influencers dropdown
- [ ] Monitor trigger check and options order placement

Made with [Cursor](https://cursor.com)