### PR TITLE
Add options place-order route and fix mode routing reconciliation

### DIFF
--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -129,8 +129,31 @@ export async function loadConfig(): Promise<AutoTraderConfig> {
     pennyMaxDailyLoss: Number(data.penny_max_daily_loss ?? DEFAULT_CONFIG.pennyMaxDailyLoss),
     pennyMaxDailyTrades: Number(data.penny_max_daily_trades ?? DEFAULT_CONFIG.pennyMaxDailyTrades),
     trendFilterEnabled: data.trend_filter_enabled ?? DEFAULT_CONFIG.trendFilterEnabled,
-    // Dual-account routing
-    modeRouting: data.mode_routing ?? DEFAULT_CONFIG.modeRouting,
+    // Dual-account routing — reconcile with boolean flags to prevent drift.
+    // If a boolean flag says disabled but mode_routing says enabled, the boolean wins
+    // (more restrictive). This guards against the migration that added mode_routing
+    // with all-"paper" defaults without reading the pre-existing boolean state.
+    modeRouting: (() => {
+      const routing = { ...(data.mode_routing ?? DEFAULT_CONFIG.modeRouting) };
+      if (data.suggested_finds_enabled === false && routing.LONG_TERM !== 'off') {
+        console.warn('[Config] suggested_finds_enabled=false but mode_routing.LONG_TERM=%s — forcing to off', routing.LONG_TERM);
+        routing.LONG_TERM = 'off';
+      }
+      if (data.trade_signals_enabled === false) {
+        if (routing.DAY_TRADE !== 'off') routing.DAY_TRADE = 'off';
+        if (routing.SWING_TRADE !== 'off') routing.SWING_TRADE = 'off';
+      }
+      if (data.options_wheel_enabled === false) {
+        if (routing.OPTIONS_PUT !== 'off') routing.OPTIONS_PUT = 'off';
+        if (routing.OPTIONS_CALL !== 'off') routing.OPTIONS_CALL = 'off';
+        if (routing.CREDIT_SPREAD !== 'off') routing.CREDIT_SPREAD = 'off';
+        if (routing.CALENDAR_SPREAD !== 'off') routing.CALENDAR_SPREAD = 'off';
+      }
+      if (data.penny_enabled === false && routing.DAY_PENNY !== 'off') {
+        routing.DAY_PENNY = 'off';
+      }
+      return routing;
+    })(),
     liveKillSwitch: data.live_kill_switch ?? DEFAULT_CONFIG.liveKillSwitch,
     liveDailyLossLimit: Number(data.live_daily_loss_limit ?? DEFAULT_CONFIG.liveDailyLossLimit),
     livePortfolioValue: Number(data.live_portfolio_value ?? DEFAULT_CONFIG.livePortfolioValue),

--- a/auto-trader/src/routes/options.ts
+++ b/auto-trader/src/routes/options.ts
@@ -2,6 +2,8 @@ import { Router } from 'express';
 import { findBestContractForStrike } from '../lib/options-chain.js';
 import { fetchQuote } from '../lib/yahoo-finance.js';
 import { getFundamentalGrade } from '../lib/fundamental-grader.js';
+import { isConnected, placeOptionsOrder, getDefaultAccount, getPaperConnection } from '../ib-connection.js';
+import { getSupabase, createAutoTradeEvent } from '../lib/supabase.js';
 
 const router = Router();
 
@@ -39,6 +41,103 @@ router.get('/options/strike-sniper', async (req, res) => {
     });
   } catch (err) {
     res.status(500).json({ error: err instanceof Error ? err.message : 'Strike sniper failed' });
+  }
+});
+
+/**
+ * POST /api/options/place-order
+ * Place an IB order for an existing paper trade that was recorded without one (paper fallback).
+ * Body: { tradeId }
+ */
+router.post('/options/place-order', async (req, res) => {
+  try {
+    const { tradeId } = req.body;
+    if (!tradeId) {
+      return res.status(400).json({ error: 'tradeId is required' });
+    }
+
+    if (!isConnected()) {
+      return res.status(503).json({ error: 'IB Gateway not connected' });
+    }
+
+    const sb = getSupabase();
+    const { data: trade, error } = await sb
+      .from('paper_trades')
+      .select('id, ticker, mode, option_strike, option_expiry, option_premium, ib_order_id, status')
+      .eq('id', tradeId)
+      .single();
+
+    if (error || !trade) {
+      return res.status(404).json({ error: 'Trade not found' });
+    }
+    if (trade.ib_order_id) {
+      return res.status(400).json({ error: `Trade already has IB order #${trade.ib_order_id}` });
+    }
+
+    const right = trade.mode === 'OPTIONS_CALL' ? 'C' : 'P';
+    let expiry = trade.option_expiry.replace(/-/g, '');
+
+    // Allow overriding limit price via request body (premium may have changed)
+    const limitPrice = req.body.limitPrice ?? trade.option_premium;
+
+    // Resolve correct IB expiry — try the stored date, then ±1 day (IB can use
+    // settlement date vs last trade date which differs by a day for monthlies)
+    const conn = getPaperConnection();
+    let resolvedExpiry: string | null = null;
+    for (const offset of [0, 1, -1, 2]) {
+      const d = new Date(
+        parseInt(expiry.slice(0, 4)),
+        parseInt(expiry.slice(4, 6)) - 1,
+        parseInt(expiry.slice(6, 8)) + offset,
+      );
+      const candidate = `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
+      const conId = await conn.resolveOptionConId(trade.ticker, right, trade.option_strike, candidate);
+      if (conId) {
+        resolvedExpiry = candidate;
+        break;
+      }
+    }
+    if (resolvedExpiry) expiry = resolvedExpiry;
+
+    const { orderId, avgFillPrice, filledQty } = await placeOptionsOrder({
+      symbol: trade.ticker,
+      right,
+      strike: trade.option_strike,
+      expiry,
+      contracts: 1,
+      limitPrice,
+      account: getDefaultAccount() ?? undefined,
+    });
+
+    await sb.from('paper_trades').update({
+      ib_order_id: orderId,
+      fill_price: avgFillPrice,
+      status: 'FILLED',
+      filled_at: new Date().toISOString(),
+    }).eq('id', tradeId);
+
+    createAutoTradeEvent({
+      ticker: trade.ticker,
+      event_type: 'success',
+      action: 'executed',
+      source: 'scanner',
+      mode: trade.mode,
+      message: `IB order filled #${orderId} — Sold ${filledQty}x $${trade.option_strike}${right} exp ${trade.option_expiry} @ $${avgFillPrice.toFixed(2)}/contract (manual placement)`,
+      metadata: { ibOrderId: orderId, strike: trade.option_strike, expiry: trade.option_expiry, premium: avgFillPrice, contracts: filledQty },
+    }).catch(() => {});
+
+    res.json({
+      success: true,
+      orderId,
+      avgFillPrice,
+      filledQty,
+      ticker: trade.ticker,
+      strike: trade.option_strike,
+    });
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : 'Unknown error';
+    console.error('[Route: options/place-order]', errMsg);
+    res.status(500).json({ error: errMsg });
   }
 });
 

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -6433,7 +6433,9 @@ async function runSchedulerCycle(): Promise<void> {
     // 6. Pre-generate Suggested Finds (daily, after market open only)
     // Moved AFTER the market hours gate — belt-and-suspenders to prevent pre-market order placement.
     // Runs after sync+reset so SF trades are tracked in _pendingDeployedDollar for this cycle.
-    if (isModeEnabled(config, 'LONG_TERM')) {
+    // Belt-and-suspenders: check BOTH mode_routing AND suggestedFindsEnabled.
+    // These can get out of sync if the frontend saves one but not the other.
+    if (isModeEnabled(config, 'LONG_TERM') && config.suggestedFindsEnabled !== false) {
       await preGenerateSuggestedFinds(config, positions);
     } else {
       log('Suggested Finds module disabled — skipping');


### PR DESCRIPTION
## Summary
- New `POST /api/options/place-order` endpoint to manually place IB orders for options trades that fell back to paper-only (e.g., when IB was offline at scan time). Includes smart expiry resolution (tries ±1 day for IB contract matching).
- Reconcile `mode_routing` with boolean feature flags (`suggested_finds_enabled`, `trade_signals_enabled`, etc.) in config loader to prevent drift.
- Belt-and-suspenders gate: suggested finds now checks both `isModeEnabled` AND `suggestedFindsEnabled`.

## Test plan
- [x] Auto-trader builds cleanly (`npm run build`)
- [x] App builds cleanly (`npm run build`)
- [x] Auto-trader restarts and connects to IB
- [x] Tested place-order route (correctly rejects when IB paper lacks options contract defs)


Made with [Cursor](https://cursor.com)