### PR TITLE
Fix options signals misrouted as DAY_TRADE from options_signal videos

### DIFF
--- a/supabase/functions/import-strategy-signals/index.ts
+++ b/supabase/functions/import-strategy-signals/index.ts
@@ -304,17 +304,26 @@ Deno.serve(async (req) => {
     const noteText = sig.notes ?? null;
 
     // Options signal path (BUY_CALL / BUY_PUT from pocket/breakout setups)
-    if (isOptionsSignal && (sig.signal === 'BUY_CALL' || sig.signal === 'BUY_PUT')) {
-      const isCall = sig.signal === 'BUY_CALL';
+    // Fallback: when strategy_type is options_signal but the LLM returned the
+    // longTriggerAbove/shortTriggerBelow format instead of BUY_CALL/BUY_PUT,
+    // convert automatically so these don't get misrouted as DAY_TRADE.
+    let effectiveSignal = sig.signal;
+    if (isOptionsSignal && !effectiveSignal) {
+      if (sig.longTriggerAbove != null) effectiveSignal = 'BUY_CALL';
+      else if (sig.shortTriggerBelow != null) effectiveSignal = 'BUY_PUT';
+    }
+
+    if (isOptionsSignal && (effectiveSignal === 'BUY_CALL' || effectiveSignal === 'BUY_PUT')) {
+      const isCall = effectiveSignal === 'BUY_CALL';
       const mode = isCall ? 'OPTIONS_CALL' : 'OPTIONS_PUT';
-      const targets = sig.targets ?? [];
+      const targets = sig.targets ?? (isCall ? sig.longTargets : sig.shortTargets) ?? [];
       const primaryTarget = targets[0] ?? null;
       const targetSummary = targets.length > 0
         ? targets.map((t, i) => `T${i + 1}: ${t}`).join(', ')
         : null;
 
-      let entryPrice = sig.trigger_price ?? null;
-      const entryCtx = sig.entry_context ?? 'above_level';
+      let entryPrice = sig.trigger_price ?? (isCall ? sig.longTriggerAbove : sig.shortTriggerBelow) ?? null;
+      const entryCtx = sig.entry_context ?? (entryPrice != null ? 'above_level' : 'above_todays_high');
 
       // Resolve "above_todays_high" / "below_todays_low" using Finnhub quote
       if (entryPrice == null && (entryCtx === 'above_todays_high' || entryCtx === 'below_todays_low')) {

--- a/supabase/migrations/20260519000001_external_signals_options_mode.sql
+++ b/supabase/migrations/20260519000001_external_signals_options_mode.sql
@@ -1,0 +1,10 @@
+-- Extend external_strategy_signals.mode CHECK to include OPTIONS_CALL and OPTIONS_PUT.
+-- Previously only DAY_TRADE, SWING_TRADE, LONG_TERM, DAY_PENNY were allowed,
+-- which caused options_signal videos to be misrouted as DAY_TRADE.
+
+ALTER TABLE external_strategy_signals
+  DROP CONSTRAINT IF EXISTS external_strategy_signals_mode_check;
+
+ALTER TABLE external_strategy_signals
+  ADD CONSTRAINT external_strategy_signals_mode_check
+    CHECK (mode IN ('DAY_TRADE', 'SWING_TRADE', 'LONG_TERM', 'DAY_PENNY', 'OPTIONS_CALL', 'OPTIONS_PUT'));


### PR DESCRIPTION
## Summary
- Adds `OPTIONS_CALL` / `OPTIONS_PUT` to `external_strategy_signals.mode` CHECK constraint (was missing, causing insert failures)
- Adds fallback in `import-strategy-signals` edge function: when `strategy_type` is `options_signal` but the LLM returned `longTriggerAbove`/`shortTriggerBelow` format instead of `BUY_CALL`/`BUY_PUT`, automatically converts to the correct options format with proper targets and entry prices
- Fixes Ali S (Options Trading Coach) signals being misrouted as `DAY_TRADE` with mangled entry prices (e.g. `2558` instead of `$25.58`)

## Changes
- `supabase/migrations/20260519000001_external_signals_options_mode.sql` — constraint update
- `supabase/functions/import-strategy-signals/index.ts` — LLM format fallback

## Already applied
- DB constraint updated on production
- Edge function deployed
- OSCR signal corrected to `OPTIONS_CALL` with `entry_price: 25.58`


Made with [Cursor](https://cursor.com)