### PR TITLE
fix: exclude null-pnl trades from win rate calculation

### DIFF
--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -751,11 +751,12 @@ export async function recalculatePerformance(accountView: AccountView = 'paper')
 
   if (error || !trades || trades.length === 0) return null;
 
-  // Only count trades that actually filled — exclude expired/unfilled orders
-  const completed = (trades as PaperTrade[]).filter(t => t.fill_price != null);
-  const wins = completed.filter(t => (t.pnl ?? 0) > 0);
-  const losses = completed.filter(t => (t.pnl ?? 0) < 0);
-  const breakevens = completed.filter(t => (t.pnl ?? 0) === 0);
+  // Only count trades that actually filled AND have computed P&L
+  // Trades with null pnl (legacy closes before recordTradeClose) are excluded
+  const completed = (trades as PaperTrade[]).filter(t => t.fill_price != null && t.pnl != null);
+  const wins = completed.filter(t => t.pnl! > 0);
+  const losses = completed.filter(t => t.pnl! < 0);
+  const breakevens = completed.filter(t => t.pnl === 0);
 
   const totalPnl = completed.reduce((sum, t) => sum + (t.pnl ?? 0), 0);
   const avgPnl = completed.length > 0 ? totalPnl / completed.length : 0;
@@ -950,10 +951,10 @@ export async function recalculatePerformanceByCategory(accountView: AccountView 
 
     const active = meaningful.filter(t => (ACTIVE_STATUSES as readonly string[]).includes(t.status));
     const completed = meaningful.filter(
-      t => (CLOSED_STATUSES as readonly string[]).includes(t.status) && t.fill_price != null
+      t => (CLOSED_STATUSES as readonly string[]).includes(t.status) && t.fill_price != null && t.pnl != null
     );
-    const wins = completed.filter(t => (t.pnl ?? 0) > 0);
-    const losses = completed.filter(t => (t.pnl ?? 0) < 0);
+    const wins = completed.filter(t => t.pnl! > 0);
+    const losses = completed.filter(t => t.pnl! < 0);
 
     const realizedPnl = completed.reduce((s, t) => s + (t.pnl ?? 0), 0);
     const avgPnl = completed.length > 0 ? realizedPnl / completed.length : 0;
@@ -1052,14 +1053,13 @@ export async function recalculatePerformanceByStrategySource(accountView: Accoun
       }
     }
 
-    if (closedStatusSet.has(trade.status) && trade.fill_price != null) {
+    if (closedStatusSet.has(trade.status) && trade.fill_price != null && trade.pnl != null) {
       curr.closedCount += 1;
-      const pnl = trade.pnl ?? 0;
-      curr.closedPnl += pnl;
-      if (pnl > 0) curr.wins += 1;
-      if (pnl < 0) curr.losses += 1;
+      curr.closedPnl += trade.pnl;
+      if (trade.pnl > 0) curr.wins += 1;
+      if (trade.pnl < 0) curr.losses += 1;
       curr.closedOutcomes.push({
-        pnl,
+        pnl: trade.pnl,
         at: trade.closed_at ?? trade.opened_at ?? '',
       });
     }
@@ -1194,18 +1194,17 @@ export async function recalculatePerformanceByStrategyVideo(accountView: Account
       }
     }
 
-    if (closedStatusSet.has(trade.status) && trade.fill_price != null) {
+    if (closedStatusSet.has(trade.status) && trade.fill_price != null && trade.pnl != null) {
       curr.closedCount += 1;
-      const pnl = trade.pnl ?? 0;
-      curr.closedPnl += pnl;
-      if (pnl > 0) curr.wins += 1;
-      if (pnl < 0) curr.losses += 1;
+      curr.closedPnl += trade.pnl;
+      if (trade.pnl > 0) curr.wins += 1;
+      if (trade.pnl < 0) curr.losses += 1;
       curr.closedOutcomes.push({
-        pnl,
+        pnl: trade.pnl,
         at: trade.closed_at ?? trade.opened_at ?? '',
       });
       if (trade.fill_price && trade.quantity) {
-        curr.returns.push((pnl / (trade.fill_price * trade.quantity)) * 100);
+        curr.returns.push((trade.pnl / (trade.fill_price * trade.quantity)) * 100);
       }
     }
 

--- a/auto-trader/src/lib/feedback.ts
+++ b/auto-trader/src/lib/feedback.ts
@@ -239,17 +239,17 @@ export async function recalculatePerformance(): Promise<boolean> {
 
   if (error || !trades || trades.length === 0) return false;
 
-  const completed = trades.filter((t: { fill_price: unknown }) => t.fill_price != null);
-  const wins = completed.filter((t: { pnl: number }) => (t.pnl ?? 0) > 0);
-  const losses = completed.filter((t: { pnl: number }) => (t.pnl ?? 0) < 0);
-  const breakevens = completed.filter((t: { pnl: number }) => (t.pnl ?? 0) === 0);
+  const completed = trades.filter((t: { fill_price: unknown; pnl: unknown }) => t.fill_price != null && t.pnl != null);
+  const wins = completed.filter((t: { pnl: number }) => t.pnl > 0);
+  const losses = completed.filter((t: { pnl: number }) => t.pnl < 0);
+  const breakevens = completed.filter((t: { pnl: number }) => t.pnl === 0);
 
-  const totalPnl = completed.reduce((sum: number, t: { pnl: number }) => sum + (t.pnl ?? 0), 0);
+  const totalPnl = completed.reduce((sum: number, t: { pnl: number }) => sum + t.pnl, 0);
   const avgPnl = completed.length > 0 ? totalPnl / completed.length : 0;
-  const avgWin = wins.length > 0 ? wins.reduce((s: number, t: { pnl: number }) => s + (t.pnl ?? 0), 0) / wins.length : 0;
-  const avgLoss = losses.length > 0 ? losses.reduce((s: number, t: { pnl: number }) => s + (t.pnl ?? 0), 0) / losses.length : 0;
-  const bestPnl = Math.max(...completed.map((t: { pnl: number }) => t.pnl ?? 0), 0);
-  const worstPnl = Math.min(...completed.map((t: { pnl: number }) => t.pnl ?? 0), 0);
+  const avgWin = wins.length > 0 ? wins.reduce((s: number, t: { pnl: number }) => s + t.pnl, 0) / wins.length : 0;
+  const avgLoss = losses.length > 0 ? losses.reduce((s: number, t: { pnl: number }) => s + t.pnl, 0) / losses.length : 0;
+  const bestPnl = Math.max(...completed.map((t: { pnl: number }) => t.pnl), 0);
+  const worstPnl = Math.min(...completed.map((t: { pnl: number }) => t.pnl), 0);
 
   const { error: updateErr } = await sb
     .from('trade_performance')

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -617,12 +617,11 @@ export async function getStrategySourcePerformance(): Promise<StrategySourcePerf
       }
     }
 
-    if (closedStatuses.has(trade.status) && trade.fill_price != null) {
+    if (closedStatuses.has(trade.status) && trade.fill_price != null && trade.pnl != null) {
       curr.closedCount += 1;
-      const pnl = trade.pnl ?? 0;
-      curr.closedPnl += pnl;
-      if (pnl > 0) curr.wins += 1;
-      if (pnl < 0) curr.losses += 1;
+      curr.closedPnl += trade.pnl;
+      if (trade.pnl > 0) curr.wins += 1;
+      if (trade.pnl < 0) curr.losses += 1;
     }
 
     bySource.set(source, curr);

--- a/supabase/functions/paper-trading-performance/index.ts
+++ b/supabase/functions/paper-trading-performance/index.ts
@@ -97,8 +97,8 @@ function computeGroupMetrics(rows: TradePerformanceRow[]): GroupMetrics {
   const sumLosses = Math.abs(losses.reduce((a, b) => a + b, 0));
   const profitFactor = sumLosses > 0 ? sumWins / sumLosses : (sumWins > 0 ? Infinity : 0);
   return {
-    count_trades_closed: rows.length,
-    win_rate: rows.length > 0 ? wins.length / rows.length : 0,
+    count_trades_closed: pnls.length,
+    win_rate: pnls.length > 0 ? wins.length / pnls.length : 0,
     avg_return_pct: returns.length > 0 ? returns.reduce((a, b) => a + b, 0) / returns.length : 0,
     median_return_pct: median(returns),
     stdev_return_pct: stdev(returns),


### PR DESCRIPTION
## Summary
- Win rate showed 18% instead of ~49% because 346 trades with `pnl IS NULL` were coerced to 0 via `(t.pnl ?? 0)`, counting as fake breakevens
- These null-pnl trades are from legacy closes (before `recordTradeClose` was introduced on May 18) where PnL was never computed
- Fix: add `t.pnl != null` guard to the `completed` filter in all 6 win rate callsites across frontend, auto-trader, and edge functions

## Files changed
- `app/src/lib/paperTradesApi.ts` — 4 callsites (global perf, category, strategy source, strategy video)
- `auto-trader/src/lib/feedback.ts` — 1 callsite (recalculatePerformance)
- `auto-trader/src/lib/supabase.ts` — 1 callsite (strategy source perf)
- `supabase/functions/paper-trading-performance/index.ts` — denominator fix

## Test plan
- [ ] Dashboard win rate should show ~49% instead of 18%
- [ ] Strategy Tracker win rates should also be corrected
- [ ] No regression in P&L totals (null trades excluded from counts, not from sums that already handled nulls)


Made with [Cursor](https://cursor.com)