### PR TITLE
fix: exclude null-pnl trades from all remaining performance tabs

### DIFF
--- a/app/src/components/PaperTrading/shared/StreakBoard.tsx
+++ b/app/src/components/PaperTrading/shared/StreakBoard.tsx
@@ -98,7 +98,7 @@ export function StreakBoard() {
           if (row.modes.includes(t.mode)) {
             const key = `${row.key}|${dateStr}`;
             const existing = byModeDate.get(key) ?? { pnl: 0, count: 0 };
-            existing.pnl += t.pnl ?? 0;
+            existing.pnl += t.pnl!;
             existing.count += 1;
             byModeDate.set(key, existing);
           }

--- a/app/src/components/PaperTrading/tabs/HistoryTab.tsx
+++ b/app/src/components/PaperTrading/tabs/HistoryTab.tsx
@@ -41,7 +41,12 @@ export function HistoryTab({ trades, pendingSignals, accountView }: HistoryTabPr
     switch (sortKey) {
       case 'date': cmp = new Date(a.opened_at).getTime() - new Date(b.opened_at).getTime(); break;
       case 'ticker': cmp = a.ticker.localeCompare(b.ticker); break;
-      case 'pnl': cmp = (a.pnl ?? 0) - (b.pnl ?? 0); break;
+      case 'pnl': {
+        const aPnl = a.pnl ?? -Infinity;
+        const bPnl = b.pnl ?? -Infinity;
+        cmp = aPnl - bPnl;
+        break;
+      }
       case 'signal': cmp = (a.signal ?? '').localeCompare(b.signal ?? ''); break;
       case 'status': cmp = (a.status ?? '').localeCompare(b.status ?? ''); break;
     }
@@ -72,9 +77,10 @@ export function HistoryTab({ trades, pendingSignals, accountView }: HistoryTabPr
   const activeTrades = trades.filter(t => ['SUBMITTED', 'FILLED', 'PARTIAL', 'PENDING'].includes(t.status));
   const totalPendingLike = activeTrades.length + pendingSignals.length;
   const confirmedPnl = (t: typeof trades[0]) => t.pnl_source != null ? t.pnl : null;
-  const totalPnl = trades.reduce((s, t) => s + (confirmedPnl(t) ?? 0), 0);
-  const wins = trades.filter(t => (confirmedPnl(t) ?? 0) > 0).length;
-  const losses = trades.filter(t => (confirmedPnl(t) ?? 0) < 0).length;
+  const tradesWithPnl = trades.filter(t => confirmedPnl(t) != null);
+  const totalPnl = tradesWithPnl.reduce((s, t) => s + confirmedPnl(t)!, 0);
+  const wins = tradesWithPnl.filter(t => confirmedPnl(t)! > 0).length;
+  const losses = tradesWithPnl.filter(t => confirmedPnl(t)! < 0).length;
 
   return (
     <div className="space-y-3">
@@ -197,7 +203,7 @@ export function HistoryTab({ trades, pendingSignals, accountView }: HistoryTabPr
                   <td className="px-4 py-3 text-right tabular-nums">
                     {trade.close_price ? `$${trade.close_price.toFixed(2)}` : '—'}
                   </td>
-                  <td className={`px-4 py-3 text-right tabular-nums font-semibold ${(confirmedPnl(trade) ?? 0) > 0 ? 'text-emerald-600' : (confirmedPnl(trade) ?? 0) < 0 ? 'text-red-600' : ''}`}>
+                  <td className={`px-4 py-3 text-right tabular-nums font-semibold ${confirmedPnl(trade) != null && confirmedPnl(trade)! > 0 ? 'text-emerald-600' : confirmedPnl(trade) != null && confirmedPnl(trade)! < 0 ? 'text-red-600' : ''}`}>
                     {confirmedPnl(trade) != null ? fmtUsd(confirmedPnl(trade)!, 2, true) : '—'}
                   </td>
                   <td className="px-4 py-3">

--- a/app/src/components/PaperTrading/tabs/StrategyPerformanceTab.tsx
+++ b/app/src/components/PaperTrading/tabs/StrategyPerformanceTab.tsx
@@ -1346,13 +1346,13 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
                                         <td className="py-1.5 text-right text-[hsl(var(--muted-foreground))]">—</td>
                                         <td className={cn(
                                           'py-1.5 text-right tabular-nums font-medium',
-                                          (trade.pnlPercent ?? 0) > 0 ? 'text-emerald-600' : (trade.pnlPercent ?? 0) < 0 ? 'text-red-600' : 'text-[hsl(var(--muted-foreground))]'
+                                          trade.pnlPercent != null && trade.pnlPercent > 0 ? 'text-emerald-600' : trade.pnlPercent != null && trade.pnlPercent < 0 ? 'text-red-600' : 'text-[hsl(var(--muted-foreground))]'
                                         )}>
                                           {trade.pnlPercent == null ? '—' : `${trade.pnlPercent >= 0 ? '+' : ''}${trade.pnlPercent.toFixed(2)}%`}
                                         </td>
                                         <td className={cn(
                                           'py-1.5 text-right tabular-nums font-semibold',
-                                          (trade.pnl ?? 0) > 0 ? 'text-emerald-600' : (trade.pnl ?? 0) < 0 ? 'text-red-600' : 'text-[hsl(var(--muted-foreground))]'
+                                          trade.pnl != null && trade.pnl > 0 ? 'text-emerald-600' : trade.pnl != null && trade.pnl < 0 ? 'text-red-600' : 'text-[hsl(var(--muted-foreground))]'
                                         )}>
                                           {trade.pnl == null ? 'Open' : fmtUsd(trade.pnl, 2, true)}
                                         </td>

--- a/app/src/lib/aiFeedback.ts
+++ b/app/src/lib/aiFeedback.ts
@@ -28,7 +28,7 @@ import { CLOSED_STATUSES } from '../../../shared/trade-status-sets.ts';
  * Uses the same Gemini model as trading signals for consistency.
  */
 export async function analyzeCompletedTrade(trade: PaperTrade): Promise<TradeLearning | null> {
-  if (!trade.closed_at || !trade.pnl) return null;
+  if (!trade.closed_at || trade.pnl == null) return null;
 
   const outcome: 'WIN' | 'LOSS' | 'BREAKEVEN' =
     trade.pnl > 0 ? 'WIN' : trade.pnl < 0 ? 'LOSS' : 'BREAKEVEN';
@@ -227,6 +227,8 @@ export async function analyzeUnreviewedTrades(): Promise<number> {
     .from('paper_trades')
     .select('*')
     .in('status', [...CLOSED_STATUSES])
+    .not('pnl', 'is', null)
+    .not('fill_price', 'is', null)
     .order('closed_at', { ascending: false })
     .limit(20);
 

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -268,19 +268,19 @@ export async function getDayTradeValidationReport(): Promise<DayTradeValidationR
   if (error) throw new Error(`Failed to fetch day trades: ${error.message}`);
   const trades = (data ?? []) as PaperTrade[];
 
-  const scannerTrades = trades.filter(t => t.entry_trigger_type === 'bracket_limit' && t.fill_price != null);
+  const scannerTrades = trades.filter(t => t.entry_trigger_type === 'bracket_limit' && t.fill_price != null && t.pnl != null);
   const withMarket = scannerTrades.filter(t => t.market_condition);
 
   const trendVsChop = ['trend', 'chop'].map(mc => {
     const subset = withMarket.filter(t => t.market_condition === mc);
-    const wins = subset.filter(t => (t.pnl ?? 0) > 0).length;
+    const wins = subset.filter(t => t.pnl! > 0).length;
     const rMults = subset.map(t => t.r_multiple).filter((r): r is number => r != null);
     return {
       marketCondition: mc,
       trades: subset.length,
       wins,
       winRatePct: subset.length > 0 ? Math.round(100 * wins / subset.length) : 0,
-      avgPnl: subset.length > 0 ? Math.round(100 * subset.reduce((s, t) => s + (t.pnl ?? 0), 0) / subset.length) / 100 : 0,
+      avgPnl: subset.length > 0 ? Math.round(100 * subset.reduce((s, t) => s + t.pnl!, 0) / subset.length) / 100 : 0,
       avgRMultiple: rMults.length > 0 ? Math.round(100 * rMults.reduce((a, b) => a + b, 0) / rMults.length) / 100 : 0,
     };
   }).filter(r => r.trades > 0);
@@ -291,7 +291,7 @@ export async function getDayTradeValidationReport(): Promise<DayTradeValidationR
     { subset: conf7Plus, label: 'conf ≥7' },
     { subset: confBelow7, label: 'conf <7' },
   ].map(({ subset, label }) => {
-    const wins = subset.filter(t => (t.pnl ?? 0) > 0).length;
+    const wins = subset.filter(t => t.pnl! > 0).length;
     const rMults = subset.map(t => t.r_multiple).filter((r): r is number => r != null);
     return {
       confBucket: label,
@@ -310,7 +310,7 @@ export async function getDayTradeValidationReport(): Promise<DayTradeValidationR
     { subset: midInPlay, label: 'mid (1.5–2.5)' },
     { subset: lowInPlay, label: 'low (<1.5)' },
   ].map(({ subset, label }) => {
-    const wins = subset.filter(t => (t.pnl ?? 0) > 0).length;
+    const wins = subset.filter(t => t.pnl! > 0).length;
     const rMults = subset.map(t => t.r_multiple).filter((r): r is number => r != null);
     return {
       bucket: label,
@@ -410,7 +410,7 @@ export async function getSwingTradeValidationReport(): Promise<SwingTradeValidat
   funnel.signalsPerWeek = days >= 1 ? Math.round((funnel.signals / days) * 5) : 0; // ~5 trading days/week
 
   const closed = trades.filter(
-    t => t.fill_price != null && (CLOSED_STATUSES as readonly string[]).includes(t.status)
+    t => t.fill_price != null && t.pnl != null && (CLOSED_STATUSES as readonly string[]).includes(t.status)
   );
   const bracketOrders = trades.filter(t => t.entry_trigger_type === 'bracket_limit');
   const filled = bracketOrders.filter(t => t.fill_price != null);
@@ -421,8 +421,8 @@ export async function getSwingTradeValidationReport(): Promise<SwingTradeValidat
     const mc = t.market_condition ?? 'unknown';
     const cur = byRegime.get(mc) ?? { trades: 0, wins: 0, pnl: 0 };
     cur.trades++;
-    if ((t.pnl ?? 0) > 0) cur.wins++;
-    cur.pnl += t.pnl ?? 0;
+    if (t.pnl! > 0) cur.wins++;
+    cur.pnl += t.pnl!;
     byRegime.set(mc, cur);
   }
   const trendVsChop = [...byRegime.entries()].map(([mc, s]) => ({
@@ -438,7 +438,7 @@ export async function getSwingTradeValidationReport(): Promise<SwingTradeValidat
     const r = t.close_reason ?? 'unknown';
     const cur = byReason.get(r) ?? { trades: 0, pnl: 0, daysHeld: [] };
     cur.trades++;
-    cur.pnl += t.pnl ?? 0;
+    cur.pnl += t.pnl!;
     if (t.filled_at && t.closed_at) {
       cur.daysHeld.push((new Date(t.closed_at).getTime() - new Date(t.filled_at).getTime()) / 86400000);
     }
@@ -458,9 +458,9 @@ export async function getSwingTradeValidationReport(): Promise<SwingTradeValidat
     const days = (new Date(t.closed_at).getTime() - new Date(t.filled_at).getTime()) / 86400000;
     return days < 2;
   });
-  const totalLosses = closed.filter(t => (t.pnl ?? 0) < 0);
-  const totalLossPnl = totalLosses.reduce((s, t) => s + (t.pnl ?? 0), 0);
-  const quickStopPnl = quickStops.reduce((s, t) => s + (t.pnl ?? 0), 0);
+  const totalLosses = closed.filter(t => t.pnl! < 0);
+  const totalLossPnl = totalLosses.reduce((s, t) => s + t.pnl!, 0);
+  const quickStopPnl = quickStops.reduce((s, t) => s + t.pnl!, 0);
   const pctOfLosses = totalLosses.length > 0 && totalLossPnl !== 0
     ? Math.round(100 * quickStopPnl / totalLossPnl)
     : 0;

--- a/auto-trader/src/lib/streak-tracker.ts
+++ b/auto-trader/src/lib/streak-tracker.ts
@@ -69,7 +69,7 @@ export async function getStreakMultiplier(mode: string, accountType: AccountType
       return 1.0;
     }
 
-    const wins = trades.filter(t => (t.pnl ?? 0) > 0).length;
+    const wins = trades.filter(t => t.pnl > 0).length;
     const winRate = wins / trades.length;
 
     const { data: stateRow } = await sb

--- a/auto-trader/src/lib/tradePerformanceMetrics.ts
+++ b/auto-trader/src/lib/tradePerformanceMetrics.ts
@@ -82,8 +82,8 @@ function computeGroupMetrics(rows: TradePerformanceRow[]): GroupMetrics {
   const sumLosses = Math.abs(losses.reduce((a, b) => a + b, 0));
   const profitFactor = sumLosses > 0 ? sumWins / sumLosses : (sumWins > 0 ? Infinity : 0);
   return {
-    count_trades_closed: rows.length,
-    win_rate: rows.length > 0 ? wins.length / rows.length : 0,
+    count_trades_closed: pnls.length,
+    win_rate: pnls.length > 0 ? wins.length / pnls.length : 0,
     avg_return_pct: returns.length > 0 ? returns.reduce((a, b) => a + b, 0) / returns.length : 0,
     median_return_pct: median(returns),
     stdev_return_pct: stdev(returns),
@@ -111,8 +111,9 @@ function aggregateByGroup(
 }
 
 function portfolioRealizedReturnPct(rows: TradePerformanceRow[]): number {
-  const totalNotional = rows.reduce((s, r) => s + (r.notional_at_entry ?? 0), 0);
-  const totalPnl = rows.reduce((s, r) => s + (r.realized_pnl ?? 0), 0);
+  const withPnl = rows.filter(r => r.realized_pnl != null && r.notional_at_entry != null);
+  const totalNotional = withPnl.reduce((s, r) => s + r.notional_at_entry!, 0);
+  const totalPnl = withPnl.reduce((s, r) => s + r.realized_pnl!, 0);
   return totalNotional > 0 ? (totalPnl / totalNotional) * 100 : 0;
 }
 


### PR DESCRIPTION
## Summary
- Extends PR #280's null-pnl fix to every remaining tab: Performance, Trade History, System Learning, Strategy Tracker
- 7 files, 35 insertions, 26 deletions across frontend, auto-trader, and shared components
- Core pattern: `t.pnl != null` filter before any win/loss classification or P&L aggregation

## Files changed
- `app/src/lib/paperTradesApi.ts` — day trade + swing trade validation reports
- `app/src/components/PaperTrading/tabs/HistoryTab.tsx` — W/L header counts, sort, row colors
- `app/src/lib/aiFeedback.ts` — `!trade.pnl` guard fix + unreviewed trades query filter
- `app/src/components/PaperTrading/tabs/StrategyPerformanceTab.tsx` — display color classes
- `auto-trader/src/lib/tradePerformanceMetrics.ts` — win_rate denominator + portfolio return calc
- `auto-trader/src/lib/streak-tracker.ts` — redundant `?? 0` cleanup
- `app/src/components/PaperTrading/shared/StreakBoard.tsx` — redundant `?? 0` cleanup

## Test plan
- [ ] Performance tab: equity curve and metrics reflect only trades with computed P&L
- [ ] Trade History: W/L counts in header exclude null-pnl trades; null-pnl trades sort last
- [ ] Validation tab: win rates match corrected data
- [ ] Strategy Tracker: per-influencer win rates corrected
- [ ] Streak board still works (query already filtered, this was cosmetic)


Made with [Cursor](https://cursor.com)