### PR TITLE
fix: attribute day trade P&L to opened_at date in StreakBoard

### DIFF
--- a/app/src/components/PaperTrading/shared/StreakBoard.tsx
+++ b/app/src/components/PaperTrading/shared/StreakBoard.tsx
@@ -76,7 +76,7 @@ export function StreakBoard() {
 
       const { data: trades } = await supabase
         .from('paper_trades')
-        .select('mode, pnl, closed_at')
+        .select('mode, pnl, closed_at, opened_at')
         .in('status', [...CLOSED_STATUSES])
         .not('pnl', 'is', null)
         .not('fill_price', 'is', null)
@@ -90,10 +90,15 @@ export function StreakBoard() {
 
       setStreakStates((coldStates ?? []) as StreakState[]);
 
+      const DAY_MODES = new Set(['DAY_TRADE', 'DAY_PENNY']);
+      const daySet = new Set(tradingDays);
       const byModeDate = new Map<string, { pnl: number; count: number }>();
       for (const t of trades ?? []) {
         if (!t.closed_at) continue;
-        const dateStr = t.closed_at.slice(0, 10);
+        const closedDate = t.closed_at.slice(0, 10);
+        // Day trades: attribute to opened_at date (they close same day; stale closes shouldn't shift P&L)
+        const openedDate = (DAY_MODES.has(t.mode) && t.opened_at) ? t.opened_at.slice(0, 10) : null;
+        const dateStr = (openedDate && daySet.has(openedDate)) ? openedDate : closedDate;
         for (const row of ROW_CONFIG) {
           if (row.modes.includes(t.mode)) {
             const key = `${row.key}|${dateStr}`;


### PR DESCRIPTION
## Summary
- Day trades (DAY_TRADE, DAY_PENNY) in the Strategy Streak board were grouped by `closed_at` date, but stale trades reconciled the next morning (via `stale_eod_close`) incorrectly attributed their P&L to the wrong day
- Now uses `opened_at` date for day trades (with fallback to `closed_at` if opened_at is outside the 10-day window)
- Example: XOM and RKLB opened Mon 5/18, stale-closed Tue 5/19 — P&L now correctly shows under Mon 5/18

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [ ] Verify StreakBoard shows $0 day trades for today and +$94 for Mon 5/18


Made with [Cursor](https://cursor.com)