### PR TITLE
Overhaul swing trade pipeline so it actually fires

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -3030,9 +3030,10 @@ async function executeScannerTrade(
 
   // ── Recent-loss cooldown gate ─────────────────────────────────────────
   // Block re-entry on any ticker that lost money in the last N days.
-  // SWING_TRADE uses 14 days; DAY_TRADE uses 5 days (intraday patterns reset faster).
+  // Both swing and day trades use 5 days — swing setups change weekly,
+  // a 14-day cooldown was too aggressive and blocked valid re-entries.
   {
-    const lookbackDays = mode === 'SWING_TRADE' ? 14 : 5;
+    const lookbackDays = 5;
     if (await hasRecentLoss(ticker, lookbackDays, { excludeOptions: true })) {
       log(`${ticker}: skipped — recent loss within ${lookbackDays}d cooldown`);
       persistEvent(ticker, 'skipped', `Re-entry blocked — ticker had a loss within ${lookbackDays} days`, {
@@ -3112,42 +3113,19 @@ async function executeScannerTrade(
 
   // ── Swing trade quality gates ─────────────────────────────────────────
   // Swing trades bypass the ORB/VWAP gates above (intraday metrics don't apply
-  // to multi-day holds), so we enforce quality via the scanner's own ML features.
-  //
-  // Chop gate: scanner records market_condition='chop' when the stock has no
-  // clear trend structure. Entering a swing trade in chop is low-probability —
-  // the AI narrative can say "bullish" but the regime label doesn't lie.
-  //
-  // Volume gate: volume_vs_10d_avg < 0.3 means the stock is trading at less than
-  // 30% of its normal volume. Low-conviction entries in thin conditions gap through
-  // stop-loss levels rather than filling cleanly (as seen with AAON on 2026-04-28,
-  // which had 0.06x volume and blew through its stop by $1.04, costing -1.32R).
+  // to multi-day holds). Swing-specific gates are RELAXED compared to day trades:
+  // - Chop/consolidation is WHERE swing entries form (accumulation, base building)
+  // - Low intraday volume is normal during pullbacks and consolidation
+  // - Wyckoff volume divergence applies to breakouts, not pullback entries
   if (mode === 'SWING_TRADE') {
-    if (idea.market_condition === 'chop') {
-      log(`${ticker}: swing trade skipped — market_condition=chop`);
-      persistEvent(ticker, 'skipped', `Swing trade skipped: choppy market conditions`, {
-        action: 'skipped', source: 'scanner', mode, skip_reason: 'swing_chop',
-      });
-      return 'skipped:swing_chop';
-    }
-    if (idea.volumeVs10dAvg != null && idea.volumeVs10dAvg < 0.3) {
-      log(`${ticker}: swing trade skipped — volume ${idea.volumeVs10dAvg.toFixed(2)}x avg (< 0.3x threshold)`);
-      persistEvent(ticker, 'skipped', `Swing trade skipped: low volume (${idea.volumeVs10dAvg.toFixed(2)}x 10d avg)`, {
+    // Only block on extremely thin volume (< 0.15x) where fills are unreliable.
+    // Normal low volume (0.15-1.0x) is expected during swing entry conditions.
+    if (idea.volumeVs10dAvg != null && idea.volumeVs10dAvg < 0.15) {
+      log(`${ticker}: swing trade skipped — volume ${idea.volumeVs10dAvg.toFixed(2)}x avg (< 0.15x, dangerously thin)`);
+      persistEvent(ticker, 'skipped', `Swing trade skipped: dangerously thin volume (${idea.volumeVs10dAvg.toFixed(2)}x 10d avg)`, {
         action: 'skipped', source: 'scanner', mode, skip_reason: 'swing_low_volume',
       });
       return 'skipped:swing_low_volume';
-    }
-
-    // Wyckoff "Four More Phase" gate: new move on volume weaker than the prior 20-day peak.
-    // If today's volume is < 65% of the highest-volume session in the last 20 days,
-    // the move lacks institutional conviction — smart money likely already distributed.
-    // This is the same pattern Somesh calls the "Four More Phase" (Wyckoff Distribution).
-    if (signal === 'BUY' && idea.volumeVsPriorPeak != null && idea.volumeVsPriorPeak < 0.65) {
-      log(`${ticker}: swing trade skipped — volume divergence ${idea.volumeVsPriorPeak.toFixed(2)}x prior peak (< 0.65x threshold) — Wyckoff Four More Phase risk`);
-      persistEvent(ticker, 'skipped', `Swing trade skipped: Wyckoff volume divergence (${idea.volumeVsPriorPeak.toFixed(2)}x prior 20d peak)`, {
-        action: 'skipped', source: 'scanner', mode, skip_reason: 'swing_volume_divergence',
-      });
-      return 'skipped:swing_volume_divergence';
     }
   }
 

--- a/supabase/functions/_shared/prompts.ts
+++ b/supabase/functions/_shared/prompts.ts
@@ -53,28 +53,48 @@ HOLD only when there is genuine ambiguity with no directional edge.`;
 
 // ── Swing Trade ─────────────────────────────────────────
 
-export const SWING_TRADE_SYSTEM = `You are a disciplined swing trader with 20 years experience. You find multi-day setups from pre-computed indicators and price data. Give BUY or SELL when data supports it; HOLD when there is no edge. You buy pullbacks to support, never after a stock already rallied 30%+.`;
+export const SWING_TRADE_SYSTEM = `You are an active swing trader who finds 2-10 day setups. You look for pullbacks to support, base breakouts, and mean-reversion entries. You give BUY or SELL when a setup exists — you are a SETUP FINDER, not a gatekeeper. HOLD only when there is genuinely no identifiable pattern. Your job is to surface opportunities, not filter them out.`;
 
 export const SWING_TRADE_RULES = `Rules:
-- Indicators determine bias FIRST; candles validate.
+- You are screening for SETUPS, not certainties. A stock at daily support with RSI cooling off IS a setup. Surface it.
 - SMA(200) = long-term trend. SMA(50) = medium-term. Above both = uptrend; below both = downtrend.
-- ADX > 25 = trending; < 20 = ranging/choppy. RSI divergences signal reversals.
-- MACD crossovers confirm momentum shifts. ATR sets multi-day stop distances.
-- Support/resistance = entry/exit zones.
-- Directional call when indicators mostly agree. HOLD when genuinely conflicting or tight range + low ADX.
-- Counter-trend only if reward > 2.5× risk.
-- Volume ratio is critical confirmation: > 2x confirms the move; > 3x = institutional accumulation/distribution; < 0.8x means the move is suspect — lower confidence significantly.
+- A stock in an uptrend that has PULLED BACK to SMA(20) or SMA(50) = high-probability BUY setup.
+- A stock in a downtrend bouncing into SMA(20) or SMA(50) from below = potential SELL setup.
+- ADX > 25 = trending (trade WITH the trend). ADX < 20 = consolidating — this is NOT bad for swing trades. Consolidation often precedes breakouts. Look for tightening ranges (Bollinger squeeze, narrowing ATR).
+- RSI(14) between 30-45 in an uptrending stock = pullback buy zone. RSI(14) between 55-70 in a downtrending stock = bounce sell zone.
+- RSI(14) < 30 on a quality large-cap = mean-reversion BUY opportunity.
+- MACD crossovers confirm momentum shifts. A bullish MACD cross after a pullback = strong entry signal.
+
+Volume interpretation for SWING (different from day trading):
+- Low volume during a pullback or consolidation is NORMAL and HEALTHY — it means selling pressure is drying up. Do NOT penalize low volume on quiet days.
+- Volume confirmation matters on the BREAKOUT or ENTRY bar, not on the screening day.
+- Volume ratio > 2x on a breakout from a base = strong confirmation.
+- Volume ratio < 0.5x during consolidation = accumulation (positive for future BUY).
+
+Setup types to look for (BUY any of these):
+1. PULLBACK TO MOVING AVERAGE: Stock above SMA(50), pulled back to SMA(20) or SMA(50), RSI cooling off.
+2. SUPPORT BOUNCE: Price near a horizontal support level (prior lows), showing signs of holding.
+3. BASE BREAKOUT: Tight range for 5+ days, ATR compressing, price near the upper boundary.
+4. MEAN REVERSION: Quality stock (above SMA200) with RSI < 35 — oversold bounce play.
+5. GAP FILL: Stock gapped down but holding above prior support — gap fill back up is the play.
+
+Setup types to look for (SELL any of these):
+1. RESISTANCE REJECTION: Price at or near major resistance, failing to break through, RSI > 65.
+2. BREAKDOWN: Price breaking below SMA(50) on increasing volume.
+3. LOWER HIGH: Stock making a lower high below a declining SMA(20) — trend continuation short.
+4. MEAN REVERSION SHORT: RSI > 75 on a stock below SMA(200) — overbought in a downtrend.
 
 Don't chase:
-- "Recent Price Move" is the most important filter. Up 15%+ in 5 bars, 25%+ in 10, or 40%+ in 20 = EXTENDED.
-- NEVER BUY an extended stock. Extended + RSI > 70 = HOLD or SELL, never BUY.
-- A 30-50% rally = "wait for pullback to SMA20/SMA50," not "buy the trend."
-- Gap up on preliminary earnings/news = extra caution. Preliminary ≠ final. Don't chase until dust settles.
-- When HOLD on extended stock, include the pullback level where it WOULD become a buy.
-- Unfilled gaps are magnets — price tends to return to fill them. An unfilled gap below current price is a potential pullback target and buy zone. Use gap levels as concrete entry/exit targets when available.
-- If earnings are within 7 days, reduce position size guidance and widen stops. Never recommend a new swing entry within 3 days of earnings unless explicitly a pre-earnings play.
+- Up 40%+ in 20 bars with no pullback = wait for a pullback, don't chase. But a stock up 15% that has NOW pulled back 5% to SMA(20) = valid BUY.
+- Gap up on preliminary earnings = wait for dust to settle.
+- Earnings within 3 days = skip unless explicitly a pre-earnings play.
+
+HOLD only when:
+- Price is stuck in the exact middle of a range with no nearby support or resistance.
+- Indicators are genuinely mixed with no pattern whatsoever.
+- Do NOT hold just because volume is low or because a stock has already moved. Pullbacks after moves are setups.
 
 Risk:
 - Entry near key support (BUY) or resistance (SELL). Stop = 1.5-2× ATR beyond swing level.
 - Target 1 = nearest major S/R. Target 2 = next level. Min 1.5× reward-to-risk.
-- Scaling plan: take 50% profit at Target 1, move stop to breakeven, let remaining 50% run to Target 2.`;
+- Scaling plan: take 50% at Target 1, move stop to breakeven, let rest run.`;

--- a/supabase/functions/trade-scanner/index.ts
+++ b/supabase/functions/trade-scanner/index.ts
@@ -864,18 +864,20 @@ Respond with a JSON array ONLY (no markdown, no backticks):
 Stocks:
 {{STOCK_DATA}}`;
 
-const SWING_SCAN_USER = `Evaluate these stocks for SWING trades (multi-day holds). For each, decide BUY, SELL, or SKIP.
-NOTE: You only have indicators (no candle data). For extreme movers (>20%), max confidence 6-7 — you'd need candles to be sure.
+const SWING_SCAN_USER = `Evaluate these stocks for SWING trades (2-10 day holds). For each, decide BUY, SELL, or SKIP.
+NOTE: You only have indicators (no candle data). A deeper analysis with full candle data will validate winners later.
 
 ${SWING_TRADE_RULES}
 
-- This is a SCREENING pass — be generous with BUY/SELL signals. A deeper analysis with full candle data will validate later.
-- Look for: pullbacks to support in uptrends, oversold bounces, breakout setups, breakdown setups, mean-reversion plays.
-- Even in a bearish market, quality stocks at support with good risk/reward are valid BUY candidates.
-- SELL (short) setups are equally valid — stocks breaking below SMA50/SMA200, bearish MACD crossovers.
-- SKIP only when there is truly no setup (flat, no volume, no catalyst, stuck in the middle of a range with no direction).
-- Aim to identify 6-10 actionable ideas from this list. The next pass will filter further.
-- Confidence reflects how promising the SETUP looks, not certainty of outcome.
+SCREENING INSTRUCTIONS — READ CAREFULLY:
+- You are a SETUP FINDER. Your job is to surface every stock that has an identifiable swing pattern. The next pass filters.
+- A stock pulling back to SMA(20) in an uptrend IS a setup. Give it BUY 6-7.
+- A stock consolidating at support with low volume IS a setup (accumulation). Give it BUY 5-6.
+- A stock with RSI < 35 above SMA(200) IS a mean-reversion setup. Give it BUY 6-7.
+- A stock breaking below SMA(50) on volume IS a setup. Give it SELL 5-6.
+- SKIP only stocks with NO identifiable pattern — stuck mid-range, no support/resistance nearby, no trend, no setup.
+- You should identify 6-10 actionable ideas. If you're SKIPping more than 60% of the list, you're being too conservative.
+- Confidence = how clean the SETUP is (not certainty of profit). Clean pullback to support = 6-7. Messy = 4-5. No setup = SKIP.
 
 Respond with a JSON array ONLY (no markdown, no backticks):
 [{"ticker":"AAPL","signal":"BUY"|"SELL"|"SKIP","confidence":0-10,"reason":"1 sentence"}]
@@ -2406,9 +2408,13 @@ Deno.serve(async (req) => {
           swingAISucceeded = true;
           const quoteMap = new Map(candidates.map(q => [q.symbol, q]));
 
-          // Log ALL Pass 1 results for diagnostics
+          // Log ALL Pass 1 results for diagnostics — confidence distribution helps tune thresholds
           const allSignals = evals.map(e => `${e.ticker}:${e.signal}/${e.confidence}`);
           console.log(`[Trade Scanner] Swing Pass 1 ALL (${evals.length}): ${allSignals.join(', ')}`);
+          const confDist = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // 0-10
+          for (const e of evals) confDist[Math.min(10, Math.max(0, e.confidence))]++;
+          const skipCount = evals.filter(e => e.signal === 'SKIP' || e.signal === 'HOLD').length;
+          console.log(`[Trade Scanner] Swing Pass 1 distribution: SKIP/HOLD=${skipCount} | conf: ${confDist.map((c, i) => c > 0 ? `${i}→${c}` : '').filter(Boolean).join(', ')}`);
 
           const nonSkip = evals.filter(e => e.signal !== 'SKIP' && e.signal !== 'HOLD').sort((a, b) => b.confidence - a.confidence);
           console.log(`[Trade Scanner] Swing Pass 1 non-SKIP (${nonSkip.length}): ${nonSkip.map(e => `${e.ticker}:${e.signal}/${e.confidence}`).join(', ') || 'none'}`);


### PR DESCRIPTION
## Summary
- Rewrote `SWING_TRADE_SYSTEM` and `SWING_TRADE_RULES` prompts — AI is now a setup finder (pullbacks, support bounces, base breakouts, mean reversion) instead of a gatekeeper that penalizes every valid swing condition
- Rewrote `SWING_SCAN_USER` with explicit confidence anchors so Gemini returns 5-7 for clean setups instead of clustering at 3
- Removed chop gate and Wyckoff volume divergence gate for swing trades (consolidation is where swing entries form)
- Relaxed volume gate from 0.3x to 0.15x (only block dangerously thin liquidity)
- Reduced loss cooldown from 14 days to 5 days
- Added confidence distribution logging for diagnostics

## Context
Swing trades have never fired because the AI was told to be suspicious of low volume, "extended" stocks, and choppy conditions — which is exactly when swing setups form. The scheduler then applied day-trade-calibrated gates that killed anything the AI did surface.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Auto-trader rebuilt and restarted
- [x] Edge functions deployed (trade-scanner + trading-signals)
- [ ] Monitor next swing scan window for Pass 1 confidence distribution
- [ ] Verify swing ideas reach the auto-trader execution pipeline

Made with [Cursor](https://cursor.com)