### PR TITLE
Rewrite swing prompts with SMB Capital prop methodology

### DIFF
--- a/docs/cursor/2026-05-19-smb-swing-trade-methodology.md
+++ b/docs/cursor/2026-05-19-smb-swing-trade-methodology.md
@@ -1,0 +1,60 @@
+# SMB Capital Swing Trade Methodology (Ryan Assan)
+
+**Source**: SMB Capital YouTube — "Ultimate Swing Trading Guide" (Ryan Assan, Senior Prop Trader)
+**Applied**: 2026-05-19 — Incorporated into `SWING_TRADE_SYSTEM`, `SWING_TRADE_RULES`, and `SWING_SCAN_USER` prompts.
+
+## Three Core Setups
+
+### 1. Consolidation Breakout (Long or Short)
+- Multi-day/week tight range near clear S/R level
+- **Rubber band effect**: longer consolidation + volume contraction → greater expansion on break
+- Stock above key SMAs (200, 50) for long; below for short
+- Elevated RVOL (≥ 1.5x) on the breakout day confirms the move
+- Stop: just below breakout level (re-entry into range = failed breakout)
+- Examples: NVDA at $500 resistance, MSFT at $376, AFRM at $27
+
+### 2. Mean Reversion / Backside Short
+- Stock extended significantly from key SMAs / multi-day VWAP
+- Blow-off top confirmed by extreme volume + tail candle
+- Short entry: lower high into the "supply zone" (heaviest volume area from blow-off day)
+- Long entry: quality stock at RSI < 30 — oversold bounce
+- Stop: above the recent high (shorts) or below the recent low (longs)
+- Target: prior breakout level or key SMA support
+- Example: Safety Shot (SHOT) — ran up, topped out, lower high into 550-650 supply zone
+
+### 3. Day-2+ Continuation
+- Day 1: massive directional move on fundamentally changing catalyst, close near high/low
+- Day 2: pullback to Day 1 support levels + 2-day anchored VWAP
+- Entry on the bounce when it holds key Day 1 levels
+- Works especially well during earnings season
+- Example: SMCI — pre-announced strong figures, Day 2 pullback to $410 (2-day VWAP)
+
+## Qualifying Variables (All Setups)
+1. **Clear S/R**: Level tested multiple times over days/weeks/months
+2. **Rubber band effect**: Price + volume contraction preceding setup
+3. **Clear risk level**: Specific price where thesis is invalidated
+4. **Relative strength/weakness**: vs sector, vs SPY
+5. **Multiple timeframe alignment**: Daily → Hourly → 5min
+6. **Trend alignment**: Key SMAs supporting direction
+7. **RVOL ≥ 1.5x on entry day** (low volume during consolidation = positive)
+8. **Skewed R:R**: Minimum 3:1 (risk $1 to make $3)
+
+## Position Management
+- **Targets**: Use ATR — first target = 1-1.5x ATR. If abnormal volume, stretch to 2x ATR.
+- **Scaling**: Take 1/3 off at Target 1, trail remaining with higher lows (longs) / lower highs (shorts) on hourly chart.
+- **Trail stop**: Using higher low approach on same timeframe as entry.
+- **Exit**: When stock makes first lower low (longs) or higher high (shorts) relative to trail.
+- **Alternative trails**: Anchored VWAP from breakout day, or 5-day EMA/SMA.
+
+## Key Indicators
+- **VWAP**: Most important — gauge sentiment, entries/exits
+- **SMAs**: 5, 20, 50, 200 on daily chart
+- **RVOL**: Minimum 1.5x on breakout/entry day
+- **ATR**: For target sizing and stop placement
+- **RSI**: Extreme readings for mean reversion
+
+## Volume Interpretation (Critical Difference from Day Trading)
+- Low volume during consolidation = energy building (rubber band coiling) → **POSITIVE**
+- Low volume on pullback = selling pressure drying up → **POSITIVE**
+- Volume confirmation matters on **breakout/entry day**, NOT screening day
+- Never penalize consolidating stocks for low current volume

--- a/supabase/functions/_shared/prompts.ts
+++ b/supabase/functions/_shared/prompts.ts
@@ -52,49 +52,74 @@ Note: Strong momentum + volume confirmation (ratio > 2.5×) can override structu
 HOLD only when there is genuine ambiguity with no directional edge.`;
 
 // ── Swing Trade ─────────────────────────────────────────
+// Based on SMB Capital prop trader methodology (Ryan Assan):
+// Three core setups: consolidation breakout, mean reversion, day-2+ continuation.
+// Key: multiple timeframe alignment, clear S/R, rubber band effect, RVOL on entry day, 3:1 R:R.
 
-export const SWING_TRADE_SYSTEM = `You are an active swing trader who finds 2-10 day setups. You look for pullbacks to support, base breakouts, and mean-reversion entries. You give BUY or SELL when a setup exists — you are a SETUP FINDER, not a gatekeeper. HOLD only when there is genuinely no identifiable pattern. Your job is to surface opportunities, not filter them out.`;
+export const SWING_TRADE_SYSTEM = `You are a senior proprietary swing trader. You find 2-10 day setups using daily charts with SMA(5/20/50/200), then confirm on hourly and 5-minute timeframes. You are a SETUP FINDER — your job is to surface every stock with a clear swing pattern. Give BUY or SELL when a setup exists. HOLD only when there is genuinely no pattern. You trade both long and short across all cap sizes.`;
 
-export const SWING_TRADE_RULES = `Rules:
-- You are screening for SETUPS, not certainties. A stock at daily support with RSI cooling off IS a setup. Surface it.
-- SMA(200) = long-term trend. SMA(50) = medium-term. Above both = uptrend; below both = downtrend.
-- A stock in an uptrend that has PULLED BACK to SMA(20) or SMA(50) = high-probability BUY setup.
-- A stock in a downtrend bouncing into SMA(20) or SMA(50) from below = potential SELL setup.
-- ADX > 25 = trending (trade WITH the trend). ADX < 20 = consolidating — this is NOT bad for swing trades. Consolidation often precedes breakouts. Look for tightening ranges (Bollinger squeeze, narrowing ATR).
-- RSI(14) between 30-45 in an uptrending stock = pullback buy zone. RSI(14) between 55-70 in a downtrending stock = bounce sell zone.
-- RSI(14) < 30 on a quality large-cap = mean-reversion BUY opportunity.
-- MACD crossovers confirm momentum shifts. A bullish MACD cross after a pullback = strong entry signal.
+export const SWING_TRADE_RULES = `Three Core Swing Setups:
 
-Volume interpretation for SWING (different from day trading):
-- Low volume during a pullback or consolidation is NORMAL and HEALTHY — it means selling pressure is drying up. Do NOT penalize low volume on quiet days.
-- Volume confirmation matters on the BREAKOUT or ENTRY bar, not on the screening day.
-- Volume ratio > 2x on a breakout from a base = strong confirmation.
-- Volume ratio < 0.5x during consolidation = accumulation (positive for future BUY).
+SETUP 1 — CONSOLIDATION BREAKOUT (long or short):
+- Multi-day or multi-week tight range near a clear resistance (long) or support (short) level.
+- "Rubber band effect": the longer the consolidation and price/volume contraction, the greater the potential expansion once S/R breaks.
+- Stock should be above key SMAs (200, 50) for long breakouts; below for short breakdowns.
+- Price near the boundary of the range = setup forming. ATR compressing = energy building.
+- Confirmation: breakout bar should have elevated RVOL (> 1.5x). But during the SCREENING phase (now), low volume consolidation is POSITIVE — it means the rubber band is coiling.
+- Stop: just below the breakout level (long) or above the breakdown level (short). A re-entry into the range = failed breakout.
+- Examples: NVDA consolidating near $500 for months then breaking out; MSFT in tight range above SMA(200) near $376 resistance.
 
-Setup types to look for (BUY any of these):
-1. PULLBACK TO MOVING AVERAGE: Stock above SMA(50), pulled back to SMA(20) or SMA(50), RSI cooling off.
-2. SUPPORT BOUNCE: Price near a horizontal support level (prior lows), showing signs of holding.
-3. BASE BREAKOUT: Tight range for 5+ days, ATR compressing, price near the upper boundary.
-4. MEAN REVERSION: Quality stock (above SMA200) with RSI < 35 — oversold bounce play.
-5. GAP FILL: Stock gapped down but holding above prior support — gap fill back up is the play.
+SETUP 2 — MEAN REVERSION / BACKSIDE SHORT:
+- Stock has extended significantly from its mean (key SMAs, multi-day VWAP) in a short time.
+- RSI near extremes: > 80 for short candidates, < 25 for long mean-reversion.
+- For shorts: stock topped out with blow-off volume, now bouncing back into the "supply zone" (area of heaviest volume from the blow-off day). A lower high into this zone = short entry.
+- For longs: quality stock (above SMA200 normally) that crashed to RSI < 30 — oversold bounce.
+- Stop: above the recent high (shorts) or below the recent low (longs).
+- Target: prior breakout level or key SMA where stock may find support/resistance.
 
-Setup types to look for (SELL any of these):
-1. RESISTANCE REJECTION: Price at or near major resistance, failing to break through, RSI > 65.
-2. BREAKDOWN: Price breaking below SMA(50) on increasing volume.
-3. LOWER HIGH: Stock making a lower high below a declining SMA(20) — trend continuation short.
-4. MEAN REVERSION SHORT: RSI > 75 on a stock below SMA(200) — overbought in a downtrend.
+SETUP 3 — DAY-2+ CONTINUATION:
+- Day 1: massive directional move on fundamentally changing catalyst (earnings beat, sector rotation) with elevated volume and close near the high/low of day.
+- Day 2: look for pullback to Day 1 support levels (for longs) or Day 1 resistance (for shorts).
+- Entry on the pullback when it holds at key Day 1 levels + 2-day anchored VWAP.
+- Works especially well during earnings season.
+- Stop: below the Day 2 low (longs) or above Day 2 high (shorts).
 
-Don't chase:
-- Up 40%+ in 20 bars with no pullback = wait for a pullback, don't chase. But a stock up 15% that has NOW pulled back 5% to SMA(20) = valid BUY.
+Qualifying Variables (the more boxes checked, higher confidence):
+- Clear support/resistance: a level tested multiple times over days/weeks/months.
+- Rubber band effect: contraction in price AND volume preceding the setup.
+- Clear risk level: a specific price where the thesis is invalidated.
+- Relative strength/weakness: stock outperforming/underperforming its sector or SPY.
+- Multiple timeframe alignment: setup visible on daily, confirmed on hourly.
+- Trend alignment: key SMAs (5, 20, 50, 200) supporting the direction.
+- RVOL >= 1.5x on the breakout/entry day (for screening, low volume during consolidation is fine).
+- Skewed R:R: minimum 3:1 (risk $1 to make $3). This is the benchmark.
+
+Volume Interpretation for Swing (CRITICAL — different from day trading):
+- Low volume during consolidation = energy building, rubber band coiling. This is POSITIVE for breakout setups.
+- Low volume on a pullback = selling pressure drying up. POSITIVE for pullback BUY entries.
+- Volume confirmation matters on the BREAKOUT/ENTRY day, NOT on the screening day.
+- Do NOT penalize a stock for low current volume if it's in a consolidation or pullback phase.
+
+Indicators:
+- SMA(200) = long-term trend. SMA(50) = medium-term. SMA(20) = short-term. SMA(5) = immediate momentum.
+- Stock above rising SMAs = uptrend. Below declining SMAs = downtrend.
+- ADX > 25 = trending. ADX < 20 = consolidating (NOT bad — consolidation precedes breakouts).
+- RSI(14) 30-45 in uptrending stock = pullback buy zone. RSI(14) 55-70 in downtrend = bounce sell zone.
+- ATR: use for target sizing. Target 1 = 1-1.5x ATR. If volume is abnormally high, stretch to 2x ATR.
+
+Don't Chase:
+- Extended 40%+ in 20 bars with no pullback = wait. But a stock up 15% that NOW pulled back to SMA(20) = valid BUY.
 - Gap up on preliminary earnings = wait for dust to settle.
 - Earnings within 3 days = skip unless explicitly a pre-earnings play.
 
 HOLD only when:
-- Price is stuck in the exact middle of a range with no nearby support or resistance.
-- Indicators are genuinely mixed with no pattern whatsoever.
-- Do NOT hold just because volume is low or because a stock has already moved. Pullbacks after moves are setups.
+- Price is stuck in the exact middle of a range with no nearby S/R.
+- No identifiable pattern from the three core setups above.
+- Do NOT hold just because volume is currently low. Low volume during consolidation = setup forming.
 
-Risk:
-- Entry near key support (BUY) or resistance (SELL). Stop = 1.5-2× ATR beyond swing level.
-- Target 1 = nearest major S/R. Target 2 = next level. Min 1.5× reward-to-risk.
-- Scaling plan: take 50% at Target 1, move stop to breakeven, let rest run.`;
+Risk Management:
+- Entry near key support (BUY) or resistance (SELL). Stop = where the thesis is wrong (below S/R, below breakout level).
+- Stop distance typically 1.5-2x ATR from entry.
+- Target 1 = nearest major S/R or 1-1.5x ATR. Target 2 = next level or 2x ATR.
+- Minimum 3:1 reward-to-risk ratio. Do not take setups below 3:1.
+- Position management: take 1/3 off at Target 1, trail remaining with higher lows (longs) or lower highs (shorts) on the hourly chart.`;

--- a/supabase/functions/trade-scanner/index.ts
+++ b/supabase/functions/trade-scanner/index.ts
@@ -865,19 +865,26 @@ Stocks:
 {{STOCK_DATA}}`;
 
 const SWING_SCAN_USER = `Evaluate these stocks for SWING trades (2-10 day holds). For each, decide BUY, SELL, or SKIP.
-NOTE: You only have indicators (no candle data). A deeper analysis with full candle data will validate winners later.
+NOTE: You only have indicators (no candle data). A deeper pass with full candle data validates winners.
 
 ${SWING_TRADE_RULES}
 
 SCREENING INSTRUCTIONS — READ CAREFULLY:
-- You are a SETUP FINDER. Your job is to surface every stock that has an identifiable swing pattern. The next pass filters.
-- A stock pulling back to SMA(20) in an uptrend IS a setup. Give it BUY 6-7.
-- A stock consolidating at support with low volume IS a setup (accumulation). Give it BUY 5-6.
-- A stock with RSI < 35 above SMA(200) IS a mean-reversion setup. Give it BUY 6-7.
-- A stock breaking below SMA(50) on volume IS a setup. Give it SELL 5-6.
-- SKIP only stocks with NO identifiable pattern — stuck mid-range, no support/resistance nearby, no trend, no setup.
-- You should identify 6-10 actionable ideas. If you're SKIPping more than 60% of the list, you're being too conservative.
-- Confidence = how clean the SETUP is (not certainty of profit). Clean pullback to support = 6-7. Messy = 4-5. No setup = SKIP.
+- You are a SETUP FINDER at a prop trading firm. Surface every stock matching one of the three core setups above.
+- Check each stock against ALL THREE setups before deciding SKIP.
+
+Confidence anchors (use these as calibration):
+- 7-8: Textbook setup — tight consolidation near clear S/R + above key SMAs + rubber band coiling. Or strong mean reversion (RSI extreme + quality name).
+- 5-6: Solid setup — pullback to SMA(20/50) in uptrend, or consolidation forming but not as tight. Or day-2 continuation candidate.
+- 4-5: Emerging setup — stock near support but pattern not fully formed yet. Worth a deeper look in Pass 2.
+- SKIP: No identifiable pattern from the three core setups. Stock mid-range, no nearby S/R, no trend.
+
+Key reminders:
+- Low volume during consolidation or pullback = POSITIVE (rubber band coiling, selling drying up). Do NOT skip for low volume.
+- ADX < 20 = consolidating = potential breakout forming. Do NOT skip for low ADX.
+- A stock that already moved 15% but NOW sits at SMA(20) support = valid BUY (pullback entry).
+- SELL setups are valid: lower highs, breakdowns below SMA(50), mean reversion shorts on extended stocks.
+- You should surface 6-10 actionable ideas. If SKIPping > 60%, you are too conservative.
 
 Respond with a JSON array ONLY (no markdown, no backticks):
 [{"ticker":"AAPL","signal":"BUY"|"SELL"|"SKIP","confidence":0-10,"reason":"1 sentence"}]


### PR DESCRIPTION
## Summary
- Rewrites `SWING_TRADE_SYSTEM`, `SWING_TRADE_RULES`, and `SWING_SCAN_USER` prompts based on SMB Capital senior prop trader Ryan Assan's methodology
- Three concrete setups: consolidation breakout, mean reversion/backside short, day-2+ continuation
- Specific qualifying variables: clear S/R, rubber band effect, relative strength, RVOL >= 1.5x on entry day, 3:1 minimum R:R
- Corrects volume interpretation: low volume during consolidation is POSITIVE (energy building), not a skip reason
- Confidence anchors calibrated to setup quality (7-8 for textbook, 5-6 for solid, 4-5 for emerging)
- Docs: `docs/cursor/2026-05-19-smb-swing-trade-methodology.md` captures the full methodology

## Test plan
- [ ] Next scanner run should surface 6-10 swing ideas (vs 0-2 previously)
- [ ] Check auto-trader logs for Pass 1 confidence distribution
- [ ] Verify no regressions in day trade scanning


Made with [Cursor](https://cursor.com)