### PR TITLE
Prune stale scan evaluations older than 4 hours

### DIFF
--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -893,8 +893,17 @@ export async function writeScanEvaluations(
       .select('auto_evaluations')
       .eq('id', scanId)
       .single();
+    // Prune stale evaluations older than 4 hours before merging
+    const staleThreshold = Date.now() - 4 * 60 * 60 * 1000;
+    const prev = existing?.auto_evaluations ?? {};
+    const pruned: Record<string, ScanEvaluation> = {};
+    for (const [t, ev] of Object.entries(prev) as [string, ScanEvaluation][]) {
+      if (ev.evaluated_at && new Date(ev.evaluated_at).getTime() > staleThreshold) {
+        pruned[t] = ev;
+      }
+    }
     const merged: Record<string, ScanEvaluation> = {
-      ...(existing?.auto_evaluations ?? {}),
+      ...pruned,
       ...Object.fromEntries(
         Object.entries(evals).map(([ticker, ev]) => [ticker, { ...ev, evaluated_at }])
       ),


### PR DESCRIPTION
## Summary
- `writeScanEvaluations` merges new evaluations into existing ones but never removes old entries
- This caused stale "Already trading this ticker" badges in the UI (e.g. ENPH blocked since May 15 with no active position)
- Now prunes evaluations older than 4 hours on every write cycle
- Also manually cleaned 25 stale evaluations from the DB

## Test plan
- [x] Type-check passes
- [x] Auto-trader rebuilt and restarted
- [x] Stale ENPH evaluation cleared from DB

Made with [Cursor](https://cursor.com)