### PR TITLE
feat: IB fills as source of truth for Today's Activity

### DIFF
--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -61,6 +61,7 @@ import {
   getTodaySignalsForManualExecute,
   getAutoTradeEvents,
   getTodaysExecutedEvents,
+  getTodayTrades,
   getDayTradeValidationReport,
   getSwingTradeValidationReport,
   clearSharedTradesCache,
@@ -114,6 +115,7 @@ interface PageCache {
   performance: TradePerformance | null;
   persistedEvents: AutoTradeEventRecord[];
   todaysExecuted: AutoTradeEventRecord[];
+  todayTrades: PaperTrade[];
   ibPositions: IBPosition[];
   ibOrders: IBLiveOrder[];
   allTrades: PaperTrade[];
@@ -147,6 +149,7 @@ export function PaperTrading() {
   const [ibOrders, setIbOrders] = useState<IBLiveOrder[]>(cached?.ibOrders ?? []);
   const [persistedEvents, setPersistedEvents] = useState<AutoTradeEventRecord[]>(cached?.persistedEvents ?? []);
   const [todaysExecuted, setTodaysExecuted] = useState<AutoTradeEventRecord[]>(cached?.todaysExecuted ?? []);
+  const [todayTrades, setTodayTrades] = useState<PaperTrade[]>(cached?.todayTrades ?? []);
   const [categoryPerf, setCategoryPerf] = useState<CategoryPerformance[]>(cached?.categoryPerf ?? []);
   const [sourcePerf, setSourcePerf] = useState<StrategySourcePerformance[]>(cached?.sourcePerf ?? []);
   const [videoPerf, setVideoPerf] = useState<StrategyVideoPerformance[]>(cached?.videoPerf ?? []);
@@ -172,7 +175,7 @@ export function PaperTrading() {
 
   // Refs for cache snapshot on unmount
   const stateRef = useRef({
-    performance, persistedEvents, todaysExecuted, ibPositions, ibOrders,
+    performance, persistedEvents, todaysExecuted, todayTrades, ibPositions, ibOrders,
     allTrades, pendingSignals, todaySignalsForExecute, categoryPerf,
     sourcePerf, videoPerf, strategyStatuses, validationReport,
     swingValidationReport, totalDeployed, marketRegime, kellyMultiplier, lastCycleSummary,
@@ -180,7 +183,7 @@ export function PaperTrading() {
   });
   useEffect(() => {
     stateRef.current = {
-      performance, persistedEvents, todaysExecuted, ibPositions, ibOrders,
+      performance, persistedEvents, todaysExecuted, todayTrades, ibPositions, ibOrders,
       allTrades, pendingSignals, todaySignalsForExecute, categoryPerf,
       sourcePerf, videoPerf, strategyStatuses, validationReport,
       swingValidationReport, totalDeployed, marketRegime, kellyMultiplier, lastCycleSummary,
@@ -195,14 +198,16 @@ export function PaperTrading() {
 
   // ── Core data: header stats + activity log (always visible) ──
   const loadCoreData = useCallback(async () => {
-    const [perf, savedEvents, todayEvents] = await Promise.all([
+    const [perf, savedEvents, todayEvents, todayTradesResult] = await Promise.all([
       getPerformance(),
       getAutoTradeEvents(100, accountView),
       getTodaysExecutedEvents(accountView),
+      getTodayTrades(accountView),
     ]);
     setPerformance(perf);
     setPersistedEvents(savedEvents);
     setTodaysExecuted(todayEvents);
+    setTodayTrades(todayTradesResult);
     fetch('http://localhost:3001/api/scheduler/status')
       .then((r) => r.json())
       .then((d) => setLastCycleSummary(d.lastCycleSummary ?? []))
@@ -337,6 +342,7 @@ export function PaperTrading() {
     loadTabData(tab, forceRefresh);
     if (forceRefresh) {
       getTodaysExecutedEvents(accountView).then(setTodaysExecuted).catch(() => {});
+      getTodayTrades(accountView).then(setTodayTrades).catch(() => {});
       loadIBData();
     }
   }, [tab]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -403,8 +409,9 @@ export function PaperTrading() {
     fetchedRef.current.delete('todaySignals');
     clearSharedTradesCache();
     await Promise.all([loadCoreData(), loadIBData()]);
+    getTodayTrades(accountView).then(setTodayTrades).catch(() => {});
     await loadTabData(tab, true);
-  }, [loadCoreData, loadIBData, loadTabData, tab]);
+  }, [loadCoreData, loadIBData, loadTabData, tab, accountView]);
 
   const updateConfig = async (updates: Partial<AutoTraderConfig>) => {
     const updated = await saveAutoTraderConfig(updates);
@@ -606,7 +613,7 @@ export function PaperTrading() {
         <div className="flex gap-1 bg-white/60 p-1 rounded-xl border border-[hsl(var(--border))] w-max sm:w-auto min-w-full">
           {[
             { id: 'portfolio' as Tab,   label: 'IB Portfolio',    short: 'Portfolio',   icon: Briefcase,     count: ibPositions.length },
-            { id: 'today' as Tab,       label: "Today's Activity", short: 'Today',       icon: Zap,           count: dedupedToday.length },
+            { id: 'today' as Tab,       label: "Today's Activity", short: 'Today',       icon: Zap,           count: todayTrades.length },
             { id: 'history' as Tab,     label: 'Trade History',    short: 'History',     icon: Clock,         count: allTrades.length },
             { id: 'performance' as Tab, label: 'Performance',      short: 'Perf',        icon: BarChart2 },
             { id: 'strategies' as Tab,  label: 'Influencers',      short: 'Influencers', icon: BarChart3,     count: sourcePerf.length },
@@ -682,6 +689,7 @@ export function PaperTrading() {
             <TodayActivityTab
               events={dedupedToday}
               trades={allTrades}
+              todayTrades={todayTrades}
               todaySignalsForExecute={todaySignalsForExecute}
               onExecuteSignal={refreshAfterAction}
               ibRealizedPnl={ibAccountPnl?.realizedPnL ?? null}

--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -45,6 +45,8 @@ function AccountDot({ type }: { type?: 'paper' | 'live' }) {
 export interface TodayActivityTabProps {
   events: AutoTradeEventRecord[];
   trades: PaperTrade[];
+  /** Today's trades from paper_trades — primary source of truth, driven by ib_fills trigger */
+  todayTrades?: PaperTrade[];
   todaySignalsForExecute?: PendingStrategySignal[];
   onExecuteSignal?: () => void;
   ibRealizedPnl?: number | null;
@@ -61,7 +63,7 @@ function isTradingDay(): boolean {
   return day !== 0 && day !== 6; // 0=Sun, 6=Sat
 }
 
-export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], onExecuteSignal, ibRealizedPnl, accountView }: TodayActivityTabProps) {
+export function TodayActivityTab({ events, trades, todayTrades, todaySignalsForExecute = [], onExecuteSignal, ibRealizedPnl }: TodayActivityTabProps) {
   const [executingId, setExecutingId] = useState<string | null>(null);
   const [executingAll, setExecutingAll] = useState(false);
   const [filterMode, setFilterMode] = useState<FilterMode>('all');
@@ -129,17 +131,27 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
     }
   };
   const todayISO = todayStart.toISOString();
-  const tradesByTicker = new Map<string, PaperTrade[]>();
-  for (const t of trades) {
+
+  // Primary data source: todayTrades (from paper_trades, kept accurate by ib_fills trigger).
+  // Fall back to filtering allTrades for backward compatibility.
+  const primaryTrades: PaperTrade[] = todayTrades ?? trades.filter(t => {
     const openedToday = t.opened_at && t.opened_at >= todayISO;
     const closedToday = t.closed_at && t.closed_at >= todayISO;
-    if (!openedToday && !closedToday) continue;
+    return openedToday || closedToday;
+  });
+
+  // Legacy lookup: events for system-only messages (reconcile warnings, orphan alerts)
+  const tradesByTicker = new Map<string, PaperTrade[]>();
+  for (const t of primaryTrades) {
     const arr = tradesByTicker.get(t.ticker) || [];
     arr.push(t);
     tradesByTicker.set(t.ticker, arr);
   }
 
-  if (events.length === 0) {
+  // System-only events (no mode = reconcile / orphan alerts)
+  const systemEvents = events.filter(e => e.source === 'system' && !e.mode);
+
+  if (primaryTrades.length === 0) {
     return (
       <div className="space-y-4">
         <div className="text-center py-12">
@@ -237,28 +249,9 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
     );
   }
 
-  const terminalStatuses = [...CLOSED_STATUSES];
-
-  const computeEventPnl = (evList: typeof events) => {
-    const countedTradeIds = new Set<string>();
-    let sum = 0;
-    for (const ev of evList) {
-      const matched = tradesByTicker.get(ev.ticker)
-        ?.sort((a, b) => {
-          const aTerminal = terminalStatuses.includes(a.status) ? 0 : 1;
-          const bTerminal = terminalStatuses.includes(b.status) ? 0 : 1;
-          return aTerminal - bTerminal;
-        })
-        ?.find(t =>
-          t.pnl != null && t.pnl_source != null && !countedTradeIds.has(t.id)
-        );
-      if (matched) {
-        countedTradeIds.add(matched.id);
-        sum += matched.pnl!;
-      }
-    }
-    return sum;
-  };
+  // P&L computed directly from trade records (accurate via ib_fills trigger)
+  const computeTradePnl = (tradeList: PaperTrade[]) =>
+    tradeList.reduce((sum, t) => sum + (t.pnl ?? 0), 0);
 
   const effectiveIbPnl = isTradingDay() ? ibRealizedPnl : null;
 
@@ -278,21 +271,17 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
       : <ChevronDown className="inline w-3 h-3 ml-0.5 opacity-80" />;
   }
 
-  const filteredSortedEvents = useMemo(() => {
-    let filtered = events;
+  const filteredSortedTrades = useMemo(() => {
+    let filtered = primaryTrades;
 
     if (filterMode !== 'all') {
-      filtered = events.filter(ev => {
-        const mode = ev.mode;
+      filtered = primaryTrades.filter(t => {
+        const mode = t.mode;
         if (filterMode === 'day') return mode === 'DAY_TRADE' || mode === 'DAY_PENNY';
         if (filterMode === 'penny') return mode === 'DAY_PENNY';
         if (filterMode === 'long_term') return mode === 'LONG_TERM' || mode === 'SWING_TRADE';
-        if (filterMode === 'gainers' || filterMode === 'losers') {
-          const trade = tradesByTicker.get(ev.ticker)?.find(t => t.pnl != null && t.pnl_source != null);
-          const pnl = trade?.pnl ?? null;
-          if (filterMode === 'gainers') return pnl != null && pnl > 0;
-          if (filterMode === 'losers') return pnl != null && pnl < 0;
-        }
+        if (filterMode === 'gainers') return t.pnl != null && t.pnl > 0;
+        if (filterMode === 'losers') return t.pnl != null && t.pnl < 0;
         return true;
       });
     }
@@ -307,13 +296,11 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
         aVal = a.ticker;
         bVal = b.ticker;
       } else if (sortKey === 'time') {
-        aVal = a.created_at;
-        bVal = b.created_at;
+        aVal = a.opened_at;
+        bVal = b.opened_at;
       } else if (sortKey === 'pnl') {
-        const matchA = tradesByTicker.get(a.ticker)?.find(t => t.pnl != null);
-        const matchB = tradesByTicker.get(b.ticker)?.find(t => t.pnl != null);
-        aVal = matchA?.pnl ?? null;
-        bVal = matchB?.pnl ?? null;
+        aVal = a.pnl ?? null;
+        bVal = b.pnl ?? null;
       }
 
       if (aVal === null && bVal === null) return 0;
@@ -323,9 +310,9 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
       const cmp = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
       return sortDir === 'asc' ? cmp : -cmp;
     });
-  }, [events, filterMode, sortKey, sortDir, tradesByTicker]);
+  }, [primaryTrades, filterMode, sortKey, sortDir]);
 
-  const filteredPnl = useMemo(() => computeEventPnl(filteredSortedEvents), [filteredSortedEvents, tradesByTicker]);
+  const filteredPnl = useMemo(() => computeTradePnl(filteredSortedTrades), [filteredSortedTrades]);
   const pnlLabel = filterMode === 'all' ? "Today's Realized P&L"
     : filterMode === 'day' ? 'Day Trade P&L'
     : filterMode === 'penny' ? 'Penny P&L'
@@ -413,7 +400,7 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
         </button>
         {filterMode !== 'all' && (
           <span className="text-[10px] text-[hsl(var(--muted-foreground))] ml-1">
-            {filteredSortedEvents.length} of {events.length}
+            {filteredSortedTrades.length} of {primaryTrades.length}
           </span>
         )}
       </div>
@@ -447,93 +434,75 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
             </tr>
           </thead>
           <tbody className="divide-y divide-[hsl(var(--border))]">
-            {filteredSortedEvents.map((event) => {
-              const matched = tradesByTicker.get(event.ticker)?.find(t =>
-                t.pnl != null || t.status === 'FILLED' || t.status === 'TARGET_HIT' || t.status === 'STOPPED' || t.status === 'CLOSED'
-              );
-
-              const isPositionSync = event.source === 'system' && !event.mode;
-              const AUTO_CLOSE_SOURCES = new Set(['lt_auto_sell', 'swing_expiry', 'capital_pressure']);
-              const isAutoClose = AUTO_CLOSE_SOURCES.has(event.source ?? '');
-              const metaPnl = isPositionSync && event.metadata ? (event.metadata as { pnl?: number }).pnl : undefined;
+            {filteredSortedTrades.map((trade) => {
               const terminalStatuses = [...CLOSED_STATUSES, ...EXCLUDED_STATUSES] as string[];
-              const isRealizedClose = matched?.close_price != null || terminalStatuses.includes(matched?.status ?? '');
-              const eventPnl = metaPnl ?? (isRealizedClose ? matched?.pnl : undefined);
-              const pnl = eventPnl ?? null;
-              const isClosed = isPositionSync || isAutoClose || (matched?.close_price != null) || terminalStatuses.includes(matched?.status ?? '');
-              const isActive = !isClosed && matched && ['FILLED', 'PARTIAL'].includes(matched.status);
-              const msg = event.message;
-              // Match "7 shares @ $675" OR "BUY 7 @ $675" (external signal format)
-              const sharesMatch = msg.match(/(\d+)\s+shares.*?@\s*~?\$?([\d.]+)/i);
-              const externalMatch = msg.match(/(?:BUY|SELL)\s+(\d+)\s+@\s*~?\$?([\d.]+)/i);
-              const qtyMatch = sharesMatch ?? externalMatch;
+              const isClosed = trade.close_price != null
+                || terminalStatuses.includes(trade.status)
+                || trade.closed_at != null;
+              const isActive = !isClosed && ['FILLED', 'PARTIAL'].includes(trade.status);
 
-              const isExternalSignal = event.source === 'external_signal'
-                || event.message?.toLowerCase().includes('external signal')
-                || matched?.notes?.startsWith('External signal')
-                || matched?.scanner_reason?.includes('External');
+              const pnl = trade.pnl ?? null;
 
-              const externalInfluencer = event.strategy_source
-                ?? matched?.scanner_reason?.match(/External strategy signal from (.+?)(?:\s*\||$)/)?.[1]
+              const isExternalSignal = trade.scanner_reason?.includes('External')
+                || trade.notes?.startsWith('External signal');
+              const externalInfluencer = trade.strategy_source
+                ?? trade.scanner_reason?.match(/External strategy signal from (.+?)(?:\s*\||$)/)?.[1]
                 ?? null;
 
-              const sourceLabel = isExternalSignal ? (externalInfluencer ? `External signal + ${externalInfluencer}` : 'External signal')
-                : event.source === 'scanner' ? 'Trade signal'
-                : event.source === 'suggested_finds' ? 'Suggested find'
-                : event.source === 'dip_buy' ? 'Dip buy'
-                : event.source === 'profit_take' ? 'Profit take'
-                : event.source === 'loss_cut' ? 'Loss cut'
-                : event.source === 'lt_auto_sell' ? 'LT auto-exit'
-                : event.source === 'swing_expiry' ? 'Swing expiry'
-                : event.source === 'capital_pressure' ? 'Capital freed'
-                : event.source === 'system' ? 'System'
-                : event.source === 'manual' ? 'Manual'
-                : 'Trade';
+              const sourceLabel = isExternalSignal
+                ? (externalInfluencer ? `External signal · ${externalInfluencer}` : 'External signal')
+                : trade.mode === 'LONG_TERM' ? 'Suggested find'
+                : 'Trade signal';
 
-              const modeLabel = event.mode === 'DAY_TRADE' ? 'Day'
-                : event.mode === 'DAY_PENNY' ? 'Penny'
-                : event.mode === 'SWING_TRADE' ? 'Swing'
-                : event.mode === 'LONG_TERM' ? 'Long Term'
-                : isPositionSync ? 'Close' : '—';
+              const modeLabel = trade.mode === 'DAY_TRADE' ? 'Day'
+                : trade.mode === 'DAY_PENNY' ? 'Penny'
+                : trade.mode === 'SWING_TRADE' ? 'Swing'
+                : trade.mode === 'LONG_TERM' ? 'Long Term'
+                : (trade.mode === 'OPTIONS_PUT' || trade.mode === 'OPTIONS_CALL'
+                   || trade.mode === 'CALENDAR_SPREAD' || trade.mode === 'CREDIT_SPREAD') ? 'Options'
+                : '—';
 
-              const SELL_SOURCES = new Set(['loss_cut', 'profit_take', 'lt_auto_sell', 'swing_expiry', 'capital_pressure']);
-              const inferredSignal = isPositionSync ? '—'
-                : SELL_SOURCES.has(event.source ?? '') ? 'SELL'
-                : 'BUY';
-              const entrySignal = event.scanner_signal ?? inferredSignal;
+              const entrySignal = trade.signal ?? 'BUY';
               const isSell = entrySignal === 'SELL';
-              const signalLabel = entrySignal;
-              const signalColor = isSell ? 'bg-red-100 text-red-700'
-                : isPositionSync ? 'bg-slate-100 text-slate-600'
-                : 'bg-emerald-100 text-emerald-700';
+              const signalColor = isSell ? 'bg-red-100 text-red-700' : 'bg-emerald-100 text-emerald-700';
+
+              const qty = trade.quantity;
+              const entryPrice = trade.fill_price;
+              const closePrice = trade.close_price;
+
+              const acctType = (trade as PaperTrade & { _accountType?: 'paper' | 'live' })._accountType;
 
               return (
-                <tr key={event.id} className={cn('hover:bg-[hsl(var(--secondary))]/50', (isPositionSync || isAutoClose) && 'bg-slate-50/50')}>
+                <tr key={trade.id} className="hover:bg-[hsl(var(--secondary))]/50">
                   <td className="px-4 py-3 font-bold">
                     <span className="inline-flex items-center gap-1.5">
-                      {accountView === 'live' && <AccountDot type="live" />}
-                      {event.ticker}
+                      {acctType === 'live' && <AccountDot type="live" />}
+                      {trade.ticker}
                     </span>
                   </td>
                   <td className="px-4 py-3">
                     <span className={cn('inline-flex px-1.5 py-0.5 rounded text-[10px] font-bold', signalColor)}>
-                      {signalLabel}
+                      {entrySignal}
                     </span>
                   </td>
                   <td className="px-4 py-3">
-                    <span className={cn(
-                      'text-[10px] px-1.5 py-0.5 rounded font-medium',
-                      isPositionSync ? 'bg-purple-50 text-purple-600' : 'bg-slate-100 text-slate-600'
-                    )}>
+                    <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-slate-100 text-slate-600">
                       {modeLabel}
                     </span>
                   </td>
                   <td className="px-4 py-3 text-xs text-[hsl(var(--muted-foreground))]">
                     <span className="font-medium text-[hsl(var(--foreground))]">{sourceLabel}</span>
-                    {qtyMatch
-                      ? <span> · {qtyMatch[1]} shares @ ${qtyMatch[2]}</span>
-                      : <span> · {msg.replace(/^External signal executed:\s*/i, '').slice(0, 45)}</span>
-                    }
+                    {qty != null && entryPrice != null && (
+                      <span> · {qty} shares @ ${entryPrice.toFixed(2)}</span>
+                    )}
+                    {closePrice != null && (
+                      <span className="ml-1 text-[10px]">→ ${closePrice.toFixed(2)}</span>
+                    )}
+                    {trade.strategy_video_heading && (
+                      <p className="text-[10px] text-[hsl(var(--muted-foreground))] truncate max-w-[180px] mt-0.5" title={trade.strategy_video_heading}>
+                        {trade.strategy_video_heading}
+                      </p>
+                    )}
                   </td>
                   <td className={cn(
                     'px-4 py-3 text-right tabular-nums font-semibold',
@@ -551,11 +520,42 @@ export function TodayActivityTab({ events, trades, todaySignalsForExecute = [], 
                     )}
                   </td>
                   <td className="px-4 py-3 text-right text-xs text-[hsl(var(--muted-foreground))] tabular-nums">
-                    {new Date(event.created_at).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}
+                    {new Date(trade.filled_at ?? trade.opened_at).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}
                   </td>
                 </tr>
               );
             })}
+            {/* System/reconcile events shown as supplementary rows */}
+            {systemEvents.map((ev) => (
+              <tr key={ev.id} className="bg-slate-50/50 hover:bg-[hsl(var(--secondary))]/50">
+                <td className="px-4 py-3 font-bold text-slate-500">
+                  <span className="inline-flex items-center gap-1.5">
+                    {ev.ticker}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="inline-flex px-1.5 py-0.5 rounded text-[10px] font-bold bg-slate-100 text-slate-600">—</span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-purple-50 text-purple-600">Close</span>
+                </td>
+                <td className="px-4 py-3 text-xs text-[hsl(var(--muted-foreground))]">
+                  <span className="font-medium text-[hsl(var(--foreground))]">System</span>
+                  <span> · {ev.message?.slice(0, 60)}</span>
+                </td>
+                <td className="px-4 py-3 text-right tabular-nums font-semibold text-slate-400">
+                  {(ev.metadata as { pnl?: number } | null)?.pnl != null
+                    ? fmtUsd((ev.metadata as { pnl: number }).pnl, 2, true)
+                    : '—'}
+                </td>
+                <td className="px-4 py-3">
+                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-50 text-blue-700 font-medium">Closed</span>
+                </td>
+                <td className="px-4 py-3 text-right text-xs text-[hsl(var(--muted-foreground))] tabular-nums">
+                  {new Date(ev.created_at).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}
+                </td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -217,6 +217,34 @@ export async function getAllTrades(limit = 50, accountView: AccountView = 'paper
   return (data ?? []) as PaperTradeWithAccount[];
 }
 
+/**
+ * Get today's trades from paper_trades directly (IB fills as source of truth).
+ * Returns all trades opened or closed today, ordered newest first.
+ * P&L comes from paper_trades.pnl which is kept accurate by the Postgres trigger
+ * on ib_fills (sync_ib_fill_to_paper_trades).
+ */
+export async function getTodayTrades(accountView: AccountView = 'paper'): Promise<PaperTradeWithAccount[]> {
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  const todayISO = todayStart.toISOString();
+
+  async function fetchForTable(table: 'paper_trades' | 'live_trades', acct?: AccountType): Promise<PaperTradeWithAccount[]> {
+    const { data, error } = await supabase
+      .from(table)
+      .select('*')
+      .or(`opened_at.gte.${todayISO},closed_at.gte.${todayISO}`)
+      .order('opened_at', { ascending: false });
+
+    if (error) return [];
+    const rows = (data ?? []) as PaperTrade[];
+    if (acct) return rows.map(t => ({ ...t, _accountType: acct }));
+    return rows;
+  }
+
+  if (accountView === 'live') return fetchForTable('live_trades', 'live');
+  return fetchForTable('paper_trades');
+}
+
 /** Day trade validation report — answers: trend vs chop? confidence ≥7 predictive? */
 export interface DayTradeValidationReport {
   trendVsChop: Array<{

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -776,7 +776,12 @@ export interface IbFill {
 
 export async function insertIbFill(fill: IbFill, accountType: AccountType = 'paper'): Promise<void> {
   const sb = getSupabase();
-  const { error } = await sb.from(fillsTable(accountType)).insert(fill);
+  // Upsert on (order_id, exec_id) so execDetails rows (with ticker/side) overwrite
+  // earlier orderStatus rows (empty ticker/side) for the same fill.
+  const { error } = await sb.from(fillsTable(accountType)).upsert(fill, {
+    onConflict: 'order_id,exec_id',
+    ignoreDuplicates: false,
+  });
   if (error) {
     console.warn(`[Supabase] Failed to persist IB fill for order ${fill.order_id}: ${error.message}`);
   }

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -4597,6 +4597,10 @@ async function processExternalStrategySignals(
   const nowMs = Date.now();
   const nowEtMinutes = getETMinutes();
 
+  // Prevent same ticker from executing two opposing conditional signals in the same batch
+  // (e.g. QQQ BUY above 500 + QQQ SELL below 495 both firing when price is between them).
+  const executedTickersThisBatch = new Set<string>();
+
   for (const signal of pending) {
     const executeAtMs = signal.execute_at ? new Date(signal.execute_at).getTime() : null;
     if (executeAtMs && nowMs < executeAtMs) {
@@ -4636,13 +4640,51 @@ async function processExternalStrategySignals(
       }
     }
 
+    // ── Price trigger gate ──────────────────────────────────────────────────
+    // If the signal has an entry_price, verify the current market price has
+    // actually reached (or crossed) that level before executing.
+    // BUY signals: execute only if currentPrice >= entry_price (breakout/long above)
+    // SELL signals: execute only if currentPrice <= entry_price (short/breakdown below)
+    // This prevents both legs of an opposing pair (e.g. QQQ BUY above X + SELL below Y)
+    // from simultaneously firing when only one trigger is actually crossed.
+    if (signal.entry_price != null) {
+      const currentPrice = await getQuotePrice(signal.ticker).catch(() => null);
+      if (currentPrice != null) {
+        const triggerCrossed = signal.signal === 'BUY'
+          ? currentPrice >= signal.entry_price
+          : currentPrice <= signal.entry_price;
+        if (!triggerCrossed) {
+          const direction = signal.signal === 'BUY' ? 'above' : 'below';
+          const triggerReason = `Entry trigger not reached: price $${currentPrice.toFixed(2)} not ${direction} entry $${signal.entry_price.toFixed(2)}`;
+          log(`${signal.ticker} [${signal.signal}]: ${triggerReason} — skipping this cycle`);
+          await updateExternalStrategySignal(signal.id, { failure_reason: triggerReason });
+          waiting += 1;
+          continue;
+        }
+      }
+    }
+
+    // ── Per-batch ticker dedup ──────────────────────────────────────────────
+    // Once a ticker has been executed this batch, skip any other signals for it.
+    // Prevents the duplicate-P&L issue where BUY and SELL for the same ticker
+    // both execute within the same scheduler cycle.
+    const tickerKey = `${signal.ticker.toUpperCase()}`;
+    if (executedTickersThisBatch.has(tickerKey)) {
+      log(`${signal.ticker}: already executed this cycle — skipping duplicate signal`);
+      waiting += 1;
+      continue;
+    }
+
     const result = await executeExternalStrategySignal(
       signal,
       config,
       positions,
       executionOptionsBySignalId.get(signal.id),
     );
-    if (result === 'executed') executed += 1;
+    if (result === 'executed') {
+      executed += 1;
+      executedTickersThisBatch.add(tickerKey);
+    }
     if (result === 'skipped') skipped += 1;
     if (result === 'failed') failed += 1;
     if (result === 'waiting') waiting += 1;

--- a/supabase/migrations/20260520000002_ib_fills_dedup_and_trigger.sql
+++ b/supabase/migrations/20260520000002_ib_fills_dedup_and_trigger.sql
@@ -1,0 +1,184 @@
+-- ── Step 1: Deduplicate existing ib_fills rows ────────────────────────────
+-- Keep one row per (order_id, COALESCE(exec_id,'')): prefer rows with a
+-- non-empty ticker, then take the lowest id (earliest insert).
+
+-- Paper account: delete all but the best row per natural key group
+DELETE FROM ib_fills
+WHERE id NOT IN (
+  SELECT DISTINCT ON (order_id, COALESCE(exec_id, ''))
+    id
+  FROM ib_fills
+  ORDER BY
+    order_id,
+    COALESCE(exec_id, ''),
+    -- prefer rows with real ticker
+    CASE WHEN ticker IS NOT NULL AND ticker != '' THEN 0 ELSE 1 END,
+    id  -- then earliest
+);
+
+-- Live account
+DELETE FROM live_ib_fills
+WHERE id NOT IN (
+  SELECT DISTINCT ON (order_id, COALESCE(exec_id, ''))
+    id
+  FROM live_ib_fills
+  ORDER BY
+    order_id,
+    COALESCE(exec_id, ''),
+    CASE WHEN ticker IS NOT NULL AND ticker != '' THEN 0 ELSE 1 END,
+    id
+);
+
+-- ── Step 2: Unique index to prevent future duplicates ─────────────────────
+CREATE UNIQUE INDEX IF NOT EXISTS ib_fills_order_exec_uniq
+  ON ib_fills (order_id, COALESCE(exec_id, ''));
+
+CREATE UNIQUE INDEX IF NOT EXISTS live_ib_fills_order_exec_uniq
+  ON live_ib_fills (order_id, COALESCE(exec_id, ''));
+
+-- ── Step 3: Postgres trigger — ib_fills → paper_trades ───────────────────
+-- Fires on INSERT and UPDATE (commission/pnl arriving from commissionReport).
+-- Matches fills to paper_trades via ib_order_id (entry), ib_tp_order_id (TP),
+-- and ib_sl_order_id (SL). Skips empty-ticker rows from orderStatus events.
+
+CREATE OR REPLACE FUNCTION sync_ib_fill_to_paper_trades()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Skip rows without ticker (orderStatus noise before execDetails arrives)
+  IF NEW.ticker IS NULL OR NEW.ticker = '' THEN
+    RETURN NEW;
+  END IF;
+
+  -- ENTRY FILL: update fill_price + promote PENDING/SUBMITTED → FILLED
+  UPDATE paper_trades SET
+    fill_price = NEW.fill_price,
+    filled_at  = COALESCE(filled_at, NEW.filled_at),
+    status     = CASE WHEN status IN ('PENDING', 'SUBMITTED') THEN 'FILLED' ELSE status END,
+    updated_at = NOW()
+  WHERE ib_order_id = NEW.order_id::text
+    AND status IN ('PENDING', 'SUBMITTED', 'FILLED');
+
+  -- TP FILL: close trade as TARGET_HIT with IB's exact P&L when available
+  UPDATE paper_trades SET
+    close_price = NEW.fill_price,
+    closed_at   = COALESCE(closed_at, NEW.filled_at),
+    status      = 'TARGET_HIT',
+    pnl         = COALESCE(
+                    NEW.realized_pnl,
+                    (NEW.fill_price - fill_price) * quantity
+                      * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                  ),
+    pnl_percent = CASE WHEN fill_price > 0 THEN
+                    ROUND((
+                      (NEW.fill_price - fill_price) / fill_price * 100
+                      * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                    )::numeric, 2)
+                  ELSE NULL END,
+    pnl_source  = CASE WHEN NEW.realized_pnl IS NOT NULL
+                    THEN 'ib_realized'
+                    ELSE 'ib_fill_calculated'
+                  END,
+    close_reason = 'target_hit',
+    updated_at   = NOW()
+  WHERE ib_tp_order_id = NEW.order_id::text
+    AND status = 'FILLED';
+
+  -- SL FILL: close trade as STOPPED with IB's exact P&L when available
+  UPDATE paper_trades SET
+    close_price = NEW.fill_price,
+    closed_at   = COALESCE(closed_at, NEW.filled_at),
+    status      = 'STOPPED',
+    pnl         = COALESCE(
+                    NEW.realized_pnl,
+                    (NEW.fill_price - fill_price) * quantity
+                      * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                  ),
+    pnl_percent = CASE WHEN fill_price > 0 THEN
+                    ROUND((
+                      (NEW.fill_price - fill_price) / fill_price * 100
+                      * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                    )::numeric, 2)
+                  ELSE NULL END,
+    pnl_source  = CASE WHEN NEW.realized_pnl IS NOT NULL
+                    THEN 'ib_realized'
+                    ELSE 'ib_fill_calculated'
+                  END,
+    close_reason = 'stopped',
+    updated_at   = NOW()
+  WHERE ib_sl_order_id = NEW.order_id::text
+    AND status = 'FILLED';
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_sync_ib_fill_paper
+  AFTER INSERT OR UPDATE ON ib_fills
+  FOR EACH ROW EXECUTE FUNCTION sync_ib_fill_to_paper_trades();
+
+-- ── Same trigger for live account ─────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION sync_live_ib_fill_to_live_trades()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.ticker IS NULL OR NEW.ticker = '' THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE live_trades SET
+    fill_price = NEW.fill_price,
+    filled_at  = COALESCE(filled_at, NEW.filled_at),
+    status     = CASE WHEN status IN ('PENDING', 'SUBMITTED') THEN 'FILLED' ELSE status END,
+    updated_at = NOW()
+  WHERE ib_order_id = NEW.order_id::text
+    AND status IN ('PENDING', 'SUBMITTED', 'FILLED');
+
+  UPDATE live_trades SET
+    close_price  = NEW.fill_price,
+    closed_at    = COALESCE(closed_at, NEW.filled_at),
+    status       = 'TARGET_HIT',
+    pnl          = COALESCE(
+                     NEW.realized_pnl,
+                     (NEW.fill_price - fill_price) * quantity
+                       * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                   ),
+    pnl_percent  = CASE WHEN fill_price > 0 THEN
+                     ROUND((
+                       (NEW.fill_price - fill_price) / fill_price * 100
+                       * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                     )::numeric, 2)
+                   ELSE NULL END,
+    pnl_source   = CASE WHEN NEW.realized_pnl IS NOT NULL THEN 'ib_realized' ELSE 'ib_fill_calculated' END,
+    close_reason = 'target_hit',
+    updated_at   = NOW()
+  WHERE ib_tp_order_id = NEW.order_id::text
+    AND status = 'FILLED';
+
+  UPDATE live_trades SET
+    close_price  = NEW.fill_price,
+    closed_at    = COALESCE(closed_at, NEW.filled_at),
+    status       = 'STOPPED',
+    pnl          = COALESCE(
+                     NEW.realized_pnl,
+                     (NEW.fill_price - fill_price) * quantity
+                       * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                   ),
+    pnl_percent  = CASE WHEN fill_price > 0 THEN
+                     ROUND((
+                       (NEW.fill_price - fill_price) / fill_price * 100
+                       * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                     )::numeric, 2)
+                   ELSE NULL END,
+    pnl_source   = CASE WHEN NEW.realized_pnl IS NOT NULL THEN 'ib_realized' ELSE 'ib_fill_calculated' END,
+    close_reason = 'stopped',
+    updated_at   = NOW()
+  WHERE ib_sl_order_id = NEW.order_id::text
+    AND status = 'FILLED';
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_sync_ib_fill_live
+  AFTER INSERT OR UPDATE ON live_ib_fills
+  FOR EACH ROW EXECUTE FUNCTION sync_live_ib_fill_to_live_trades();


### PR DESCRIPTION
## Summary

- **Postgres trigger on `ib_fills`**: `sync_ib_fill_to_paper_trades` fires on every INSERT or UPDATE, automatically patching `paper_trades.fill_price`, `close_price`, `pnl`, `status` — no more manual DB fixes after fills
- **Unique index + upsert**: deduplicates `ib_fills` rows so `execDetails` (with ticker/side) always wins over empty `orderStatus` noise rows
- **Today's Activity reads from `paper_trades`**: switched from event-driven rows to `getTodayTrades()` which queries paper_trades for today — P&L is now accurate and includes every trade IB executed (no more missing losses)
- **Price trigger gate**: conditional signals (BUY above X, SELL below Y) now check the live price before executing — prevents the QQQ/SPY duplicate P&L bug where both legs fire simultaneously
- **Per-batch ticker dedup**: `executedTickers` Set prevents same ticker executing two opposing signals in the same scheduler cycle

## What this eliminates

- Missing P&L for bracket exits (target/stop-loss)
- Missing sells for orphaned position closes
- Duplicated P&L when opposing BUY+SELL fire for same ticker
- Manual `auto_trade_events` inserts that have been needed every trading day
- Stale SUBMITTED status when trade was actually filled

## Test plan
- [ ] Verify Today's Activity tab shows all paper_trades opened/closed today
- [ ] Verify P&L values match IBKR realized P&L
- [ ] Verify new fills from IB auto-update paper_trades within seconds (trigger)
- [ ] Verify conditional signals with entry_price wait for price to cross trigger

Made with [Cursor](https://cursor.com)