### PR TITLE
fix: video delete now clears strategy_video_id from paper_trades

### DIFF
--- a/app/src/components/PaperTrading/tabs/StrategyPerformanceTab.tsx
+++ b/app/src/components/PaperTrading/tabs/StrategyPerformanceTab.tsx
@@ -467,6 +467,7 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
       onRefresh?.();
     } catch (err) {
       console.error('[handleRemoveVideo]', err);
+      alert(`Failed to remove video: ${err instanceof Error ? err.message : 'Unknown error'}`);
     } finally {
       setRemovingVideoId(null);
     }

--- a/app/src/lib/strategyVideoQueueApi.ts
+++ b/app/src/lib/strategyVideoQueueApi.ts
@@ -309,6 +309,18 @@ export async function deleteStrategyVideo(videoId: string): Promise<void> {
     .delete()
     .eq('video_id', videoId);
 
+  // Clear strategy_video_id from paper_trades and live_trades so the video
+  // no longer appears in the Strategy Performance tab after deletion.
+  await supabase
+    .from('paper_trades')
+    .update({ strategy_video_id: null })
+    .eq('strategy_video_id', videoId);
+
+  await supabase
+    .from('live_trades')
+    .update({ strategy_video_id: null })
+    .eq('strategy_video_id', videoId);
+
   const { error } = await supabase
     .from('strategy_videos')
     .delete()


### PR DESCRIPTION
## Root Cause

When a strategy video was deleted via the Remove button, `deleteStrategyVideo` correctly removed it from `strategy_videos` and `strategy_video_queue` — but `paper_trades` records still had `strategy_video_id` pointing to the deleted video.

Since `recalculatePerformanceByStrategyVideo` builds video rows by grouping `paper_trades` records, the deleted video kept reappearing after every refresh, making Remove look broken.

## Fix

- `deleteStrategyVideo` now nulls out `strategy_video_id` in `paper_trades` and `live_trades` before deleting from `strategy_videos`
- Added `alert()` in `handleRemoveVideo` so failures surface to the user instead of failing silently
- Manually patched 14 existing `paper_trades` rows for the two already-deleted premarket gameplan videos

## Test plan
- [ ] Click Remove on a video → confirm video disappears immediately after refresh
- [ ] Re-open Strategies tab → video should not reappear

Made with [Cursor](https://cursor.com)