### PR TITLE
fix: exclude CANCELLED trades from Today's Activity

### DIFF
--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -141,7 +141,7 @@ export function TodayActivityTab({ events, trades, todayTrades, todaySignalsForE
     const openedToday = t.opened_at && t.opened_at >= todayISO;
     const closedToday = t.closed_at && t.closed_at >= todayISO;
     return openedToday || closedToday;
-  })).filter(t => !OPTIONS_MODES.has(t.mode));
+  })).filter(t => !OPTIONS_MODES.has(t.mode) && t.status !== 'CANCELLED');
 
   // Legacy lookup: events for system-only messages (reconcile warnings, orphan alerts)
   const tradesByTicker = new Map<string, PaperTrade[]>();


### PR DESCRIPTION
## Summary
- CANCELLED paper_trades were leaking into Today's Activity as \"Closed\" rows with no P&L (AMD, ENPH, SMH, MRVL today). Added \`&& t.status !== 'CANCELLED'\` to the primaryTrades filter.
- Also patched DB directly: ACMR/INOD/RKLB/CORT P&L updated to IB net realized P&L (previously showed gross, missing commissions). SNOW updated from CANCELLED → SUBMITTED (it's an open IB position).

Made with [Cursor](https://cursor.com)