### PR TITLE
fix: EOD close sell orders retroactively patch pnl with IB net realized P&L

### DIFF
--- a/auto-trader/src/lib/trade-closer.ts
+++ b/auto-trader/src/lib/trade-closer.ts
@@ -108,6 +108,9 @@ export async function recordTradeClose(params: CloseTradeParams): Promise<void> 
     pnl_percent: pnlPct != null ? parseFloat(pnlPct.toFixed(2)) : null,
     pnl_source: pnlSource,
     closed_at: new Date().toISOString(),
+    // Store close orderId so the trigger can retroactively patch pnl with
+    // IB's net realized_pnl when the commission report arrives asynchronously.
+    ...(orderId != null ? { ib_close_order_id: orderId.toString() } : {}),
     ...(extraUpdates ?? {}),
   };
 

--- a/supabase/migrations/20260520000004_ib_close_order_id.sql
+++ b/supabase/migrations/20260520000004_ib_close_order_id.sql
@@ -1,0 +1,166 @@
+-- Add ib_close_order_id to paper_trades / live_trades so the trigger can
+-- retroactively patch pnl with IB's net realized_pnl when the commission
+-- report arrives after an EOD soft-close sell order.
+--
+-- Previously the trigger only matched entry/TP/SL order IDs.  EOD sweep
+-- closes place a NEW sell orderId that was never stored on the paper_trade,
+-- so the commission event had nothing to match on → gross P&L fallback.
+
+ALTER TABLE paper_trades   ADD COLUMN IF NOT EXISTS ib_close_order_id text;
+ALTER TABLE live_trades    ADD COLUMN IF NOT EXISTS ib_close_order_id text;
+
+-- ── Update trigger: add 4th case for soft-close sells ─────────────────────
+
+CREATE OR REPLACE FUNCTION sync_ib_fill_to_paper_trades()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.ticker IS NULL OR NEW.ticker = '' THEN
+    RETURN NEW;
+  END IF;
+
+  -- ENTRY FILL: update fill_price + promote PENDING/SUBMITTED → FILLED
+  UPDATE paper_trades SET
+    fill_price = NEW.fill_price,
+    filled_at  = COALESCE(filled_at, NEW.filled_at),
+    status     = CASE WHEN status IN ('PENDING', 'SUBMITTED') THEN 'FILLED' ELSE status END,
+    updated_at = NOW()
+  WHERE ib_order_id = NEW.order_id::text
+    AND status IN ('PENDING', 'SUBMITTED', 'FILLED');
+
+  -- TP FILL: close trade as TARGET_HIT with IB's exact P&L when available
+  UPDATE paper_trades SET
+    close_price = NEW.fill_price,
+    closed_at   = COALESCE(closed_at, NEW.filled_at),
+    status      = 'TARGET_HIT',
+    pnl         = COALESCE(
+                    NEW.realized_pnl,
+                    (NEW.fill_price - fill_price) * quantity
+                      * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                  ),
+    pnl_percent = CASE WHEN fill_price > 0 THEN
+                    ROUND((
+                      (NEW.fill_price - fill_price) / fill_price * 100
+                      * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                    )::numeric, 2)
+                  ELSE NULL END,
+    pnl_source  = CASE WHEN NEW.realized_pnl IS NOT NULL
+                    THEN 'ib_realized'
+                    ELSE 'ib_fill_calculated'
+                  END,
+    close_reason = 'target_hit',
+    updated_at   = NOW()
+  WHERE ib_tp_order_id = NEW.order_id::text
+    AND status = 'FILLED';
+
+  -- SL FILL: close trade as STOPPED with IB's exact P&L when available
+  UPDATE paper_trades SET
+    close_price = NEW.fill_price,
+    closed_at   = COALESCE(closed_at, NEW.filled_at),
+    status      = 'STOPPED',
+    pnl         = COALESCE(
+                    NEW.realized_pnl,
+                    (NEW.fill_price - fill_price) * quantity
+                      * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                  ),
+    pnl_percent = CASE WHEN fill_price > 0 THEN
+                    ROUND((
+                      (NEW.fill_price - fill_price) / fill_price * 100
+                      * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                    )::numeric, 2)
+                  ELSE NULL END,
+    pnl_source  = CASE WHEN NEW.realized_pnl IS NOT NULL
+                    THEN 'ib_realized'
+                    ELSE 'ib_fill_calculated'
+                  END,
+    close_reason = 'stopped',
+    updated_at   = NOW()
+  WHERE ib_sl_order_id = NEW.order_id::text
+    AND status = 'FILLED';
+
+  -- EOD / SOFT-CLOSE FILL: patch pnl when commission arrives for a manual
+  -- close sell that was placed by the EOD sweep or reconciler.  Only fires
+  -- once realized_pnl is present (the commissionReport UPDATE), leaving the
+  -- initial gross pnl set by recordTradeClose intact until then.
+  UPDATE paper_trades SET
+    pnl        = NEW.realized_pnl,
+    pnl_source = 'ib_realized',
+    updated_at = NOW()
+  WHERE ib_close_order_id = NEW.order_id::text
+    AND NEW.realized_pnl IS NOT NULL
+    AND status IN ('CLOSED', 'TARGET_HIT', 'STOPPED');
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ── Same update for live account ───────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION sync_live_ib_fill_to_live_trades()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.ticker IS NULL OR NEW.ticker = '' THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE live_trades SET
+    fill_price = NEW.fill_price,
+    filled_at  = COALESCE(filled_at, NEW.filled_at),
+    status     = CASE WHEN status IN ('PENDING', 'SUBMITTED') THEN 'FILLED' ELSE status END,
+    updated_at = NOW()
+  WHERE ib_order_id = NEW.order_id::text
+    AND status IN ('PENDING', 'SUBMITTED', 'FILLED');
+
+  UPDATE live_trades SET
+    close_price  = NEW.fill_price,
+    closed_at    = COALESCE(closed_at, NEW.filled_at),
+    status       = 'TARGET_HIT',
+    pnl          = COALESCE(
+                     NEW.realized_pnl,
+                     (NEW.fill_price - fill_price) * quantity
+                       * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                   ),
+    pnl_percent  = CASE WHEN fill_price > 0 THEN
+                     ROUND((
+                       (NEW.fill_price - fill_price) / fill_price * 100
+                       * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                     )::numeric, 2)
+                   ELSE NULL END,
+    pnl_source   = CASE WHEN NEW.realized_pnl IS NOT NULL THEN 'ib_realized' ELSE 'ib_fill_calculated' END,
+    close_reason = 'target_hit',
+    updated_at   = NOW()
+  WHERE ib_tp_order_id = NEW.order_id::text
+    AND status = 'FILLED';
+
+  UPDATE live_trades SET
+    close_price  = NEW.fill_price,
+    closed_at    = COALESCE(closed_at, NEW.filled_at),
+    status       = 'STOPPED',
+    pnl          = COALESCE(
+                     NEW.realized_pnl,
+                     (NEW.fill_price - fill_price) * quantity
+                       * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                   ),
+    pnl_percent  = CASE WHEN fill_price > 0 THEN
+                     ROUND((
+                       (NEW.fill_price - fill_price) / fill_price * 100
+                       * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                     )::numeric, 2)
+                   ELSE NULL END,
+    pnl_source   = CASE WHEN NEW.realized_pnl IS NOT NULL THEN 'ib_realized' ELSE 'ib_fill_calculated' END,
+    close_reason = 'stopped',
+    updated_at   = NOW()
+  WHERE ib_sl_order_id = NEW.order_id::text
+    AND status = 'FILLED';
+
+  -- EOD / SOFT-CLOSE FILL: patch pnl with IB's net realized_pnl on commission
+  UPDATE live_trades SET
+    pnl        = NEW.realized_pnl,
+    pnl_source = 'ib_realized',
+    updated_at = NOW()
+  WHERE ib_close_order_id = NEW.order_id::text
+    AND NEW.realized_pnl IS NOT NULL
+    AND status IN ('CLOSED', 'TARGET_HIT', 'STOPPED');
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Root Cause

The Postgres trigger (`sync_ib_fill_to_paper_trades`) only matched 3 order ID columns:
- `ib_order_id` — entry fill
- `ib_tp_order_id` — take-profit fill  
- `ib_sl_order_id` — stop-loss fill

When the EOD sweep places a market sell to close a position, it generates a **new order ID** that was never stored on the `paper_trade`. The commission event arriving in `ib_fills` had nothing to match on → trigger skipped it → `pnl` stayed at gross math (`(sell - buy) × qty`) instead of IB's net realized P&L.

This was the root cause of the daily P&L discrepancy for ACMR, INOD, RKLB, CORT etc. (commission gap, typically ~\$2–\$3 per trade in commissions).

## Fix

- **`paper_trades` / `live_trades`**: Add `ib_close_order_id text` column via migration
- **`recordTradeClose`**: Write `ib_close_order_id = orderId.toString()` whenever closing with a market-sell orderId
- **Trigger**: Add a 4th `UPDATE` case that fires when `ib_fills.realized_pnl` is set and `ib_close_order_id` matches — retroactively patches `pnl` to IB's net number and sets `pnl_source = 'ib_realized'`

## Flow After Fix

1. EOD sweep places sell → `recordTradeClose({..., orderId: 19981})` runs
2. `paper_trade` gets `close_price`, gross `pnl`, `pnl_source='ib_fill_calculated'`, **`ib_close_order_id='19981'`**
3. Commission report arrives 1–2s later → updates `ib_fills.realized_pnl = -2.14`
4. Trigger fires → `UPDATE paper_trades SET pnl=-2.14, pnl_source='ib_realized' WHERE ib_close_order_id='19981'`
5. UI shows exact IB net P&L, no manual patch needed

## Test plan
- [ ] Verify `ib_close_order_id` column exists in `paper_trades` after migration
- [ ] Verify EOD sweep tomorrow shows `pnl_source='ib_realized'` for closed day trades
- [ ] Verify no commission gap between UI and IBKR P&L

Made with [Cursor](https://cursor.com)