### PR TITLE
Fix bracket oversell guard, conditional entry signals, grouped orders UI

### DIFF
--- a/app/src/components/PaperTrading/tabs/OptionsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/OptionsTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { RefreshCw, Plus, X, AlertTriangle, CheckCircle, Activity, Pencil, Check, TrendingUp, DollarSign, Crosshair, Search, Loader2, Send } from 'lucide-react';
+import { RefreshCw, Plus, X, AlertTriangle, CheckCircle, Activity, Pencil, Check, TrendingUp, DollarSign, Crosshair, Search, Loader2, Send, Trash2 } from 'lucide-react';
 import { cn } from '../../../lib/utils';
 import { fmtUsd } from '../utils';
 import {
@@ -77,15 +77,18 @@ function PositionCard({
   atRisk,
   atRiskReason,
   onSubmitToIB,
+  onDiscard,
 }: {
   pos: OpenOptionsPosition;
   currentPrice?: TickerQuote;
   atRisk?: boolean;
   atRiskReason?: string;
   onSubmitToIB?: (id: string) => Promise<void>;
+  onDiscard?: (id: string) => Promise<void>;
 }) {
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [discarding, setDiscarding] = useState(false);
 
   const handleSubmit = async () => {
     if (!onSubmitToIB) return;
@@ -97,6 +100,16 @@ function PositionCard({
       setSubmitError(err instanceof Error ? err.message : 'Failed to submit');
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const handleDiscard = async () => {
+    if (!onDiscard) return;
+    setDiscarding(true);
+    try {
+      await onDiscard(pos.id);
+    } finally {
+      setDiscarding(false);
     }
   };
   const dte = daysUntil(pos.option_expiry);
@@ -247,17 +260,32 @@ function PositionCard({
         </div>
       )}
 
-      {/* Submit to IB — only shown for paper-only positions */}
-      {!pos.ib_order_id && onSubmitToIB && (
+      {/* Submit to IB / Discard — only shown for paper-only positions */}
+      {!pos.ib_order_id && (onSubmitToIB || onDiscard) && (
         <div className="mt-2 space-y-1">
-          <button
-            onClick={handleSubmit}
-            disabled={submitting}
-            className="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-600 text-white text-[11px] font-semibold hover:bg-violet-700 disabled:opacity-50 transition-colors"
-          >
-            {submitting ? <Loader2 className="w-3 h-3 animate-spin" /> : <Send className="w-3 h-3" />}
-            {submitting ? 'Submitting to IB…' : 'Submit to IB'}
-          </button>
+          <div className="flex gap-1.5">
+            {onSubmitToIB && (
+              <button
+                onClick={handleSubmit}
+                disabled={submitting || discarding}
+                className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-600 text-white text-[11px] font-semibold hover:bg-violet-700 disabled:opacity-50 transition-colors"
+              >
+                {submitting ? <Loader2 className="w-3 h-3 animate-spin" /> : <Send className="w-3 h-3" />}
+                {submitting ? 'Submitting…' : 'Submit to IB'}
+              </button>
+            )}
+            {onDiscard && (
+              <button
+                onClick={handleDiscard}
+                disabled={discarding || submitting}
+                title="Discard — remove this paper trade without submitting to IB"
+                className="flex items-center justify-center gap-1 px-2.5 py-1.5 rounded-lg border border-red-200 text-red-600 text-[11px] font-semibold hover:bg-red-50 disabled:opacity-50 transition-colors"
+              >
+                {discarding ? <Loader2 className="w-3 h-3 animate-spin" /> : <Trash2 className="w-3 h-3" />}
+                {discarding ? '' : 'Discard'}
+              </button>
+            )}
+          </div>
           {submitError && (
             <p className="text-[10px] text-red-600 text-center">{submitError}</p>
           )}
@@ -763,6 +791,19 @@ export function OptionsTab() {
     await load();
   }
 
+  async function handleDiscardPaperTrade(positionId: string): Promise<void> {
+    const res = await fetch('http://localhost:3001/api/options/discard', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tradeId: positionId }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({})) as { error?: string };
+      throw new Error(body.error ?? `Discard failed (HTTP ${res.status})`);
+    }
+    await load();
+  }
+
   // Split open positions into needs-attention and healthy, computing the reason for each flagged position.
   const deployed = openPositions.reduce((s, p) => {
     return s + (p.option_strike * 100 * (p.option_contracts ?? 1));
@@ -930,6 +971,7 @@ export function OptionsTab() {
                       atRisk
                       atRiskReason={atRiskReasons.get(pos.id)}
                       onSubmitToIB={handleSubmitToIB}
+                      onDiscard={handleDiscardPaperTrade}
                     />
                   ))}
                 </div>
@@ -951,6 +993,7 @@ export function OptionsTab() {
                       pos={pos}
                       currentPrice={openPrices.get(pos.ticker)}
                       onSubmitToIB={handleSubmitToIB}
+                      onDiscard={handleDiscardPaperTrade}
                     />
                   ))}
                 </div>

--- a/app/src/components/PaperTrading/tabs/PortfolioTab.tsx
+++ b/app/src/components/PaperTrading/tabs/PortfolioTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import {
   Briefcase,
   WifiOff,
@@ -200,55 +200,121 @@ export function PortfolioTab({ positions, orders, pendingSignals, connected, onR
               <tr className="bg-[hsl(var(--secondary))]/50 text-[hsl(var(--muted-foreground))] text-xs">
                 <th className="text-left px-4 py-2.5 font-medium">Symbol</th>
                 <th className="text-left px-4 py-2.5 font-medium">Side</th>
-                <th className="text-left px-4 py-2.5 font-medium">Type</th>
-                <th className="text-right px-4 py-2.5 font-medium">Price</th>
                 <th className="text-right px-4 py-2.5 font-medium">Qty</th>
+                <th className="px-4 py-2.5 font-medium">Protection</th>
                 <th className="text-left px-4 py-2.5 font-medium">Status</th>
-                <th className="text-left px-4 py-2.5 font-medium">Role</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-[hsl(var(--border))]">
-              {orders.map((order, i) => {
-                const isChild = order.parentId && order.parentId !== 0;
-                const isStop = order.orderType === 'STP';
-                const isLimit = order.orderType === 'LMT';
-                let role = 'Entry';
-                if (isChild && isStop) role = 'Stop Loss';
-                else if (isChild && isLimit) role = 'Take Profit';
-                return (
-                  <tr key={`${order.orderId}-${i}`} className={`hover:bg-[hsl(var(--secondary))]/50 ${isChild ? 'bg-slate-50/50' : ''}`}>
-                    <td className={`px-4 py-2.5 ${isChild ? 'pl-8 text-[hsl(var(--muted-foreground))]' : 'font-bold'}`}>
-                      {order.ticker}
-                    </td>
-                    <td className="px-4 py-2.5">
-                      <span className={`inline-flex px-2 py-0.5 rounded text-[10px] font-bold ${order.side === 'BUY' ? 'bg-emerald-100 text-emerald-700' : 'bg-red-100 text-red-700'}`}>
-                        {order.side}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2.5 text-xs text-[hsl(var(--muted-foreground))]">{order.orderType}</td>
-                    <td className="px-4 py-2.5 text-right tabular-nums">
-                      {order.price ? `$${Number(order.price).toFixed(2)}` : '—'}
-                    </td>
-                    <td className="px-4 py-2.5 text-right tabular-nums">{order.quantity}</td>
-                    <td className="px-4 py-2.5">
-                      <span className={`inline-flex px-2 py-0.5 rounded text-[10px] font-bold ${
-                        order.status === 'Filled' ? 'bg-emerald-100 text-emerald-700'
-                          : order.status === 'Cancelled' ? 'bg-slate-100 text-slate-500'
-                          : 'bg-blue-100 text-blue-700'
-                      }`}>
-                        {order.status}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2.5 text-xs text-[hsl(var(--muted-foreground))]">
-                      {isChild ? (
-                        <span className={`inline-flex px-1.5 py-0.5 rounded text-[10px] font-medium ${isStop ? 'bg-red-50 text-red-600' : 'bg-emerald-50 text-emerald-600'}`}>
-                          {role}
+              {(() => {
+                // Group bracket child pairs (same parentId, STP + LMT) into single rows.
+                // Standalone orders (no parentId or unmatched) render as individual rows.
+                const bracketMap = new Map<number, { stp?: typeof orders[0]; lmt?: typeof orders[0] }>();
+                const standalone: typeof orders = [];
+
+                for (const order of orders) {
+                  if (order.parentId && order.parentId !== 0) {
+                    const group = bracketMap.get(order.parentId) ?? {};
+                    if (order.orderType === 'STP') group.stp = order;
+                    else if (order.orderType === 'LMT') group.lmt = order;
+                    else standalone.push(order);
+                    bracketMap.set(order.parentId, group);
+                  } else {
+                    standalone.push(order);
+                  }
+                }
+
+                const rows: React.ReactNode[] = [];
+
+                // Bracket pairs — one row per bracket
+                bracketMap.forEach((group, parentId) => {
+                  const { stp, lmt } = group;
+                  if (stp && lmt) {
+                    const representative = stp;
+                    const slPrice = Number(stp.price).toFixed(2);
+                    const tpPrice = Number(lmt.price).toFixed(2);
+                    const statusOrder = stp.status === 'Filled' || lmt.status === 'Filled' ? 'Filled'
+                      : stp.status === 'Cancelled' || lmt.status === 'Cancelled' ? 'Cancelled'
+                      : stp.status;
+                    rows.push(
+                      <tr key={`bracket-${parentId}`} className="hover:bg-[hsl(var(--secondary))]/50">
+                        <td className="px-4 py-3 font-bold">{representative.ticker}</td>
+                        <td className="px-4 py-3">
+                          <span className={`inline-flex px-2 py-0.5 rounded text-[10px] font-bold ${representative.side === 'BUY' ? 'bg-emerald-100 text-emerald-700' : 'bg-red-100 text-red-700'}`}>
+                            {representative.side}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-right tabular-nums">{representative.quantity}</td>
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-1.5 text-xs">
+                            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-red-50 text-red-600 font-medium tabular-nums">
+                              SL ${slPrice}
+                            </span>
+                            <span className="text-[hsl(var(--muted-foreground))] select-none">←——→</span>
+                            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-emerald-50 text-emerald-600 font-medium tabular-nums">
+                              TP ${tpPrice}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className={`inline-flex px-2 py-0.5 rounded text-[10px] font-bold ${
+                            statusOrder === 'Filled' ? 'bg-emerald-100 text-emerald-700'
+                              : statusOrder === 'Cancelled' ? 'bg-slate-100 text-slate-500'
+                              : 'bg-blue-100 text-blue-700'
+                          }`}>
+                            {statusOrder}
+                          </span>
+                        </td>
+                      </tr>
+                    );
+                  } else {
+                    // Unmatched child (only STP or only LMT) — fall through to standalone
+                    if (stp) standalone.push(stp);
+                    if (lmt) standalone.push(lmt);
+                  }
+                });
+
+                // Standalone orders (entries, unmatched legs, MKT orders)
+                for (const order of standalone) {
+                  const isStop = order.orderType === 'STP';
+                  const isLimit = order.orderType === 'LMT';
+                  const isChild = order.parentId && order.parentId !== 0;
+                  let role = 'Entry';
+                  if (isChild && isStop) role = 'Stop Loss';
+                  else if (isChild && isLimit) role = 'Take Profit';
+                  rows.push(
+                    <tr key={`${order.orderId}`} className="hover:bg-[hsl(var(--secondary))]/50">
+                      <td className="px-4 py-3 font-bold">{order.ticker}</td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex px-2 py-0.5 rounded text-[10px] font-bold ${order.side === 'BUY' ? 'bg-emerald-100 text-emerald-700' : 'bg-red-100 text-red-700'}`}>
+                          {order.side}
                         </span>
-                      ) : role}
-                    </td>
-                  </tr>
-                );
-              })}
+                      </td>
+                      <td className="px-4 py-3 text-right tabular-nums">{order.quantity}</td>
+                      <td className="px-4 py-3 text-xs text-[hsl(var(--muted-foreground))]">
+                        <span className="tabular-nums">{order.price ? `$${Number(order.price).toFixed(2)}` : '—'}</span>
+                        <span className="ml-1.5 text-[10px] opacity-60">{order.orderType}</span>
+                        {isChild && (
+                          <span className={`ml-2 inline-flex px-1.5 py-0.5 rounded text-[10px] font-medium ${isStop ? 'bg-red-50 text-red-600' : 'bg-emerald-50 text-emerald-600'}`}>
+                            {role}
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex px-2 py-0.5 rounded text-[10px] font-bold ${
+                          order.status === 'Filled' ? 'bg-emerald-100 text-emerald-700'
+                            : order.status === 'Cancelled' ? 'bg-slate-100 text-slate-500'
+                            : 'bg-blue-100 text-blue-700'
+                        }`}>
+                          {order.status}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                }
+
+                return rows;
+              })()}
             </tbody>
           </table>
         </div>

--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -99,6 +99,9 @@ export interface OptionsOrderParams {
   account?: string;
   action?: 'BUY' | 'SELL';
   tradingClass?: string;
+  /** When provided, IB routes by conId rather than symbol/strike/expiry — avoids
+   *  code=200 rejections when the working expiry offset differs from the stored date. */
+  conId?: number;
 }
 
 export interface OptionsOrderResult {
@@ -832,20 +835,25 @@ export class IBConnection {
       const tick = params.limitPrice >= 3.0 ? 0.05 : 0.01;
       const limitPrice = Math.round(params.limitPrice / tick) * tick;
 
-      const contract: Contract = {
-        symbol: symbol.toUpperCase(),
-        secType: SecType.OPT,
-        exchange: 'SMART',
-        currency: 'USD',
-        strike,
-        right: right === 'P' ? OptionType.Put : OptionType.Call,
-        lastTradeDateOrContractMonth: expiry,
-        multiplier: 100,
-        // tradingClass intentionally omitted — let IB resolve by symbol/strike/expiry.
-        // Hardcoding the symbol as tradingClass causes rejections for tickers where
-        // IB's internal trading class differs (e.g. ADI, DOCU, RBRK).
-        ...(params.tradingClass ? { tradingClass: params.tradingClass } : {}),
-      };
+      // When a conId is provided (from resolveOptionConId), use it as the sole
+      // contract identifier — IB resolves the exact series from its database,
+      // bypassing any symbol/strike/expiry mismatch (e.g. settlement date offset).
+      const contract: Contract = params.conId
+        ? { conId: params.conId, exchange: 'SMART', currency: 'USD' }
+        : {
+            symbol: symbol.toUpperCase(),
+            secType: SecType.OPT,
+            exchange: 'SMART',
+            currency: 'USD',
+            strike,
+            right: right === 'P' ? OptionType.Put : OptionType.Call,
+            lastTradeDateOrContractMonth: expiry,
+            multiplier: 100,
+            // tradingClass intentionally omitted — let IB resolve by symbol/strike/expiry.
+            // Hardcoding the symbol as tradingClass causes rejections for tickers where
+            // IB's internal trading class differs (e.g. ADI, DOCU, RBRK).
+            ...(params.tradingClass ? { tradingClass: params.tradingClass } : {}),
+          };
 
       const orderId = this.getNextOrderId();
 
@@ -910,7 +918,7 @@ export class IBConnection {
 
   async resolveOptionConId(
     symbol: string, right: 'P' | 'C', strike: number, expiry: string,
-  ): Promise<number | null> {
+  ): Promise<{ conId: number; resolvedExpiry: string } | null> {
     if (!this.ib || !this._connected) return null;
 
     // Helper that fires one reqContractDetails request and waits up to 8s.
@@ -978,7 +986,10 @@ export class IBConnection {
       d.setDate(d.getDate() + offsetDays);
       const candidate = `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
       const conId = await tryResolve(candidate);
-      if (conId) return conId;
+      // Return both the conId AND the expiry date that actually worked —
+      // callers must use resolvedExpiry (not the original) when placing orders
+      // to avoid IB rejecting with code=200 "No security definition found".
+      if (conId) return { conId, resolvedExpiry: candidate };
     }
     return null;
   }
@@ -994,13 +1005,15 @@ export class IBConnection {
 
     const { symbol, right, strike, frontExpiry, backExpiry, contracts, account } = params;
 
-    const [frontConId, backConId] = await Promise.all([
+    const [frontResult, backResult] = await Promise.all([
       this.resolveOptionConId(symbol, right, strike, frontExpiry),
       this.resolveOptionConId(symbol, right, strike, backExpiry),
     ]);
-    if (!frontConId || !backConId) {
+    if (!frontResult || !backResult) {
       throw new Error(`Could not resolve conIds for ${symbol} ${strike}${right} ${frontExpiry}/${backExpiry}`);
     }
+    const frontConId = frontResult.conId;
+    const backConId = backResult.conId;
 
     const tick = params.limitPrice >= 3.0 ? 0.05 : 0.01;
     const limitPrice = Math.round(params.limitPrice / tick) * tick;
@@ -1048,13 +1061,15 @@ export class IBConnection {
 
     const { symbol, right, sellStrike, buyStrike, expiry, contracts, account } = params;
 
-    const [sellConId, buyConId] = await Promise.all([
+    const [sellResult, buyResult] = await Promise.all([
       this.resolveOptionConId(symbol, right, sellStrike, expiry),
       this.resolveOptionConId(symbol, right, buyStrike, expiry),
     ]);
-    if (!sellConId || !buyConId) {
+    if (!sellResult || !buyResult) {
       throw new Error(`Could not resolve conIds for ${symbol} ${sellStrike}/${buyStrike}${right} ${expiry}`);
     }
+    const sellConId = sellResult.conId;
+    const buyConId = buyResult.conId;
 
     const tick = params.limitPrice >= 3.0 ? 0.05 : 0.01;
     const limitPrice = Math.round(params.limitPrice / tick) * tick;

--- a/auto-trader/src/lib/options-scanner.ts
+++ b/auto-trader/src/lib/options-scanner.ts
@@ -1208,14 +1208,19 @@ export async function autoTradeOption(ticket: OptionsTradeTicket): Promise<{ tra
     return { tradeId, ibOrderId: null, isLive: false };
   }
 
-  // Validate the contract exists in IB before placing — resolveOptionConId now tries
-  // the exact expiry plus ±1/±2 day offsets and omits tradingClass for maximum
-  // compatibility. If it still returns null after all retries, the options chain
-  // genuinely doesn't list this contract (strike too far OTM, no market, etc.).
+  // Validate the contract exists in IB before placing — resolveOptionConId tries the
+  // exact expiry plus ±1/±2 day offsets and omits tradingClass for maximum compatibility.
+  // It returns both the conId AND the expiry that actually resolved (which may differ by
+  // a day from the stored date for settlement-date vs last-trade-date differences).
+  // We pass the conId to placeOptionsOrder so IB routes by contract ID, bypassing any
+  // remaining symbol/expiry/tradingClass mismatch (e.g. ADI, DOCU, RBRK, VIK).
   const conn = getPaperConnection();
+  let resolvedConId: number | undefined;
+  let resolvedExpiry: string = ticket.expiry;
+
   if (conn) {
-    const conId = await conn.resolveOptionConId(ticket.ticker, 'P', ticket.strike, ticket.expiry);
-    if (!conId) {
+    const resolved = await conn.resolveOptionConId(ticket.ticker, 'P', ticket.strike, ticket.expiry);
+    if (!resolved) {
       console.warn(`[Options Auto-Trade] IB cannot resolve ${ticket.ticker} $${ticket.strike}P exp ${ticket.expiry} after expiry-offset retries — falling back to paper trade`);
       const tradeId = await paperTradeOption(ticket);
       createAutoTradeEvent({
@@ -1229,6 +1234,11 @@ export async function autoTradeOption(ticket: OptionsTradeTicket): Promise<{ tra
       }).catch(() => {});
       return { tradeId, ibOrderId: null, isLive: false };
     }
+    resolvedConId = resolved.conId;
+    resolvedExpiry = resolved.resolvedExpiry;
+    if (resolvedExpiry !== ticket.expiry) {
+      console.log(`[Options Auto-Trade] Expiry offset: ${ticket.ticker} $${ticket.strike}P stored=${ticket.expiry} → IB resolved=${resolvedExpiry} (settlement-date difference)`);
+    }
   }
 
   try {
@@ -1236,9 +1246,10 @@ export async function autoTradeOption(ticket: OptionsTradeTicket): Promise<{ tra
       symbol: ticket.ticker,
       right: 'P',
       strike: ticket.strike,
-      expiry: ticket.expiry,
+      expiry: resolvedExpiry,
       contracts: ticket.contracts ?? 1,
       limitPrice: ticket.premium,
+      conId: resolvedConId,
       account: getDefaultAccount() ?? undefined,
     });
 

--- a/auto-trader/src/routes/options.ts
+++ b/auto-trader/src/routes/options.ts
@@ -98,14 +98,21 @@ router.post('/options/place-order', async (req, res) => {
     let resolvedStrike: number = trade.option_strike;
 
     // ── Step 1: Try to resolve the exact stored contract (strike + expiry) ──
-    // resolveOptionConId now retries ±1/2 day expiry offsets internally.
+    // resolveOptionConId retries ±1/2 day expiry offsets internally and returns
+    // BOTH the conId and the expiry date that actually matched. We must use the
+    // resolvedExpiry (not the stored date) in the order, otherwise IB rejects with
+    // code=200 "No security definition" when the stored date is off by one day.
+    // We also pass conId so IB routes by contract ID, bypassing tradingClass
+    // mismatches (e.g. ADI, DOCU, RBRK, VIK).
     const conn = getPaperConnection();
-    const exactConId = await conn.resolveOptionConId(trade.ticker, right, trade.option_strike, expiry);
+    const exactResult = await conn.resolveOptionConId(trade.ticker, right, trade.option_strike, expiry);
 
-    if (exactConId) {
-      // Re-derive which expiry offset worked (the resolved expiry is embedded in
-      // resolveOptionConId's retry logic — we just need the order to go through).
-      console.log(`[place-order] Exact contract resolved for ${trade.ticker} $${trade.option_strike}${right} — placing order`);
+    if (exactResult) {
+      expiry = exactResult.resolvedExpiry;
+      if (expiry !== trade.option_expiry.replace(/-/g, '')) {
+        console.log(`[place-order] Expiry offset applied: ${trade.ticker} $${trade.option_strike}${right} stored=${trade.option_expiry} → IB resolved=${expiry}`);
+      }
+      console.log(`[place-order] Contract resolved for ${trade.ticker} $${trade.option_strike}${right} conId=${exactResult.conId} exp=${expiry} — placing order`);
     } else {
       // ── Step 2: Exact strike not in IB (came from synthetic pricing) ──
       // Fetch IB's real options chain and find the nearest listed contract.
@@ -148,6 +155,7 @@ router.post('/options/place-order', async (req, res) => {
       expiry,
       contracts: 1,
       limitPrice,
+      conId: exactResult?.conId,
       account: getDefaultAccount() ?? undefined,
     });
 
@@ -182,6 +190,65 @@ router.post('/options/place-order', async (req, res) => {
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : 'Unknown error';
     console.error('[Route: options/place-order]', errMsg);
+    res.status(500).json({ error: errMsg });
+  }
+});
+
+/**
+ * POST /api/options/discard
+ * Discard a paper-only options trade that was never submitted to IB.
+ * Only allowed if the trade has no ib_order_id (i.e., hasn't been submitted).
+ * Body: { tradeId }
+ */
+router.post('/options/discard', async (req, res) => {
+  try {
+    const { tradeId } = req.body;
+    if (!tradeId) {
+      return res.status(400).json({ error: 'tradeId is required' });
+    }
+
+    const sb = getSupabase();
+    const { data: trade, error } = await sb
+      .from('paper_trades')
+      .select('id, ticker, mode, option_strike, option_expiry, ib_order_id, status')
+      .eq('id', tradeId)
+      .single();
+
+    if (error || !trade) {
+      return res.status(404).json({ error: 'Trade not found' });
+    }
+    if (trade.ib_order_id) {
+      return res.status(400).json({ error: 'Cannot discard a trade that has already been submitted to IB' });
+    }
+
+    const { error: updateError } = await sb
+      .from('paper_trades')
+      .update({
+        status: 'CANCELLED',
+        close_reason: 'discarded',
+        closed_at: new Date().toISOString(),
+        notes: `[DISCARDED] Paper-only trade removed manually — never submitted to IB`,
+      })
+      .eq('id', tradeId);
+
+    if (updateError) {
+      return res.status(500).json({ error: updateError.message });
+    }
+
+    createAutoTradeEvent({
+      ticker: trade.ticker,
+      event_type: 'info',
+      action: 'skipped',
+      source: 'scanner',
+      mode: trade.mode,
+      message: `🗑 ${trade.ticker} $${trade.option_strike}P exp ${trade.option_expiry} discarded — paper-only trade removed without submitting to IB`,
+      metadata: { tradeId, reason: 'manual_discard' },
+    }).catch(() => {});
+
+    res.json({ success: true, tradeId });
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : 'Unknown error';
+    console.error('[Route: options/discard]', errMsg);
     res.status(500).json({ error: errMsg });
   }
 });

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -378,8 +378,47 @@ export function startScheduler(): void {
     } catch (err) {
       console.error('[EOD Position Check] Failed:', err instanceof Error ? err.message : err);
     }
+
+    // Auto-discard paper-only options trades that were never submitted to IB.
+    // These are trades the scanner recorded when IB was offline or the contract
+    // couldn't be resolved. If they weren't manually submitted by end of day,
+    // the strike/premium data is stale — tomorrow's scan will find fresh opportunities.
+    try {
+      const sb = getSupabase();
+      const { data: stale } = await sb
+        .from('paper_trades')
+        .select('id, ticker, option_strike, option_expiry, mode')
+        .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
+        .in('status', ['FILLED', 'SUBMITTED'])
+        .is('ib_order_id', null);
+
+      if (stale?.length) {
+        const now = new Date().toISOString();
+        for (const row of stale as Array<{ id: string; ticker: string; option_strike: number; option_expiry: string; mode: string }>) {
+          await sb.from('paper_trades').update({
+            status: 'CANCELLED',
+            close_reason: 'discarded',
+            closed_at: now,
+            notes: `[AUTO-DISCARD] Paper-only trade never submitted to IB — discarded at EOD`,
+          }).eq('id', row.id);
+
+          createAutoTradeEvent({
+            ticker: row.ticker,
+            event_type: 'info',
+            action: 'skipped',
+            source: 'scanner',
+            mode: row.mode as 'OPTIONS_PUT' | 'OPTIONS_CALL',
+            message: `🗑 ${row.ticker} $${row.option_strike}P exp ${row.option_expiry} auto-discarded at EOD — paper-only, never submitted to IB`,
+            metadata: { tradeId: row.id, reason: 'eod_auto_discard' },
+          }).catch(() => {});
+        }
+        log(`[EOD] Auto-discarded ${stale.length} paper-only options trade(s) never submitted to IB`);
+      }
+    } catch (err) {
+      console.error('[EOD Auto-Discard] Failed:', err instanceof Error ? err.message : err);
+    }
   }, { timezone: 'America/New_York' });
-  log('EOD position check: 4:10 PM ET (IB-level short + long detection)');
+  log('EOD position check: 4:10 PM ET (IB-level short + long detection + paper-only options discard)');
 
   // EOD reconciliation — 4:15 PM ET: compare today's IB executions against paper_trades,
   // correct any fill_price / P&L discrepancies, and recalculate global performance.
@@ -3930,6 +3969,25 @@ async function executeExternalStrategySignal(
       accountType: extAccountType,
     })) {
       return skipExternalSignal('Duplicate active trade for ticker', 'duplicate_active_trade');
+    }
+
+    // Bracket-oversell guard: never execute a SELL external signal when there is an
+    // active LONG (BUY) position for the same ticker, and vice versa.
+    // The existing IB bracket (STP + LMT) fires at the same price level — placing a
+    // second SELL order would oversell and create an accidental short.
+    // This mirrors the CSCO/AMAT scenario from May 15 2026.
+    const oppositeSignal = signal.signal === 'SELL' ? 'BUY' : 'SELL';
+    const hasOpposingPosition = await hasActiveTrade(ticker, {
+      ...(signal.mode !== 'LONG_TERM' ? { excludeMode: 'LONG_TERM' as const } : {}),
+      signal: oppositeSignal,
+      excludeOptions: true,
+      accountType: extAccountType,
+    });
+    if (hasOpposingPosition) {
+      return skipExternalSignal(
+        `Active ${oppositeSignal === 'BUY' ? 'LONG' : 'SHORT'} position already open for ${ticker} — ${signal.signal} signal blocked to prevent bracket oversell`,
+        'opposing_position_blocks_signal',
+      );
     }
   }
 

--- a/supabase/functions/extract-strategy-metadata-from-transcript/index.ts
+++ b/supabase/functions/extract-strategy-metadata-from-transcript/index.ts
@@ -37,7 +37,7 @@ Return a single JSON object (no markdown, no code block) with these fields. Use 
   "applicable_timeframes": ["DAY_TRADE"] | ["SWING_TRADE"] | ["DAY_TRADE","SWING_TRADE"] | [],
   "execution_window_et": {"start":"09:35","end":"10:30"} | null,
   "setup_type": "breakout" | "momentum" | "pullback_vwap" | "range" | "pocket_pivot" | "bullish_engulfing" | "volume_breakout" | null,
-  "extracted_signals": [{"ticker":"TSLA","longTriggerAbove":414,"longTargets":[416.9,420],"shortTriggerBelow":409,"shortTargets":[405.3,402.65]}] | [],
+  "extracted_signals": [{"ticker":"TSLA","longTriggerAbove":414,"longTargets":[416.9,420],"shortTriggerBelow":409,"shortTargets":[405.3,402.65]}] | [{"ticker":"SWKS","entry_context":"above_todays_high","longTriggerAbove":null,"longTargets":[80],"shortTriggerBelow":null,"shortTargets":[]}] | [],
   "summary": "1-2 sentence summary of the strategy"
 }
 
@@ -52,6 +52,7 @@ Rules:
 - longTriggerAbove / shortTriggerBelow / longTargets / shortTargets: MUST be actual dollar prices, NOT percentages. META trades near $600, TSLA near $300-$500, NVDA near $100-$200, SPY near $500-$700, QQQ near $400-$600. If the numbers you extracted are in single digits or look like percentages (e.g. 5.96, 6.1), you made an error — re-read the transcript and extract the real dollar price. A number like "6.1" for META means nothing; the real level would be something like $610 or $608.
 - ATH / all-time-high language: if the transcript says "above ATH" or "new all-time high" for the long trigger without giving a specific number, set longTriggerAbove = shortTriggerBelow (use the short trigger level as a proxy). If shortTriggerBelow is also missing, use shortTargets[0]. Never leave BOTH longTriggerAbove and shortTriggerBelow null when the transcript gives any price levels for that ticker.
 - "below X" always maps to shortTriggerBelow=X. "above X" always maps to longTriggerAbove=X. Extract these directly from the transcript — do not leave them null if a number is present.
+- Conditional entry (no explicit price): if the transcript says "if and only if we can get above today's high", "above today's high", "if it breaks above yesterday's high", or similar phrases WITHOUT giving a specific dollar price for the entry, set longTriggerAbove=null and add entry_context="above_todays_high". The system will resolve the actual price at import time. Similarly, "below today's low" / "below yesterday's low" without a price → shortTriggerBelow=null, entry_context="below_todays_low". If a specific price IS given alongside the condition (e.g. "above today's high at $95"), use longTriggerAbove=95 and entry_context="above_level". Never silently drop a ticker because the entry is conditional — always emit the signal with entry_context set.
 - trade_date: for daily_signal or daily_penny when date is explicit (e.g. "for Thursday", "today's levels", "Monday morning watchlist").
 - execution_window_et: only if time window is specified (e.g. "9:30-9:35 levels", "first candle rule").
 - setup_type: how the influencer intends execution:

--- a/supabase/functions/import-strategy-signals/index.ts
+++ b/supabase/functions/import-strategy-signals/index.ts
@@ -9,6 +9,7 @@
  * 2. For each extracted signal: create PENDING external_strategy_signals rows
  *    - longTriggerAbove  → BUY signal
  *    - shortTriggerBelow → SELL signal
+ *    - entry_context (above_todays_high / below_todays_low) → resolves via Finnhub → BUY/SELL signal
  * 3. If execution_window_et present: set execute_at / expires_at (ET timezone)
  * 4. Skip if signal already exists for same video_id + ticker + signal direction (idempotent)
  */
@@ -380,15 +381,47 @@ Deno.serve(async (req) => {
       continue;
     }
 
+    // Resolve entry_context for stock signals when the LLM did not give an explicit price.
+    // e.g. "above today's high" / "below today's low" — fetch Finnhub to get a concrete level.
+    let resolvedLongTrigger = sig.longTriggerAbove ?? null;
+    let resolvedShortTrigger = sig.shortTriggerBelow ?? null;
+    const stockEntryCtx = sig.entry_context ?? null;
+
+    if (stockEntryCtx && (resolvedLongTrigger == null || resolvedShortTrigger == null)) {
+      const quote = await getFinnhubQuote(ticker);
+      if (quote) {
+        const nowHourET = new Date().toLocaleString('en-US', { timeZone: 'America/New_York', hour: 'numeric', hour12: false });
+        const hourET = parseInt(nowHourET);
+        const intraday = hourET >= 10 && hourET < 16;
+
+        if (resolvedLongTrigger == null && (stockEntryCtx === 'above_todays_high' || stockEntryCtx === 'above_level')) {
+          const raw = (intraday && quote.h > 0) ? quote.h : quote.pc;
+          resolvedLongTrigger = Math.round(raw * 1.002 * 100) / 100; // +0.2% buffer above high
+          console.log(`[import-strategy-signals] ${ticker}: resolved ${stockEntryCtx} → long trigger $${resolvedLongTrigger} (Finnhub ${intraday ? 'intraday high' : 'prevClose'})`);
+        }
+        if (resolvedShortTrigger == null && (stockEntryCtx === 'below_todays_low' || stockEntryCtx === 'below_level')) {
+          const raw = (intraday && quote.l > 0) ? quote.l : quote.pc;
+          resolvedShortTrigger = Math.round(raw * 0.998 * 100) / 100; // -0.2% buffer below low
+          console.log(`[import-strategy-signals] ${ticker}: resolved ${stockEntryCtx} → short trigger $${resolvedShortTrigger} (Finnhub ${intraday ? 'intraday low' : 'prevClose'})`);
+        }
+      } else {
+        console.warn(`[import-strategy-signals] ${ticker}: entry_context="${stockEntryCtx}" but no Finnhub quote — skipping`);
+        continue;
+      }
+    }
+
     // Long (BUY) signal — one row per entry level (unique constraint is on ticker+signal+entry_price+date).
     // Use the first target as primary; additional targets go into notes for human reference.
-    if (sig.longTriggerAbove != null) {
-      const entryPrice = sig.longTriggerAbove;
+    if (resolvedLongTrigger != null) {
+      const entryPrice = resolvedLongTrigger;
       const longTargets = sig.longTargets ?? [];
       const primaryTarget = longTargets[0] ?? null;
       const targetSummary = longTargets.length > 0
         ? longTargets.map((t, i) => `T${i + 1}: ${t}`).join(', ')
         : null;
+      const entryDesc = stockEntryCtx === 'above_todays_high'
+        ? `Long above today's high (~${entryPrice})`
+        : `Long above ${entryPrice}`;
       toInsert.push({
         source_name: video.source_name,
         source_url: sourceUrl,
@@ -397,12 +430,12 @@ Deno.serve(async (req) => {
         mode: primaryMode,
         confidence: 7,
         entry_price: entryPrice,
-        stop_loss: stopLoss ?? (sig.shortTriggerBelow ?? null),
+        stop_loss: stopLoss ?? (resolvedShortTrigger ?? null),
         target_price: primaryTarget,
         execute_on_date: tradeDate,
         execute_at: executeAt,
         expires_at: expiresAt,
-        notes: noteText ?? `Long above ${entryPrice}${targetSummary ? ` — targets: ${targetSummary}` : ''}`,
+        notes: noteText ?? `${entryDesc}${targetSummary ? ` — targets: ${targetSummary}` : ''}`,
         status: 'PENDING',
         strategy_video_id: videoId,
         strategy_video_heading: video.video_heading ?? null,
@@ -410,13 +443,16 @@ Deno.serve(async (req) => {
     }
 
     // Short (SELL) signal — one row per entry level.
-    if (sig.shortTriggerBelow != null) {
-      const entryPrice = sig.shortTriggerBelow;
+    if (resolvedShortTrigger != null) {
+      const entryPrice = resolvedShortTrigger;
       const shortTargets = sig.shortTargets ?? [];
       const primaryTarget = shortTargets[0] ?? null;
       const targetSummary = shortTargets.length > 0
         ? shortTargets.map((t, i) => `T${i + 1}: ${t}`).join(', ')
         : null;
+      const entryDesc = stockEntryCtx === 'below_todays_low'
+        ? `Short below today's low (~${entryPrice})`
+        : `Short below ${entryPrice}`;
       toInsert.push({
         source_name: video.source_name,
         source_url: sourceUrl,
@@ -425,12 +461,12 @@ Deno.serve(async (req) => {
         mode: primaryMode,
         confidence: 7,
         entry_price: entryPrice,
-        stop_loss: stopLoss ?? (sig.longTriggerAbove ?? null),
+        stop_loss: stopLoss ?? (resolvedLongTrigger ?? null),
         target_price: primaryTarget,
         execute_on_date: tradeDate,
         execute_at: executeAt,
         expires_at: expiresAt,
-        notes: noteText ?? `Short below ${entryPrice}${targetSummary ? ` — targets: ${targetSummary}` : ''}`,
+        notes: noteText ?? `${entryDesc}${targetSummary ? ` — targets: ${targetSummary}` : ''}`,
         status: 'PENDING',
         strategy_video_id: videoId,
         strategy_video_heading: video.video_heading ?? null,


### PR DESCRIPTION
## Summary

- **Bracket-oversell guard**: Before executing any external SELL signal, check for an active LONG position (and vice versa). Prevents the IWM/SMH scenario where an influencer SELL signal triggers at the same price as an existing bracket STP, causing an oversell → accidental short. Mirrors `excludeMode: LONG_TERM` from the adjacent conflict check.
- **Conditional entry signals**: LLM extraction now recognises "above today's high" / "below today's low" language without an explicit price, emitting `entry_context=above_todays_high`. Import resolves to Finnhub high/low (+0.2% buffer) at import time so SWKS/ARM/GEHC-style videos produce real PENDING signals instead of being silently dropped.
- **Options conId routing**: `resolveOptionConId` now returns `{ conId, resolvedExpiry }`. Callers use the resolved (offset-adjusted) expiry and pass conId directly to IB, avoiding code=200 "No security definition" rejections for ADI/DOCU/RBRK/VIK-style tickers.
- **Grouped bracket UI**: Open Orders groups STP+LMT child pairs into one row with `SL $X ←——→ TP $Y` range indicator. Six rows → three rows for a three-position bracket portfolio.

## Test plan
- [ ] Confirm IWM/SMH SELL signals in queue are SKIPPED with "Active LONG position" reason at next scheduler cycle
- [ ] Re-submit a "above today's high" transcript and verify signals import with resolved Finnhub prices
- [ ] Open Portfolio tab and confirm bracket positions show as single grouped rows
- [ ] Verify options order placement still works for a standard ticker

Made with [Cursor](https://cursor.com)