### PR TITLE
fix: sync IB cancellations to DB and show pending vs filled badges

### DIFF
--- a/app/src/components/PaperTrading/tabs/OptionsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/OptionsTab.tsx
@@ -133,7 +133,11 @@ function PositionCard({
           <span className="text-[10px] px-1.5 py-0.5 rounded bg-violet-100 text-violet-700 font-medium">
             {pos.mode === 'OPTIONS_CALL' ? 'CALL' : 'PUT'}
           </span>
-          {pos.ib_order_id ? (
+          {pos.ib_order_id && pos.status === 'SUBMITTED' ? (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 font-medium">
+              ⏳ Pending #{pos.ib_order_id}
+            </span>
+          ) : pos.ib_order_id ? (
             <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700 font-medium">
               ✓ IB #{pos.ib_order_id}
             </span>

--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -406,12 +406,28 @@ export class IBConnection {
         }, this.label).catch(fillErr => console.warn(`${this.tag} Failed to persist orderStatus fill: ${fillErr instanceof Error ? fillErr.message : fillErr}`));
       }
 
-      if ((status === 'Cancelled' || status === 'Inactive') && this._pendingOrderCallbacks.has(orderId)) {
-        const pending = this._pendingOrderCallbacks.get(orderId)!;
-        clearTimeout(pending.timer);
-        this._pendingOrderCallbacks.delete(orderId);
-        console.error(`${this.tag} Order ${orderId} (${pending.symbol}) ${status}`);
-        pending.reject(new Error(`IB order ${orderId} (${pending.symbol}) ${status}`));
+      if (status === 'Cancelled' || status === 'Inactive') {
+        if (this._pendingOrderCallbacks.has(orderId)) {
+          const pending = this._pendingOrderCallbacks.get(orderId)!;
+          clearTimeout(pending.timer);
+          this._pendingOrderCallbacks.delete(orderId);
+          console.error(`${this.tag} Order ${orderId} (${pending.symbol}) ${status}`);
+          pending.reject(new Error(`IB order ${orderId} (${pending.symbol}) ${status}`));
+        } else {
+          // Order was already timed out (saved as SUBMITTED in DB) — sync cancellation back.
+          console.log(`${this.tag} Order ${orderId} ${status} by IB/user — syncing to DB`);
+          import('./lib/supabase.js').then(({ getSupabase }) => {
+            getSupabase()
+              .from('paper_trades')
+              .update({ status: 'CANCELLED', close_reason: `IB order ${status.toLowerCase()}` })
+              .eq('ib_order_id', String(orderId))
+              .eq('status', 'SUBMITTED')
+              .then(({ error }) => {
+                if (error) console.warn(`${this.tag} Failed to sync cancellation for order ${orderId}: ${error.message}`);
+                else console.log(`${this.tag} Order ${orderId} marked CANCELLED in DB`);
+              });
+          }).catch(() => {});
+        }
       }
     });
 


### PR DESCRIPTION
## Summary

- **IB cancellation sync**: the global `orderStatus` handler now catches `Cancelled`/`Inactive` for orders that already timed out and were saved as `SUBMITTED` in the DB. Previously, user-initiated IB cancellations after the 120s timeout window were silently dropped; now they update `paper_trades.status → CANCELLED`.
- **UI badge distinction**: `OptionsTab` now shows an amber `⏳ Pending #ID` badge for `SUBMITTED` orders (limit order placed but not yet filled) vs. the existing green `✓ IB #ID` badge for filled positions.
- **Manual fix**: directly updated RBRK #20643 (`d6733c63`) from `SUBMITTED → CANCELLED` since the auto-trader wasn't running when the user cancelled it from the IB app.

## Test plan
- [ ] Place a GTC limit option order; confirm it shows "⏳ Pending #ID" in amber
- [ ] Let/wait for it to fill; confirm badge switches to green "✓ IB #ID"  
- [ ] Cancel a pending order from IB app; confirm within seconds it disappears from the Open tab (status → CANCELLED, filtered out)

Made with [Cursor](https://cursor.com)