### PR TITLE
fix: startup reconciliation for cancelled options/spread orders

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -272,6 +272,58 @@ export class IBConnection {
     } catch (pnlErr) {
       console.warn(`${this.tag} reqPnL failed:`, pnlErr instanceof Error ? pnlErr.message : pnlErr);
     }
+
+    // Reconcile any SUBMITTED paper_trades that were cancelled while we were offline.
+    // Give IB 2s to finish sending startup orderStatus events before we check.
+    setTimeout(() => this._reconcileSubmittedOrders(), 2000);
+  }
+
+  private _reconcileSubmittedOrders(): void {
+    if (!this.ib) return;
+    const emitter = this.ib as unknown as { on: Function; off: Function };
+
+    const openIbOrderIds = new Set<number>();
+    const orderHandler = (orderId: number) => { openIbOrderIds.add(orderId); };
+    const endHandler = () => {
+      emitter.off(EventName.openOrder, orderHandler);
+      emitter.off(EventName.openOrderEnd, endHandler);
+
+      import('./lib/supabase.js').then(({ getSupabase }) => {
+        getSupabase()
+          .from('paper_trades')
+          .select('id, ticker, ib_order_id')
+          .eq('status', 'SUBMITTED')
+          .not('ib_order_id', 'is', null)
+          .then(({ data, error }) => {
+            if (error || !data?.length) return;
+            const toCancel = data.filter(t => !openIbOrderIds.has(Number(t.ib_order_id)));
+            if (!toCancel.length) {
+              console.log(`${this.tag} Reconcile: all SUBMITTED orders still open in IB`);
+              return;
+            }
+            const ids = toCancel.map(t => t.ib_order_id!);
+            console.log(`${this.tag} Reconcile: cancelling ${toCancel.length} order(s) missing from IB: ${toCancel.map(t => `${t.ticker}#${t.ib_order_id}`).join(', ')}`);
+            getSupabase()
+              .from('paper_trades')
+              .update({ status: 'CANCELLED', close_reason: 'IB order cancelled (reconciled at startup)' })
+              .in('ib_order_id', ids)
+              .eq('status', 'SUBMITTED')
+              .then(({ error: updErr }) => {
+                if (updErr) console.warn(`${this.tag} Reconcile update failed: ${updErr.message}`);
+              });
+          });
+      }).catch(() => {});
+    };
+
+    emitter.on(EventName.openOrder, orderHandler);
+    emitter.on(EventName.openOrderEnd, endHandler);
+    try {
+      this.ib.reqAllOpenOrders();
+      console.log(`${this.tag} Reconcile: checking SUBMITTED orders vs IB open orders...`);
+    } catch {
+      emitter.off(EventName.openOrder, orderHandler);
+      emitter.off(EventName.openOrderEnd, endHandler);
+    }
   }
 
   // ── Connect ──────────────────────────────────────────
@@ -413,13 +465,14 @@ export class IBConnection {
           this._pendingOrderCallbacks.delete(orderId);
           console.error(`${this.tag} Order ${orderId} (${pending.symbol}) ${status}`);
           pending.reject(new Error(`IB order ${orderId} (${pending.symbol}) ${status}`));
-        } else {
-          // Order was already timed out (saved as SUBMITTED in DB) — sync cancellation back.
-          console.log(`${this.tag} Order ${orderId} ${status} by IB/user — syncing to DB`);
+        } else if (status === 'Cancelled') {
+          // Only hard-cancel in DB for true Cancelled status — never for Inactive,
+          // which is a normal transient state for GTC orders outside market hours.
+          console.log(`${this.tag} Order ${orderId} Cancelled by IB/user — syncing to DB`);
           import('./lib/supabase.js').then(({ getSupabase }) => {
             getSupabase()
               .from('paper_trades')
-              .update({ status: 'CANCELLED', close_reason: `IB order ${status.toLowerCase()}` })
+              .update({ status: 'CANCELLED', close_reason: 'IB order cancelled' })
               .eq('ib_order_id', String(orderId))
               .eq('status', 'SUBMITTED')
               .then(({ error }) => {


### PR DESCRIPTION
## Summary

- **Startup reconciliation**: on connect, `_reconcileSubmittedOrders()` calls `reqAllOpenOrders`, collects all open IB order IDs, then marks any `SUBMITTED` paper_trade whose `ib_order_id` is absent from IB's list as `CANCELLED`. Runs 2s after connection is ready to let IB finish sending startup events.
- **Inactive ≠ Cancelled**: the previous fix incorrectly treated `Inactive` as a permanent cancellation. IB sends `Inactive` for GTC orders that are valid but outside market hours — these should remain `SUBMITTED`. Only an actual `Cancelled` event triggers a DB update.
- **Data fix**: manually cancelled SOXL #21325, CRDO #21328, AMD #21331 and RBRK #20643 that were stuck as SUBMITTED after being cancelled from the IB app.

## Test plan
- [ ] Cancel a GTC option order from IB app; restart auto-trader; confirm it logs "Reconcile: cancelling N order(s) missing from IB" and the order disappears from the Open tab
- [ ] Place a GTC order outside market hours; verify `Inactive` status from IB does NOT cancel it in the DB

Made with [Cursor](https://cursor.com)