### PR TITLE
fix: use GTC for credit spread and calendar spread orders

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -1113,7 +1113,7 @@ export class IBConnection {
       orderType: OrderType.LMT,
       totalQuantity: contracts,
       lmtPrice: limitPrice,
-      tif: TimeInForce.DAY,
+      tif: TimeInForce.GTC,
       transmit: true,
       ...(account ? { account } : {}),
     };
@@ -1173,7 +1173,7 @@ export class IBConnection {
       orderType: OrderType.LMT,
       totalQuantity: contracts,
       lmtPrice: limitPrice,
-      tif: TimeInForce.DAY,
+      tif: TimeInForce.GTC,
       transmit: true,
       ...(account ? { account } : {}),
     };


### PR DESCRIPTION
## Summary

Credit spread and calendar spread orders were using `TimeInForce.DAY`, which caused IB to silently cancel them when they didn't fill immediately. Changed both to `TimeInForce.GTC` so they persist until filled or manually cancelled — consistent with how single-leg options are handled.

Affected orders: SOXL #21325, CRDO #21328, AMD #21331 were all cancelled by IB today for this reason.

Note: stock market orders (`placeMarketOrder`) correctly remain `DAY` since market orders should always fill within seconds or fail cleanly.

Made with [Cursor](https://cursor.com)