### PR TITLE
fix: never use synthetic Black-Scholes chain when IB is connected

### DIFF
--- a/auto-trader/src/lib/options-chain.ts
+++ b/auto-trader/src/lib/options-chain.ts
@@ -276,7 +276,7 @@ async function getOptionChainParams(conId: number, symbol: string): Promise<Opti
         resolve(result);
       };
 
-      const timeout = setTimeout(() => finish(allParams[0] ?? null), 15_000);
+      const timeout = setTimeout(() => finish(allParams[0] ?? null), 30_000);
 
       registerReqErrorCallback(reqId, () => finish(null));
 
@@ -536,6 +536,11 @@ export async function getOptionsChain(
   constraints?: ExpiryConstraints,
 ): Promise<OptionsChainSummary | null> {
   const syntheticFallback = async () => {
+    // When IB is connected, never fall back to synthetic Black-Scholes chains.
+    // BS generates mathematically valid but IB-unlisted strikes — orders using
+    // them always fail resolveOptionConId. Return null so the scanner skips the
+    // ticker cleanly instead of creating a fake trade.
+    if (isConnected()) return null;
     const s = await getSyntheticOptionsChain(symbol, underlyingPrice, deltaTarget, dteDays, constraints);
     if (s) s.ivRank = storedIvRank;
     return s;


### PR DESCRIPTION
## Problem

The options scanner was routinely creating paper trades with untradeable strike prices. Root cause: `getOptionsChain()` has 5 fallback paths to a Black-Scholes synthetic chain — triggered by `reqSecDefOptParams` timeouts or rate limits during the 34-ticker scan loop. BS picks mathematically clean strikes that IB doesn't list, so every order attempt fails `resolveOptionConId`.

Today's evidence: AMAT \$390P and VIK \$75P were both synthetic strikes that don't exist as real IB contracts.

## Fix

One guard in `syntheticFallback()`: if `isConnected()` is true, return `null` instead of generating BS strikes. All 5 fallback paths in `getOptionsChain()` now correctly skip the ticker when IB is online but data is temporarily unavailable.

Synthetic chain is preserved for the offline case only (IB gateway down, paper trading, display).

Also: `reqSecDefOptParams` timeout bumped from 15s → 30s to reduce false timeouts during high-load scans.

## Impact
- No more fake paper trades from synthetic strikes when IB is online
- Scanner will skip a ticker if IB can't provide live chain data (correct behaviour)
- Roll logic, spread management, P&L display still work — they use `getOptionGreeksForContract` for specific contracts, not the chain

Made with [Cursor](https://cursor.com)