### PR TITLE
Add RKLB and FIG to options watchlist

### DIFF
--- a/supabase/migrations/20260521000001_options_watchlist_rklb_fig.sql
+++ b/supabase/migrations/20260521000001_options_watchlist_rklb_fig.sql
@@ -1,0 +1,6 @@
+-- Options Watchlist — add RKLB, FIG
+-- NVDA, MSFT, META, RDDT were already present from prior migrations.
+INSERT INTO options_watchlist (ticker, added_by, notes, tier, sector) VALUES
+  ('RKLB', 'user', 'Rocket Lab — space launch & satellites, high-beta momentum, elevated IV',  'HIGH_VOL', 'Aerospace & Defense'),
+  ('FIG',  'user', 'Figs — added to options watchlist by user',                                'HIGH_VOL', 'Consumer Discretionary')
+ON CONFLICT (ticker) DO NOTHING;


### PR DESCRIPTION
## Summary
- Adds RKLB (Rocket Lab) and FIG to options_watchlist
- NVDA, MSFT, META, RDDT were already present — no changes needed for those
- Both new tickers assigned HIGH_VOL tier; RKLB in Aerospace & Defense, FIG in Consumer Discretionary

Made with [Cursor](https://cursor.com)