### PR TITLE
feat: enable swing shorts, separate position pools, scale sizes

### DIFF
--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -144,6 +144,7 @@ export async function loadAutoTraderConfig(): Promise<AutoTraderConfig> {
       const config: AutoTraderConfig = {
         enabled: data.enabled ?? DEFAULT_CONFIG.enabled,
         maxPositions: data.max_positions ?? DEFAULT_CONFIG.maxPositions,
+        maxSwingPositions: data.max_swing_positions ?? DEFAULT_CONFIG.maxSwingPositions,
         positionSize: Number(data.position_size) || DEFAULT_CONFIG.positionSize,
         minScannerConfidence: data.min_scanner_confidence ?? DEFAULT_CONFIG.minScannerConfidence,
         minFAConfidence: data.min_fa_confidence ?? DEFAULT_CONFIG.minFAConfidence,

--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -274,8 +274,9 @@ export class IBConnection {
     }
 
     // Reconcile any SUBMITTED paper_trades that were cancelled while we were offline.
-    // Give IB 2s to finish sending startup orderStatus events before we check.
-    setTimeout(() => this._reconcileSubmittedOrders(), 2000);
+    // Give IB 15s to finish delivering all open orders after a fresh connection —
+    // the 2s window was too short and caused false cancellations of legitimately open orders.
+    setTimeout(() => this._reconcileSubmittedOrders(), 15000);
   }
 
   private _reconcileSubmittedOrders(): void {
@@ -289,11 +290,15 @@ export class IBConnection {
       emitter.off(EventName.openOrderEnd, endHandler);
 
       import('./lib/supabase.js').then(({ getSupabase }) => {
+        // Only reconcile orders submitted more than 10 minutes ago — very recent orders
+        // may not yet be visible in reqAllOpenOrders on a fresh connection.
+        const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
         getSupabase()
           .from('paper_trades')
           .select('id, ticker, ib_order_id')
           .eq('status', 'SUBMITTED')
           .not('ib_order_id', 'is', null)
+          .lt('opened_at', tenMinutesAgo)
           .then(({ data, error }) => {
             if (error || !data?.length) return;
             const toCancel = data.filter(t => !openIbOrderIds.has(Number(t.ib_order_id)));

--- a/auto-trader/src/lib/options-scanner.ts
+++ b/auto-trader/src/lib/options-scanner.ts
@@ -94,14 +94,16 @@ const BEAR_DEFENSIVE_SECTORS = [           // only these sectors in bear mode
 
 // Hard stops — one headline is enough (existential / regulatory)
 const RED_FLAG_HARD = [
-  'fraud', 'sec investigation', 'doj', 'department of justice',
+  'sec investigation', 'doj', 'department of justice',
   'chapter 11', 'chapter 7', 'going concern', 'delisting',
   'fda rejection', 'restatement', 'accounting irregularit',
   'whistleblower', 'ponzi', 'subpoena',
 ];
-// Soft stops — require 2+ headlines to avoid incidental mentions on large caps
+// Soft stops — require 2+ headlines to avoid incidental mentions on large caps.
+// 'fraud' moved here because AMZN/GOOGL regularly appear in headlines about
+// marketplace/ad fraud by third parties — one mention is not company-level risk.
 const RED_FLAG_SOFT = [
-  'bankruptcy', 'class action', 'recall', 'ceo resign', 'cfo resign',
+  'fraud', 'bankruptcy', 'class action', 'recall', 'ceo resign', 'cfo resign',
   'tariff', 'trade war', 'import duty', 'trade dispute',
 ];
 
@@ -1042,24 +1044,11 @@ export async function runOptionsScan(freeCapital = 100_000): Promise<OptionsScan
     .join(', ') || 'none';
   console.log(`\n[Options Scanner] ━━━ Starting scan — ${total} tickers | VIX ${ctx.vix.toFixed(1)} | ${ctx.spyAboveSma200 ? 'Bull' : 'Bear'} mode | δ target ${ctx.deltaTarget} | free capital $${(freeCapital / 1000).toFixed(0)}k | crowded weeks: ${crowdedWeeksSummary} ━━━`);
 
-  // STABLE-tier frequency gate: only scan STABLE tickers on Mon/Wed/Fri.
-  // On Tue/Thu they qualify very rarely (low IV) and waste ~35 Finnhub calls.
-  const todayDow = new Date().getUTCDay(); // 0=Sun,1=Mon,2=Tue,3=Wed,4=Thu,5=Fri,6=Sat
-  const isStableDay = todayDow === 1 || todayDow === 3 || todayDow === 5; // Mon/Wed/Fri
-
   // Scan each ticker (sequential to avoid IB request flooding)
   for (const [i, entry] of (watchlist as WatchlistEntry[]).entries()) {
     const leverageFactor = parseLeverageFactor(entry.notes);
     const tier: WatchlistTier = (entry.tier as WatchlistTier) ?? 'GROWTH';
     const num = `[${String(i + 1).padStart(2, '0')}/${total}]`;
-
-    // Skip STABLE tickers on Tue/Thu — they're low-IV names that rarely qualify
-    // and account for ~30% of API budget on days when they almost never pass IV gates.
-    if (tier === 'STABLE' && !isStableDay) {
-      console.log(`[Options Scanner] ${num} ${entry.ticker.padEnd(5)} ✗  stable_tier_off_day`);
-      skipped.push({ ticker: entry.ticker, reason: 'stable_tier_off_day' });
-      continue;
-    }
 
     try {
       const result = await checkStock(

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -70,6 +70,7 @@ export async function loadConfig(): Promise<AutoTraderConfig> {
   return {
     enabled: data.enabled ?? DEFAULT_CONFIG.enabled,
     maxPositions: data.max_positions ?? DEFAULT_CONFIG.maxPositions,
+    maxSwingPositions: data.max_swing_positions ?? DEFAULT_CONFIG.maxSwingPositions,
     positionSize: Number(data.position_size) || DEFAULT_CONFIG.positionSize,
     minScannerConfidence: data.min_scanner_confidence ?? DEFAULT_CONFIG.minScannerConfidence,
     minFAConfidence: data.min_fa_confidence ?? DEFAULT_CONFIG.minFAConfidence,
@@ -396,13 +397,15 @@ export async function getTickerWinRate(
   return { wins, losses, winRate, total };
 }
 
-export async function countActivePositions(accountType: AccountType = 'paper'): Promise<number> {
+export async function countActivePositions(accountType: AccountType = 'paper', tradeMode?: string): Promise<number> {
   const sb = getSupabase();
-  const { count } = await sb
+  let query = sb
     .from(tradesTable(accountType))
     .select('id', { count: 'exact', head: true })
     .in('status', [...ACTIVE_STATUSES])
     .not('mode', 'in', '(OPTIONS_PUT,OPTIONS_CALL)');
+  if (tradeMode) query = query.eq('mode', tradeMode);
+  const { count } = await query;
   return count ?? 0;
 }
 

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -2554,6 +2554,11 @@ function isPermanentDbError(err: unknown): boolean {
     || msg.includes('duplicate key');
 }
 
+// Dedup cache: prevents the same skip/warning from being persisted more than once
+// per trading day. Key = "YYYY-MM-DD:ticker:eventType:message". Cleared at midnight.
+const _persistedToday = new Set<string>();
+let _persistDedupDate = '';
+
 async function persistEvent(
   ticker: string,
   eventType: string,
@@ -2562,6 +2567,19 @@ async function persistEvent(
   accountType: AccountType = 'paper',
 ): Promise<void> {
   const safeType = (VALID_EVENT_TYPES.has(eventType as AutoTradeEventType) ? eventType : 'info') as AutoTradeEventType;
+
+  // For 'skipped' events, only persist once per ticker+reason per trading day
+  if (eventType === 'skipped') {
+    const etDate = new Date().toLocaleDateString('en-US', { timeZone: 'America/New_York' });
+    if (etDate !== _persistDedupDate) {
+      _persistedToday.clear();
+      _persistDedupDate = etDate;
+    }
+    const dedupKey = `${etDate}:${ticker}:${eventType}:${message}`;
+    if (_persistedToday.has(dedupKey)) return;
+    _persistedToday.add(dedupKey);
+  }
+
   const payload: AutoTradeEventInput = { ticker, event_type: safeType, message, ...extra };
   const delays = [1000, 2000];
   for (let attempt = 0; attempt <= delays.length; attempt++) {
@@ -3119,31 +3137,26 @@ async function executeScannerTrade(
   if (mode === 'DAY_TRADE') {
     if (idea.price < 50) {
       log(`${ticker}: skipped — price $${idea.price.toFixed(2)} below $50 minimum (scanner price floor)`);
-      persistEvent(ticker, 'skipped', `Scanner price floor: price $${idea.price.toFixed(2)} < $50`, {
-        action: 'skipped', source: 'scanner', mode, skip_reason: 'price_floor',
-      });
+      log(`${ticker}: skipped — price floor (not persisted)`);
       return 'skipped:price_floor';
     }
-    if (idea.volumeVs10dAvg != null && idea.volumeVs10dAvg < 0.15) {
+    // Volume gate: only meaningful after 10:00 AM ET — comparing sub-30-min
+    // intraday volume to a full-day 10d average will always look "illiquid"
+    // at the open (AAPL at 9:41 legitimately shows 0.04× daily avg).
+    const nowEtHour = ((new Date().getUTCHours() - 4 + 24) % 24);
+    const nowEtMin  = new Date().getUTCMinutes();
+    const afterTenAM = nowEtHour > 10 || (nowEtHour === 10 && nowEtMin >= 0);
+    if (afterTenAM && idea.volumeVs10dAvg != null && idea.volumeVs10dAvg < 0.15) {
       log(`${ticker}: skipped — volume ${idea.volumeVs10dAvg.toFixed(2)}x avg (< 0.15x, illiquid)`);
-      persistEvent(ticker, 'skipped', `Illiquid: volume ${idea.volumeVs10dAvg.toFixed(2)}x 10d avg`, {
-        action: 'skipped', source: 'scanner', mode, skip_reason: 'illiquid',
-      });
+      // Don't persist — this is a transient gate result that fires every scan cycle
+      // and would flood the activity log. Console log is sufficient.
       return 'skipped:illiquid';
     }
   }
 
-  // For SWING_TRADE SELL signals: block unless we already hold a long to close.
-  // Multi-day shorts from scanner signals are too risky to auto-execute.
-  // For DAY_TRADE SELL signals: allow — intraday shorts are standard day trading
-  // (open short, cover same day). The EOD sweep closes any open day trades.
-  if (signal === 'SELL' && mode === 'SWING_TRADE') {
-    const hasLong = positions.some(p => p.symbol.toUpperCase() === ticker && p.position > 0);
-    if (!hasLong) {
-      log(`${ticker}: scanner SELL skipped — no long position to close (swing short not allowed)`);
-      return 'skipped:no_long_to_sell';
-    }
-  }
+  // SWING_TRADE SELL signals open a short position (bracket order with GTC TIF).
+  // Stop/target levels are correctly oriented for shorts (stop above entry, target below).
+  // The position management pipeline handles swing shorts the same as longs.
 
   // Options positions on the same ticker don't block stock day/swing trades —
   // they are different instruments and managed by a separate pipeline.
@@ -6521,13 +6534,22 @@ async function runTradeExecutionOnly(): Promise<void> {
     const rtDayEvals: Record<string, { status: ScanEvaluationStatus; reason: string }> = {};
     const rtSwingEvals: Record<string, { status: ScanEvaluationStatus; reason: string }> = {};
     if (newIdeas.length > 0) {
-      const activeCount = await countActivePositions();
-      const slots = config.maxPositions - activeCount;
-      if (slots > 0) {
-        const qualified = newIdeas
-          .filter(i => i.confidence >= config.minScannerConfidence)
+      const [activeDayCount, activeSwingCount] = await Promise.all([
+        countActivePositions('paper', 'DAY_TRADE'),
+        countActivePositions('paper', 'SWING_TRADE'),
+      ]);
+      const daySlots = Math.max(0, config.maxPositions - activeDayCount);
+      const swingSlots = Math.max(0, config.maxSwingPositions - activeSwingCount);
+      if (daySlots > 0 || swingSlots > 0) {
+        const qualifiedDay = newIdeas
+          .filter(i => i.mode !== 'SWING_TRADE' && i.confidence >= config.minScannerConfidence)
           .sort((a, b) => b.confidence - a.confidence)
-          .slice(0, slots);
+          .slice(0, daySlots);
+        const qualifiedSwing = newIdeas
+          .filter(i => i.mode === 'SWING_TRADE' && i.confidence >= config.minScannerConfidence)
+          .sort((a, b) => b.confidence - a.confidence)
+          .slice(0, swingSlots);
+        const qualified = [...qualifiedDay, ...qualifiedSwing];
         for (const idea of qualified) {
           const result = await executeScannerTrade(idea, config, positions);
           log(`  ${idea.ticker}: ${result}`);
@@ -6811,14 +6833,23 @@ async function runSchedulerCycle(): Promise<void> {
       };
 
       if (newIdeas.length > 0) {
-        const activeCount = await countActivePositions();
-        const slots = config.maxPositions - activeCount;
+        const [activeDayCount, activeSwingCount] = await Promise.all([
+          countActivePositions('paper', 'DAY_TRADE'),
+          countActivePositions('paper', 'SWING_TRADE'),
+        ]);
+        const daySlots = Math.max(0, config.maxPositions - activeDayCount);
+        const swingSlots = Math.max(0, config.maxSwingPositions - activeSwingCount);
 
-        if (slots > 0) {
-          const qualified = newIdeas
-            .filter(i => i.confidence >= config.minScannerConfidence)
+        if (daySlots > 0 || swingSlots > 0) {
+          const qualifiedDay = newIdeas
+            .filter(i => i.mode !== 'SWING_TRADE' && i.confidence >= config.minScannerConfidence)
             .sort((a, b) => b.confidence - a.confidence)
-            .slice(0, slots);
+            .slice(0, daySlots);
+          const qualifiedSwing = newIdeas
+            .filter(i => i.mode === 'SWING_TRADE' && i.confidence >= config.minScannerConfidence)
+            .sort((a, b) => b.confidence - a.confidence)
+            .slice(0, swingSlots);
+          const qualified = [...qualifiedDay, ...qualifiedSwing];
 
           for (const idea of qualified) {
             const result = await executeScannerTrade(idea, config, positions);
@@ -6830,7 +6861,7 @@ async function runSchedulerCycle(): Promise<void> {
             await new Promise(r => setTimeout(r, 2000));
           }
         } else {
-          log(`Max positions reached (${config.maxPositions}) — skipping scanner ideas`);
+          log(`Max positions reached (day: ${config.maxPositions}, swing: ${config.maxSwingPositions}) — skipping scanner ideas`);
           for (const idea of newIdeas) recordEval(idea, 'skipped:max_positions');
         }
       } else if (scannerIdeasLoaded) {

--- a/shared/config-defaults.ts
+++ b/shared/config-defaults.ts
@@ -9,6 +9,7 @@
 export interface AutoTraderConfig {
   enabled: boolean;
   maxPositions: number;
+  maxSwingPositions: number;
   positionSize: number;
   minScannerConfidence: number;
   minFAConfidence: number;
@@ -75,6 +76,7 @@ export interface AutoTraderConfig {
 export const DEFAULT_CONFIG: AutoTraderConfig = {
   enabled: false,
   maxPositions: 3,
+  maxSwingPositions: 2,
   positionSize: 1000,
   minScannerConfidence: 7,
   minFAConfidence: 7,

--- a/supabase/migrations/20260526000001_extend_setup_type_values.sql
+++ b/supabase/migrations/20260526000001_extend_setup_type_values.sql
@@ -1,0 +1,7 @@
+-- Extend setup_type check constraint to include newer setup types:
+--   pocket_pivot     - daily chart consolidation pocket breakout (options signal style)
+--   bullish_engulfing - bullish engulfing candle reversal pattern on daily chart
+--   volume_breakout  - already broke out on above-average volume, continuation expected
+ALTER TABLE strategy_videos DROP CONSTRAINT IF EXISTS strategy_videos_setup_type_check;
+ALTER TABLE strategy_videos ADD CONSTRAINT strategy_videos_setup_type_check
+  CHECK (setup_type IN ('breakout', 'momentum', 'pullback_vwap', 'range', 'pocket_pivot', 'bullish_engulfing', 'volume_breakout'));

--- a/supabase/migrations/20260526000002_add_max_swing_positions_config.sql
+++ b/supabase/migrations/20260526000002_add_max_swing_positions_config.sql
@@ -1,0 +1,5 @@
+-- Add max_swing_positions to auto_trader_config so swing-trade slot pool
+-- is configurable independently of the day-trade pool (max_positions).
+-- Default 2: allows up to 2 concurrent swing trade positions.
+ALTER TABLE auto_trader_config
+  ADD COLUMN IF NOT EXISTS max_swing_positions INTEGER DEFAULT 2;


### PR DESCRIPTION
## Summary

- **Swing SELL signals enabled** — scanner bearish signals now open short positions with GTC bracket orders (stop above entry, target below entry). Previously blocked by a hard gate regardless of signal quality.
- **Separate day/swing slot pools** — added `maxSwingPositions` config (default 3) as an independent pool from `maxPositions` (day trades). Day-trade signals at market open can no longer starve swing entries.
- **Options scanner improvements** — removed Tue/Thu STABLE-tier skip (Finnhub rate limits are per-minute, not cross-day; skipping saves nothing). Moved `'fraud'` from hard to soft stop requiring 2+ headlines (AMZN/GOOGL appear in fraud-adjacent news as innocent third parties routinely).
- **Reconciler stability** — startup delay increased 2s→15s; orders <10 min old excluded from cancellation to prevent false positives on restart.
- **DB migration** — `max_swing_positions` column added to `auto_trader_config`.
- **Frontend** — `maxSwingPositions` wired into `loadAutoTraderConfig()`.

## Test plan

- [ ] Verify swing SELL signals execute bracket orders in IB with stop ABOVE entry and target BELOW entry
- [ ] Verify day trades and swing trades draw from independent slot pools (no starvation)
- [ ] Verify options scanner scans STABLE tickers all 5 days of the week
- [ ] Verify restart no longer cancels orders placed within the last 10 minutes
- [ ] Verify frontend builds clean with no TypeScript errors

Made with [Cursor](https://cursor.com)