### PR TITLE
fix: separate swing scanner confidence threshold (conf=7 swings now execute)

### DIFF
--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -146,6 +146,7 @@ export async function loadAutoTraderConfig(): Promise<AutoTraderConfig> {
         maxPositions: data.max_positions ?? DEFAULT_CONFIG.maxPositions,
         maxSwingPositions: data.max_swing_positions ?? DEFAULT_CONFIG.maxSwingPositions,
         positionSize: Number(data.position_size) || DEFAULT_CONFIG.positionSize,
+        minSwingScannerConfidence: data.min_swing_scanner_confidence ?? DEFAULT_CONFIG.minSwingScannerConfidence,
         minScannerConfidence: data.min_scanner_confidence ?? DEFAULT_CONFIG.minScannerConfidence,
         minFAConfidence: data.min_fa_confidence ?? DEFAULT_CONFIG.minFAConfidence,
         minSuggestedFindsConviction: data.min_suggested_finds_conviction ?? DEFAULT_CONFIG.minSuggestedFindsConviction,

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -73,6 +73,7 @@ export async function loadConfig(): Promise<AutoTraderConfig> {
     maxSwingPositions: data.max_swing_positions ?? DEFAULT_CONFIG.maxSwingPositions,
     positionSize: Number(data.position_size) || DEFAULT_CONFIG.positionSize,
     minScannerConfidence: data.min_scanner_confidence ?? DEFAULT_CONFIG.minScannerConfidence,
+    minSwingScannerConfidence: data.min_swing_scanner_confidence ?? DEFAULT_CONFIG.minSwingScannerConfidence,
     minFAConfidence: data.min_fa_confidence ?? DEFAULT_CONFIG.minFAConfidence,
     minSuggestedFindsConviction: data.min_suggested_finds_conviction ?? DEFAULT_CONFIG.minSuggestedFindsConviction,
     accountId: data.account_id ?? DEFAULT_CONFIG.accountId,

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -3432,7 +3432,10 @@ async function executeScannerTrade(
     faRiskReward = fa.trade.riskReward;
   }
 
-  if (faConf < config.minFAConfidence) return `skipped:fa_conf_${faConf}`;
+  // Swings with pre-set scanner levels use scanner confidence — use the lower swing threshold.
+  // Swings without levels (fresh FA call) and day trades use minFAConfidence.
+  const confThreshold = mode === 'SWING_TRADE' ? config.minSwingScannerConfidence : config.minFAConfidence;
+  if (faConf < confThreshold) return `skipped:fa_conf_${faConf}`;
   if (faRec === 'HOLD') return 'skipped:fa_hold';
   if (faRec !== signal) return `skipped:direction_mismatch`;
 
@@ -6546,7 +6549,7 @@ async function runTradeExecutionOnly(): Promise<void> {
           .sort((a, b) => b.confidence - a.confidence)
           .slice(0, daySlots);
         const qualifiedSwing = newIdeas
-          .filter(i => i.mode === 'SWING_TRADE' && i.confidence >= config.minScannerConfidence)
+          .filter(i => i.mode === 'SWING_TRADE' && i.confidence >= config.minSwingScannerConfidence)
           .sort((a, b) => b.confidence - a.confidence)
           .slice(0, swingSlots);
         const qualified = [...qualifiedDay, ...qualifiedSwing];
@@ -6846,7 +6849,7 @@ async function runSchedulerCycle(): Promise<void> {
             .sort((a, b) => b.confidence - a.confidence)
             .slice(0, daySlots);
           const qualifiedSwing = newIdeas
-            .filter(i => i.mode === 'SWING_TRADE' && i.confidence >= config.minScannerConfidence)
+            .filter(i => i.mode === 'SWING_TRADE' && i.confidence >= config.minSwingScannerConfidence)
             .sort((a, b) => b.confidence - a.confidence)
             .slice(0, swingSlots);
           const qualified = [...qualifiedDay, ...qualifiedSwing];

--- a/shared/config-defaults.ts
+++ b/shared/config-defaults.ts
@@ -12,6 +12,7 @@ export interface AutoTraderConfig {
   maxSwingPositions: number;
   positionSize: number;
   minScannerConfidence: number;
+  minSwingScannerConfidence: number;
   minFAConfidence: number;
   minSuggestedFindsConviction: number;
   accountId: string | null;
@@ -79,6 +80,7 @@ export const DEFAULT_CONFIG: AutoTraderConfig = {
   maxSwingPositions: 2,
   positionSize: 1000,
   minScannerConfidence: 7,
+  minSwingScannerConfidence: 7,
   minFAConfidence: 7,
   minSuggestedFindsConviction: 8,
   accountId: null,


### PR DESCRIPTION
## Problem

Swing scanner produces `conf=7` signals (CHWY/NU/VFC SELL, ABBV BUY). With `minScannerConfidence=8` (tuned for day trade quality), all swing ideas were filtered out at the slot allocation step before reaching `executeScannerTrade`. This was a silent failure — swings appeared in the scan summary but never executed.

This is the final reason zero swing trades ran even after fixing the SELL gate and the separate slot pools.

## Fix

- Add `minSwingScannerConfidence: 7` as a separate config from `minScannerConfidence`
- Swing slot filter uses `minSwingScannerConfidence`; day trade filter still uses `minScannerConfidence`  
- Within `executeScannerTrade`, swing trades use `minSwingScannerConfidence` as their confidence floor (day trades continue using `minFAConfidence`)

## Test plan
- [ ] CHWY/NU/VFC SELL and ABBV BUY ideas now reach `executeScannerTrade`
- [ ] Day trade confidence gate unchanged (still requires conf ≥ 8)
- [ ] `min_swing_scanner_confidence` DB column can be tuned independently in Settings

Made with [Cursor](https://cursor.com)