### PR TITLE
fix: resolve IB bracket order silent failures causing orphaned positions

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -55,6 +55,7 @@ export interface BracketOrderResult {
   parentOrderId: number;
   takeProfitOrderId: number;
   stopLossOrderId: number;
+  timedOut?: boolean; // true = IB did not ACK within timeout; treat as SUBMITTED pending reconciliation
 }
 
 export interface MarketOrderParams {
@@ -162,6 +163,7 @@ export class IBConnection {
 
   private ib: IBApi | null = null;
   private _connected = false;
+  private _readyForOrdersAt = 0; // epoch ms — orders blocked until this time after each connect
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private _accounts: string[] = [];
@@ -221,6 +223,7 @@ export class IBConnection {
   // ── Public API ───────────────────────────────────────
 
   isConnected(): boolean { return this._connected; }
+  isReadyForOrders(): boolean { return this._connected && Date.now() >= this._readyForOrdersAt; }
   getAccounts(): string[] { return this._accounts; }
   getDefaultAccount(): string | null { return this._accounts[0] ?? null; }
   getIBApi(): IBApi | null { return this.ib; }
@@ -344,6 +347,9 @@ export class IBConnection {
     ib.on(EventName.connected, () => {
       console.log(`${this.tag} Connected to IB Gateway at ${IB_HOST}:${this.port}`);
       this._connected = true;
+      // Hold off new order placement for 60s after each connect — IB paper accounts
+      // show "connected" before they're fully ready to ack bracket orders.
+      this._readyForOrdersAt = Date.now() + 60_000;
       this.reconnectAttempts = 0;
       this.connectionListeners.forEach(fn => fn(true));
       ib.reqManagedAccts();
@@ -425,8 +431,16 @@ export class IBConnection {
     });
 
     ib.on(EventName.nextValidId, (orderId: number) => {
-      this._nextOrderId = orderId;
-      console.log(`${this.tag} Next valid order ID: ${this._nextOrderId}`);
+      // IB broadcasts nextValidId proactively (not just on reqIds()). Only accept
+      // the new value when it's strictly higher than our current counter — otherwise
+      // IB's stale broadcast would reset our counter backwards and cause duplicate
+      // order-ID rejections on the next placeOrder call.
+      if (orderId > this._nextOrderId) {
+        this._nextOrderId = orderId;
+        console.log(`${this.tag} Next valid order ID: ${this._nextOrderId}`);
+      } else {
+        console.log(`${this.tag} nextValidId broadcast ${orderId} ignored (current counter already at ${this._nextOrderId})`);
+      }
       this._subscribeToPnlIfReady();
     });
 
@@ -658,6 +672,10 @@ export class IBConnection {
       if (!this.ib || !this._connected) {
         return reject(new Error(`${this.tag} Not connected to IB Gateway`));
       }
+      if (!this.isReadyForOrders()) {
+        const waitSec = Math.ceil((this._readyForOrdersAt - Date.now()) / 1000);
+        return reject(new Error(`${this.tag} IB connection warming up — orders blocked for ${waitSec}s more after reconnect`));
+      }
 
       const { symbol, side, quantity, entryPrice, stopLoss, takeProfit, tif = 'GTC' } = params;
 
@@ -710,18 +728,21 @@ export class IBConnection {
       };
 
       // Wait for IB to acknowledge the parent order (PreSubmitted or Submitted)
-      // before resolving. Without this, placeOrder() is fire-and-forget and the
-      // order can silently vanish if IB is in a transient state — leaving our DB
-      // with a SUBMITTED paper_trade that IB has no record of.
+      // before resolving. We resolve with timedOut=true if IB doesn't respond in
+      // time — the caller saves a SUBMITTED paper_trade so the reconciler can
+      // verify/close it later. We never reject on timeout alone because IB paper
+      // frequently accepts bracket orders but sends the ack >30s later, creating
+      // orphaned IB positions with no corresponding DB record.
       let ackResolved = false;
-      const ACK_TIMEOUT_MS = 8_000;
+      const ACK_TIMEOUT_MS = 30_000;
 
       const ackTimer = setTimeout(() => {
         if (ackResolved) return;
         ackResolved = true;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (this.ib as any).off(EventName.orderStatus, onOrderStatus);
-        reject(new Error(`Bracket order ${parentId} (${symbol}) not acknowledged by IB within ${ACK_TIMEOUT_MS / 1000}s — IB may not have received it`));
+        console.warn(`${this.tag} Bracket order ${parentId} (${symbol}) not acknowledged within ${ACK_TIMEOUT_MS / 1000}s — saving as SUBMITTED for reconciler`);
+        resolve({ parentOrderId: parentId, takeProfitOrderId: tpId, stopLossOrderId: slId, timedOut: true });
       }, ACK_TIMEOUT_MS);
 
       const onOrderStatus = (ordId: number, status: string) => {

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -248,6 +248,8 @@ const RETRYABLE_SKIP_PREFIXES = [
   'skipped:swing_volume_divergence',
   'skipped:market_direction_bearish',
   'skipped:market_direction_bullish',
+  'failed:order',      // transient IB connectivity failure — retry next cycle
+  'failed:no_contract', // IB connection down — retry when reconnected
 ];
 
 function isRetryableSkip(result: string): boolean {
@@ -3634,6 +3636,10 @@ async function executeScannerTrade(
         tif,
       });
 
+      if (result.timedOut) {
+        log(`${ticker}: ⚠️ IB ACK timed out — saving as SUBMITTED anyway (order ${result.parentOrderId}); reconciler will verify`);
+      }
+
       await createPaperTrade({
         ticker, mode, signal,
         scanner_confidence: Math.round(effectiveScannerConf),
@@ -3673,6 +3679,10 @@ async function executeScannerTrade(
             takeProfit: targetPrice2,
             tif,
           });
+
+          if (result2.timedOut) {
+            log(`${ticker}: ⚠️ T2 IB ACK timed out — saving as SUBMITTED anyway (order ${result2.parentOrderId}); reconciler will verify`);
+          }
 
           await createPaperTrade({
             ticker, mode, signal,


### PR DESCRIPTION
## Summary
- **Root cause of all bracket order failures**: IB proactively re-broadcasts `nextValidId` every ~5 minutes. Our code was resetting `_nextOrderId` backwards on each broadcast, causing subsequent orders to reuse already-submitted IDs → IB silently rejects duplicates with no error event (hence "not acknowledged within 8s/30s").
- **60s post-reconnect warmup**: IB paper account says "connected" before it's ready; now orders are blocked for 60s after each reconnect to let the session fully initialize.
- **Bracket timeout → SUBMITTED**: Instead of rejecting on ACK timeout, we resolve with `timedOut=true` and still create a `SUBMITTED` paper_trade. The reconciler verifies it against IB's open orders. This prevents orphaned IB positions with no DB record (which caused the `$1.0596` commission event with no matching trade today).
- **`failed:order` is now retryable**: Transient IB failures no longer permanently blacklist a ticker for the session — it retries on the next scan cycle.

## Test plan
- [ ] After restart, check auto-trader log for `nextValidId broadcast X ignored (current counter already at Y)` — confirms guard is working
- [ ] After 60s warmup expires, swing/day trade orders should ACK cleanly (no more "not acknowledged within Xs")
- [ ] If ACK does time out, check that a SUBMITTED paper_trade record is created in DB
- [ ] VFC / NU / ABBV swing trades should execute on next eligible scan cycle

Made with [Cursor](https://cursor.com)