### PR TITLE
fix: force IB orderStatus emit via reqAllOpenOrders after bracket dispatch

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -771,6 +771,9 @@ export class IBConnection {
         this.ib.placeOrder(tpId, contract, takeProfitOrder);
         this.ib.placeOrder(slId, contract, stopLossOrder);
         console.log(`${this.tag} Bracket order dispatched: ${side} ${quantity}x ${symbol} entry=$${entryPrice} tp=$${takeProfit} sl=$${stopLoss} (parentId=${parentId}) — awaiting IB ack...`);
+        // Force IB to emit orderStatus for all submitted orders — paper account
+        // sometimes doesn't proactively push status back in degraded sessions.
+        setTimeout(() => { if (!ackResolved) this.ib?.reqAllOpenOrders(); }, 2000);
       } catch (err) {
         ackResolved = true;
         clearTimeout(ackTimer);


### PR DESCRIPTION
IB paper account in degraded state (post-reconnect) does not proactively send orderStatus for newly placed bracket orders. Calling reqAllOpenOrders() 2s after dispatch forces IB to emit orderStatus for all submitted orders, allowing our ACK listener to resolve the promise instead of timing out.

Made with [Cursor](https://cursor.com)