### PR TITLE
feat: add Swing Trades and Options Wheel cards to Performance tab

### DIFF
--- a/app/src/components/PaperTrading/shared/SignalScorecard.tsx
+++ b/app/src/components/PaperTrading/shared/SignalScorecard.tsx
@@ -6,7 +6,7 @@ export interface SignalScorecardProps {
   title: string;
   subtitle: string;
   data: CategoryPerformance | undefined;
-  color: 'indigo' | 'blue' | 'emerald' | 'violet' | 'green';
+  color: 'indigo' | 'blue' | 'emerald' | 'violet' | 'green' | 'amber';
 }
 
 const colorClasses = {
@@ -15,6 +15,7 @@ const colorClasses = {
   emerald: 'border-emerald-200 bg-emerald-50',
   violet: 'border-violet-200 bg-violet-50',
   green: 'border-green-200 bg-green-50',
+  amber: 'border-amber-200 bg-amber-50',
 };
 
 const textColors = {
@@ -23,6 +24,7 @@ const textColors = {
   emerald: 'text-emerald-700',
   violet: 'text-violet-700',
   green: 'text-green-700',
+  amber: 'text-amber-700',
 };
 
 export function SignalScorecard({ title, subtitle, data, color }: SignalScorecardProps) {

--- a/app/src/components/PaperTrading/tabs/PerformanceTab.tsx
+++ b/app/src/components/PaperTrading/tabs/PerformanceTab.tsx
@@ -95,6 +95,7 @@ export function PerformanceTab({
   const influencerDt = categories.find(c => c.category === 'influencer_day_trade');
   const pennyDt = categories.find(c => c.category === 'day_penny');
   const sw = categories.find(c => c.category === 'swing_trade');
+  const optWheel = categories.find(c => c.category === 'options_wheel');
   const dipBuy = categories.find(c => c.category === 'dip_buy');
   const profitTake = categories.find(c => c.category === 'profit_take');
 
@@ -157,12 +158,13 @@ export function PerformanceTab({
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
-          <SignalScorecard title="Suggested Finds" subtitle="Long-term picks" data={sf} color="indigo" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
           <SignalScorecard title="Scanner Day Trades" subtitle="Trade signals only" data={scannerDt} color="blue" />
           <SignalScorecard title="Influencer Day Trades" subtitle="Strategy video signals" data={influencerDt} color="emerald" />
           <SignalScorecard title="Penny Day Trades" subtitle="Momentum scanner" data={pennyDt} color="green" />
-          <SignalScorecard title="Swing Trades" subtitle="Scanner signals" data={sw} color="violet" />
+          <SignalScorecard title="Swing Trades" subtitle="Multi-day scanner signals" data={sw} color="violet" />
+          <SignalScorecard title="Options Wheel" subtitle="Cash-secured puts & calls" data={optWheel} color="amber" />
+          <SignalScorecard title="Suggested Finds" subtitle="Long-term picks" data={sf} color="indigo" />
         </div>
 
         {((dipBuy?.totalTrades ?? 0) > 0 || (profitTake?.totalTrades ?? 0) > 0) && (

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -822,7 +822,7 @@ export async function recalculatePerformance(accountView: AccountView = 'paper')
 // ── Category Performance (Signal Quality) ────────────────
 
 export interface CategoryPerformance {
-  category: 'suggested_finds' | 'day_trade' | 'scanner_day_trade' | 'influencer_day_trade' | 'day_penny' | 'swing_trade' | 'dip_buy' | 'profit_take';
+  category: 'suggested_finds' | 'day_trade' | 'scanner_day_trade' | 'influencer_day_trade' | 'day_penny' | 'swing_trade' | 'options_wheel' | 'dip_buy' | 'profit_take';
   totalTrades: number;
   activeTrades: number;
   wins: number;
@@ -960,6 +960,10 @@ export async function recalculatePerformanceByCategory(accountView: AccountView 
     {
       key: 'swing_trade',
       filter: (t) => t.mode === 'SWING_TRADE',
+    },
+    {
+      key: 'options_wheel',
+      filter: (t) => t.mode === 'OPTIONS_PUT' || t.mode === 'OPTIONS_CALL' || t.mode === 'CREDIT_SPREAD' || t.mode === 'CALENDAR_SPREAD',
     },
     {
       key: 'dip_buy',


### PR DESCRIPTION
Adds Swing Trades and Options Wheel (OPTIONS_PUT/CALL/CREDIT_SPREAD) scorecards to the Performance tab. Reorganizes the grid to 3 columns so all 6 cards fit cleanly. Also adds amber color variant to SignalScorecard.

Made with [Cursor](https://cursor.com)