### PR TITLE
Add Options filter chip to Today's Activity

### DIFF
--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -53,7 +53,7 @@ export interface TodayActivityTabProps {
   accountView?: AccountView;
 }
 
-type FilterMode = 'all' | 'day' | 'penny' | 'swing' | 'long_term' | 'gainers' | 'losers';
+type FilterMode = 'all' | 'day' | 'penny' | 'swing' | 'long_term' | 'options' | 'gainers' | 'losers';
 type SortKey = 'ticker' | 'pnl' | 'time' | null;
 type SortDir = 'asc' | 'desc';
 
@@ -135,13 +135,13 @@ export function TodayActivityTab({ events, trades, todayTrades, todaySignalsForE
   const OPTIONS_MODES = new Set(['OPTIONS_PUT', 'OPTIONS_CALL', 'CALENDAR_SPREAD', 'CREDIT_SPREAD', 'EARNINGS_CALENDAR']);
 
   // Primary data source: todayTrades (from paper_trades, kept accurate by ib_fills trigger).
-  // Exclude options — they are managed in the Options Wheel tab and their P&L is not IB-fill-based.
+  // Include all modes — options trades visible via the "Options" filter chip.
   // Fall back to filtering allTrades for backward compatibility.
   const primaryTrades: PaperTrade[] = (todayTrades ?? trades.filter(t => {
     const openedToday = t.opened_at && t.opened_at >= todayISO;
     const closedToday = t.closed_at && t.closed_at >= todayISO;
     return openedToday || closedToday;
-  })).filter(t => !OPTIONS_MODES.has(t.mode) && t.status !== 'CANCELLED');
+  })).filter(t => t.status !== 'CANCELLED');
 
   // Legacy lookup: events for system-only messages (reconcile warnings, orphan alerts)
   const tradesByTicker = new Map<string, PaperTrade[]>();
@@ -289,6 +289,7 @@ export function TodayActivityTab({ events, trades, todayTrades, todaySignalsForE
         if (filterMode === 'penny') return mode === 'DAY_PENNY';
         if (filterMode === 'swing') return mode === 'SWING_TRADE';
         if (filterMode === 'long_term') return mode === 'LONG_TERM';
+        if (filterMode === 'options') return OPTIONS_MODES.has(mode ?? '');
         if (filterMode === 'gainers') return t.pnl != null && t.pnl > 0;
         if (filterMode === 'losers') return t.pnl != null && t.pnl < 0;
         return true;
@@ -327,6 +328,7 @@ export function TodayActivityTab({ events, trades, todayTrades, todaySignalsForE
     : filterMode === 'penny' ? 'Penny P&L'
     : filterMode === 'swing' ? 'Swing P&L'
     : filterMode === 'long_term' ? 'Long Term P&L'
+    : filterMode === 'options' ? 'Options P&L'
     : filterMode === 'gainers' ? 'Gainers P&L'
     : 'Losers P&L';
 
@@ -378,6 +380,7 @@ export function TodayActivityTab({ events, trades, todayTrades, todaySignalsForE
           { id: 'penny',     label: 'Penny' },
           { id: 'swing',     label: 'Swing' },
           { id: 'long_term', label: 'Long Term' },
+          { id: 'options',   label: 'Options' },
         ] as { id: FilterMode; label: string }[]).map(f => (
           <button
             key={f.id}


### PR DESCRIPTION
## Summary
- Options trades (OPTIONS_PUT, OPTIONS_CALL, CALENDAR_SPREAD, CREDIT_SPREAD) are now visible in Today's Activity
- "All" view includes options trades alongside day/swing/long-term trades
- New "Options" chip filters to show only options wheel trades
- Previously options were completely hidden from this tab, making AMAT and similar fills invisible

## Test plan
- [ ] Open Today's Activity — AMAT (OPTIONS_PUT) should appear in the list
- [ ] Click "Options" chip — should show only options trades
- [ ] Click "All" — should return to full view including options
- [ ] P&L header should update to "Options P&L" when Options chip is active

Made with [Cursor](https://cursor.com)