### PR TITLE
Fix credit spread phantom P&L on IB order failure

### DIFF
--- a/auto-trader/src/lib/credit-spread-scanner.ts
+++ b/auto-trader/src/lib/credit-spread-scanner.ts
@@ -347,17 +347,33 @@ async function executeCreditSpread(ticket: CreditSpreadTicket): Promise<void> {
 
   const expiryIso = `${ticket.expiry.slice(0, 4)}-${ticket.expiry.slice(4, 6)}-${ticket.expiry.slice(6, 8)}`;
 
+  // If IB placement failed, record as CANCELLED (not FILLED) so the position
+  // monitor doesn't track it and generate phantom P&L from fallback stock prices.
+  // Credit spreads are multi-leg IB orders — they cannot be paper-simulated safely.
+  if (!ibOrderId) {
+    console.warn(`[Credit Spread] IB order failed for ${ticket.ticker} — skipping paper_trade insert to prevent phantom P&L`);
+    await createAutoTradeEvent({
+      ticker: ticket.ticker,
+      mode: 'CREDIT_SPREAD',
+      event_type: 'warning',
+      action: 'skipped',
+      message: `${ticket.direction} ${ticket.sellStrike}/${ticket.buyStrike} — IB order failed, position NOT opened`,
+      metadata: { direction: ticket.direction, sellStrike: ticket.sellStrike, buyStrike: ticket.buyStrike },
+    });
+    return;
+  }
+
   await sb.from('paper_trades').insert({
     ticker: ticket.ticker,
     mode: 'CREDIT_SPREAD',
     signal: 'SELL',
-    status: ibOrderId ? 'SUBMITTED' : 'FILLED',
+    status: 'SUBMITTED',
     opened_at: new Date().toISOString(),
-    filled_at: ibOrderId ? null : new Date().toISOString(),
+    filled_at: null,
     entry_price: ticket.netCredit,
     quantity: ticket.contracts,
     position_size: ticket.maxLoss,
-    ib_order_id: ibOrderId?.toString() ?? null,
+    ib_order_id: ibOrderId.toString(),
     option_strike: ticket.sellStrike,
     option_expiry: expiryIso,
     option_premium: ticket.netCredit,


### PR DESCRIPTION
## Root cause
`executeCreditSpread()` set `status = ibOrderId ? 'SUBMITTED' : 'FILLED'`. When the IB vertical spread order failed (ibOrderId = null), the position was inserted as **FILLED** — a live open position that never existed in IB.

The scheduler's position monitor then:
1. Found no matching IB position
2. Waited 30 min (guard period)
3. Closed it using a **fallback stock price** (not options price)
4. Computed nonsense P&L: ALAB -$560, RKLB -$631, SOXL -$745

## Fix
If IB placement fails → skip the DB insert entirely, log a warning event instead. Credit spreads require IB execution; there's nothing to track without a fill.

## Test plan
- [ ] Trigger a credit spread scan with IB disconnected — no paper_trade should be created
- [ ] With IB connected, a successful spread order should still insert as SUBMITTED
- [ ] Today's phantom ALAB/RKLB/SOXL records manually cancelled in DB

Made with [Cursor](https://cursor.com)