### PR TITLE
Add strategy gates and direction-aware position size multiplier

### DIFF
--- a/auto-trader/src/lib/feedback.ts
+++ b/auto-trader/src/lib/feedback.ts
@@ -388,4 +388,139 @@ export async function updatePerformancePatterns(): Promise<void> {
       updated_at: new Date().toISOString(),
     })
     .eq('id', 'global');
+
+  // After updating patterns, evaluate whether any strategy directions need gating.
+  await evaluateAndGateStrategies();
+}
+
+// ── Strategy Gate Evaluator ───────────────────────────────────────────────────
+// Reads paper_trades grouped by (mode, signal) over a rolling window.
+// If win rate drops below GATE_THRESHOLD with enough samples, sets blocked=true
+// in strategy_gates. If it recovers above RECOVERY_THRESHOLD, clears the block.
+//
+// This is the "actuator" that closes the observe → act feedback loop.
+// Runs automatically after updatePerformancePatterns().
+
+const GATE_WINDOW_DAYS = 30;       // look back 30 days of trades
+const GATE_MIN_SAMPLES = 10;       // need at least 10 trades before gating
+const GATE_THRESHOLD = 0.30;       // block if win rate < 30%
+const GATE_RECOVERY_THRESHOLD = 0.45; // unblock when win rate recovers to 45%
+const GATE_AUTO_UNBLOCK_DAYS = 14; // also auto-unblock after 14 days regardless
+
+export async function evaluateAndGateStrategies(): Promise<void> {
+  const sb = getSupabase();
+  const since = new Date(Date.now() - GATE_WINDOW_DAYS * 86_400_000).toISOString();
+
+  // Get all closed trades in the window with a realized P&L
+  const { data: trades } = await sb
+    .from('paper_trades')
+    .select('mode, signal, pnl')
+    .in('status', [...CLOSED_STATUSES])
+    .not('pnl', 'is', null)
+    .not('fill_price', 'is', null)
+    .gte('closed_at', since);
+
+  if (!trades?.length) return;
+
+  // Group by (mode, signal)
+  const groups: Record<string, { wins: number; total: number }> = {};
+  for (const t of trades) {
+    const key = `${t.mode}::${t.signal}`;
+    if (!groups[key]) groups[key] = { wins: 0, total: 0 };
+    groups[key].total++;
+    if ((t.pnl ?? 0) > 0) groups[key].wins++;
+  }
+
+  // Fetch current gate states
+  const { data: currentGates } = await sb.from('strategy_gates').select('*');
+  const gateMap = new Map<string, { blocked: boolean; blocked_at: string | null; auto_unblock_at: string | null }>(
+    (currentGates ?? []).map((g: { mode: string; direction: string; blocked: boolean; blocked_at: string | null; auto_unblock_at: string | null }) => [
+      `${g.mode}::${g.direction}`, g
+    ])
+  );
+
+  const now = new Date();
+
+  for (const [key, stats] of Object.entries(groups)) {
+    if (stats.total < GATE_MIN_SAMPLES) continue; // not enough data to gate
+
+    const [mode, direction] = key.split('::');
+    const winRate = stats.wins / stats.total;
+    const existing = gateMap.get(key);
+    const isCurrentlyBlocked = existing?.blocked ?? false;
+
+    // Check auto-unblock by time
+    const autoUnblockAt = existing?.auto_unblock_at ? new Date(existing.auto_unblock_at) : null;
+    if (isCurrentlyBlocked && autoUnblockAt && now > autoUnblockAt) {
+      await sb.from('strategy_gates').upsert({
+        mode, direction, blocked: false,
+        win_rate: winRate, sample_size: stats.total,
+        blocked_at: null, auto_unblock_at: null,
+        reason: `Auto-unblocked after ${GATE_AUTO_UNBLOCK_DAYS}d cooldown. Current win rate: ${(winRate * 100).toFixed(0)}%`,
+        updated_at: now.toISOString(),
+      });
+      console.log(`[GateEval] ✅ ${mode} ${direction} auto-unblocked (time expired) | win rate ${(winRate * 100).toFixed(0)}%`);
+      continue;
+    }
+
+    if (!isCurrentlyBlocked && winRate < GATE_THRESHOLD) {
+      // Block it
+      const autoUnblock = new Date(now.getTime() + GATE_AUTO_UNBLOCK_DAYS * 86_400_000);
+      await sb.from('strategy_gates').upsert({
+        mode, direction, blocked: true,
+        win_rate: winRate, sample_size: stats.total,
+        blocked_at: now.toISOString(),
+        auto_unblock_at: autoUnblock.toISOString(),
+        reason: `Win rate ${(winRate * 100).toFixed(0)}% (${stats.wins}W/${stats.total - stats.wins}L over ${GATE_WINDOW_DAYS}d) below ${(GATE_THRESHOLD * 100).toFixed(0)}% threshold`,
+        updated_at: now.toISOString(),
+      });
+      console.log(`[GateEval] 🚫 ${mode} ${direction} BLOCKED | win rate ${(winRate * 100).toFixed(0)}% < ${(GATE_THRESHOLD * 100).toFixed(0)}% (${stats.wins}W/${stats.total}T)`);
+
+    } else if (isCurrentlyBlocked && winRate >= GATE_RECOVERY_THRESHOLD) {
+      // Unblock — strategy recovered
+      await sb.from('strategy_gates').upsert({
+        mode, direction, blocked: false,
+        win_rate: winRate, sample_size: stats.total,
+        blocked_at: null, auto_unblock_at: null,
+        reason: `Recovered: win rate ${(winRate * 100).toFixed(0)}% >= ${(GATE_RECOVERY_THRESHOLD * 100).toFixed(0)}% threshold`,
+        updated_at: now.toISOString(),
+      });
+      console.log(`[GateEval] ✅ ${mode} ${direction} UNBLOCKED | win rate ${(winRate * 100).toFixed(0)}% recovered`);
+
+    } else {
+      // Update win rate in place without changing blocked status
+      await sb.from('strategy_gates').upsert({
+        mode, direction,
+        blocked: isCurrentlyBlocked,
+        win_rate: winRate, sample_size: stats.total,
+        updated_at: now.toISOString(),
+      });
+    }
+  }
+}
+
+// ── Strategy Gate Check ───────────────────────────────────────────────────────
+// Call this before placing any order. Returns null if allowed, or a skip reason string.
+
+export async function checkStrategyGate(mode: string, direction: string): Promise<string | null> {
+  try {
+    const sb = getSupabase();
+    const { data } = await sb
+      .from('strategy_gates')
+      .select('blocked, reason, win_rate, auto_unblock_at')
+      .or(`direction.eq.${direction},direction.eq.BOTH`)
+      .eq('mode', mode)
+      .eq('blocked', true)
+      .limit(1)
+      .maybeSingle();
+
+    if (!data) return null;
+
+    const unblockStr = data.auto_unblock_at
+      ? ` (auto-unblock: ${new Date(data.auto_unblock_at).toLocaleDateString()})`
+      : ' (manual unblock required)';
+    return `strategy_gate:${mode}_${direction}_${(data.win_rate * 100).toFixed(0)}pct_wr${unblockStr}`;
+  } catch {
+    return null; // non-blocking: if gate check fails, allow the trade
+  }
 }

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -82,6 +82,7 @@ import {
   analyzeCompletedTrade,
   analyzeUnreviewedTrades,
   updatePerformancePatterns,
+  checkStrategyGate,
 } from './lib/feedback.js';
 import { logLongTermPerformance } from './lib/performanceLog.js';
 import { logClosedTradePerformance } from './lib/tradePerformanceLog.js';
@@ -3282,6 +3283,19 @@ async function executeScannerTrade(
   // they are different instruments and managed by a separate pipeline.
   if (await hasActiveTrade(ticker, { excludeOptions: true })) return 'skipped:duplicate';
 
+  // ── Strategy Gate ─────────────────────────────────────────────────────────
+  // Hard block on (mode, direction) pairs that have proven no edge.
+  // Populated automatically by evaluateAndGateStrategies() and seeded manually.
+  // Non-blocking on error (checkStrategyGate returns null if Supabase is down).
+  const gateBlock = await checkStrategyGate(mode, signal);
+  if (gateBlock) {
+    log(`${ticker}: BLOCKED by strategy gate — ${gateBlock}`);
+    persistEvent(ticker, 'skipped', `Strategy gate active: ${mode} ${signal} has insufficient edge`, {
+      action: 'skipped', source: 'scanner', mode, skip_reason: gateBlock,
+    });
+    return `skipped:${gateBlock}`;
+  }
+
   // ── Same-day re-entry cooldown (DAY_TRADE only — penny has its own session state) ──
   // hasActiveTrade only checks SUBMITTED/FILLED/PARTIAL — once a day trade hits
   // its target or stop (TARGET_HIT / STOPPED / CLOSED) the ticker is "free" again
@@ -3600,10 +3614,37 @@ async function executeScannerTrade(
   const streakMult = await getStreakMultiplier(mode);
   if (streakMult < 1.0) log(`${ticker}: cold streak active for ${mode} — sizing ×${streakMult}`);
 
+  // ── Win-rate position size multiplier (direction-aware) ───────────────────
+  // When a specific direction (BUY vs SELL) has a poor but not gate-level win rate,
+  // reduce position size proportionally. Separate from streakMult (mode-level, 0.5×
+  // flat) — this is continuous and direction-specific.
+  // Scale: wr >= 50% → 1.0×, wr 40-49% → 0.75×, wr 30-39% → 0.5×, < 30% → 0.0 (gated already)
+  let winRateMult = 1.0;
+  try {
+    const sb2 = (await import('./lib/supabase.js')).getSupabase();
+    const { data: gateRow } = await sb2
+      .from('strategy_gates')
+      .select('win_rate, blocked')
+      .eq('mode', mode)
+      .or(`direction.eq.${signal},direction.eq.BOTH`)
+      .maybeSingle();
+
+    if (gateRow && !gateRow.blocked && gateRow.win_rate != null) {
+      const wr = Number(gateRow.win_rate);
+      if (wr < 0.40 && wr >= 0.30) {
+        winRateMult = 0.50;
+        log(`${ticker}: ${mode} ${signal} win rate ${(wr * 100).toFixed(0)}% — sizing ×0.50 (reduced confidence)`);
+      } else if (wr < 0.50 && wr >= 0.40) {
+        winRateMult = 0.75;
+        log(`${ticker}: ${mode} ${signal} win rate ${(wr * 100).toFixed(0)}% — sizing ×0.75 (moderate confidence)`);
+      }
+    }
+  } catch { /* non-blocking — defaults to 1.0 */ }
+
   const sizingRaw = calculatePositionSize(config, {
     price: entryPrice, mode, entryPrice, stopLoss,
     drawdownMultiplier: dd.multiplier * kellyMult * vixMult * econMult,
-    streakMultiplier: streakMult,
+    streakMultiplier: streakMult * winRateMult,
   });
   // Scanner trades (AI-generated, not expert-vetted) must be capped per mode.
   // Swing trades use a separate, larger cap (swingPositionSize, default $5K) because

--- a/supabase/migrations/20260527000001_strategy_gates.sql
+++ b/supabase/migrations/20260527000001_strategy_gates.sql
@@ -1,0 +1,42 @@
+-- strategy_gates: direction-level hard blocks when a signal type has proven no edge.
+-- Complements strategy_streak_state (mode-level 0.5× soft reduction) by adding
+-- a SELL-vs-BUY distinction — so SWING SELL can be blocked while SWING BUY continues.
+--
+-- Populated automatically by evaluateAndGateStrategies() in feedback.ts.
+-- Can also be manually seeded (e.g. to immediately block a known-bad signal).
+
+CREATE TABLE IF NOT EXISTS strategy_gates (
+  mode            TEXT NOT NULL,
+  direction       TEXT NOT NULL CHECK (direction IN ('BUY', 'SELL', 'BOTH')),
+  blocked         BOOLEAN NOT NULL DEFAULT FALSE,
+  win_rate        NUMERIC(5,4),           -- rolling win rate when gate was set
+  sample_size     INTEGER,                -- number of trades used to compute win_rate
+  blocked_at      TIMESTAMPTZ,
+  auto_unblock_at TIMESTAMPTZ,            -- NULL = manual unblock only
+  reason          TEXT,
+  updated_at      TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (mode, direction)
+);
+
+ALTER TABLE strategy_gates ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read strategy_gates"  ON strategy_gates FOR SELECT USING (true);
+CREATE POLICY "Anyone can insert strategy_gates" ON strategy_gates FOR INSERT WITH CHECK (true);
+CREATE POLICY "Anyone can update strategy_gates" ON strategy_gates FOR UPDATE USING (true);
+CREATE POLICY "Anyone can delete strategy_gates" ON strategy_gates FOR DELETE USING (true);
+
+-- Seed: immediately block SWING_TRADE SELL — 14% win rate over last 7+ trades.
+-- auto_unblock_at = NULL: requires manual review before re-enabling.
+INSERT INTO strategy_gates (mode, direction, blocked, win_rate, sample_size, blocked_at, auto_unblock_at, reason)
+VALUES (
+  'SWING_TRADE', 'SELL', TRUE, 0.14, 7,
+  NOW(),
+  NULL,
+  'Auto-seeded: 14% win rate (1W/7L) — overnight shorts consistently stopped out at market open. Review before re-enabling.'
+)
+ON CONFLICT (mode, direction) DO UPDATE SET
+  blocked = EXCLUDED.blocked,
+  win_rate = EXCLUDED.win_rate,
+  sample_size = EXCLUDED.sample_size,
+  blocked_at = EXCLUDED.blocked_at,
+  reason = EXCLUDED.reason,
+  updated_at = NOW();


### PR DESCRIPTION
## Summary

- **Root cause fix**: SWING SELL signals have a 14% win rate (1W/7L) because overnight shorts get stopped out at market open. The streak tracker operates at mode level, so SWING BUY wins were masking SWING SELL losses — neither was gated. This closes the \"observe → act\" gap.
- **`strategy_gates` table**: Direction-level hard blocks (SWING_TRADE + SELL vs BUY) on top of the existing mode-level `strategy_streak_state` 0.5× soft reduction. Seeded with SWING SELL blocked immediately.
- **`evaluateAndGateStrategies()`**: Runs automatically after every `updatePerformancePatterns()` call. Auto-gates when win rate < 30% with 10+ samples; auto-unblocks at 45% recovery or after 14 days.
- **Position size multiplier**: 0.75× at 40–49% win rate, 0.5× at 30–39% — composable with Kelly, VIX regime, and streak multipliers.
- **Gate check in scheduler**: First check after duplicate detection — any blocked `(mode, direction)` pair returns a `skipped:strategy_gate:...` event immediately, before price levels or sizing are computed.

## Test plan
- [ ] Verify SWING SELL signals log `skipped:strategy_gate` in auto-trader stdout
- [ ] Verify SWING BUY signals still execute normally
- [ ] Verify `evaluateAndGateStrategies()` runs at 4:20 PM ET after EOD analysis
- [ ] Verify gate auto-unblocks when win rate recovers (manual or after 14 days)

Made with [Cursor](https://cursor.com)