### PR TITLE
Replace SWING SELL hard block with SPY SMA50 regime gate

### DIFF
--- a/auto-trader/src/lib/feedback.ts
+++ b/auto-trader/src/lib/feedback.ts
@@ -393,25 +393,23 @@ export async function updatePerformancePatterns(): Promise<void> {
   await evaluateAndGateStrategies();
 }
 
-// ── Strategy Gate Evaluator ───────────────────────────────────────────────────
-// Reads paper_trades grouped by (mode, signal) over a rolling window.
-// If win rate drops below GATE_THRESHOLD with enough samples, sets blocked=true
-// in strategy_gates. If it recovers above RECOVERY_THRESHOLD, clears the block.
+// ── Strategy Gate Win Rate Tracker ───────────────────────────────────────────
+// Reads paper_trades grouped by (mode, signal) over a rolling 30-day window and
+// writes the current win rate + sample size into strategy_gates for visibility.
 //
-// This is the "actuator" that closes the observe → act feedback loop.
-// Runs automatically after updatePerformancePatterns().
+// IMPORTANT: This function NEVER sets blocked=true. Blocking is a manual decision
+// made by the operator (you). The system shows you the data; you decide the action.
+//
+// The actual direction-level gate for SWING SELL is the SPY regime check in
+// scheduler.ts — that's structural (fight the trend = bad), not data-driven blocking.
 
-const GATE_WINDOW_DAYS = 30;       // look back 30 days of trades
-const GATE_MIN_SAMPLES = 10;       // need at least 10 trades before gating
-const GATE_THRESHOLD = 0.30;       // block if win rate < 30%
-const GATE_RECOVERY_THRESHOLD = 0.45; // unblock when win rate recovers to 45%
-const GATE_AUTO_UNBLOCK_DAYS = 14; // also auto-unblock after 14 days regardless
+const GATE_WINDOW_DAYS = 30;  // rolling window for win rate computation
+const GATE_MIN_SAMPLES = 5;   // min trades before writing a rate (avoid noise)
 
 export async function evaluateAndGateStrategies(): Promise<void> {
   const sb = getSupabase();
   const since = new Date(Date.now() - GATE_WINDOW_DAYS * 86_400_000).toISOString();
 
-  // Get all closed trades in the window with a realized P&L
   const { data: trades } = await sb
     .from('paper_trades')
     .select('mode, signal, pnl')
@@ -422,7 +420,6 @@ export async function evaluateAndGateStrategies(): Promise<void> {
 
   if (!trades?.length) return;
 
-  // Group by (mode, signal)
   const groups: Record<string, { wins: number; total: number }> = {};
   for (const t of trades) {
     const key = `${t.mode}::${t.signal}`;
@@ -431,70 +428,25 @@ export async function evaluateAndGateStrategies(): Promise<void> {
     if ((t.pnl ?? 0) > 0) groups[key].wins++;
   }
 
-  // Fetch current gate states
-  const { data: currentGates } = await sb.from('strategy_gates').select('*');
-  const gateMap = new Map<string, { blocked: boolean; blocked_at: string | null; auto_unblock_at: string | null }>(
-    (currentGates ?? []).map((g: { mode: string; direction: string; blocked: boolean; blocked_at: string | null; auto_unblock_at: string | null }) => [
-      `${g.mode}::${g.direction}`, g
-    ])
-  );
-
   const now = new Date();
 
   for (const [key, stats] of Object.entries(groups)) {
-    if (stats.total < GATE_MIN_SAMPLES) continue; // not enough data to gate
+    if (stats.total < GATE_MIN_SAMPLES) continue;
 
     const [mode, direction] = key.split('::');
     const winRate = stats.wins / stats.total;
-    const existing = gateMap.get(key);
-    const isCurrentlyBlocked = existing?.blocked ?? false;
 
-    // Check auto-unblock by time
-    const autoUnblockAt = existing?.auto_unblock_at ? new Date(existing.auto_unblock_at) : null;
-    if (isCurrentlyBlocked && autoUnblockAt && now > autoUnblockAt) {
-      await sb.from('strategy_gates').upsert({
-        mode, direction, blocked: false,
-        win_rate: winRate, sample_size: stats.total,
-        blocked_at: null, auto_unblock_at: null,
-        reason: `Auto-unblocked after ${GATE_AUTO_UNBLOCK_DAYS}d cooldown. Current win rate: ${(winRate * 100).toFixed(0)}%`,
-        updated_at: now.toISOString(),
-      });
-      console.log(`[GateEval] ✅ ${mode} ${direction} auto-unblocked (time expired) | win rate ${(winRate * 100).toFixed(0)}%`);
-      continue;
-    }
+    // Only update win_rate and sample_size — never touch blocked.
+    // blocked is a manual field; the system only provides data, not decisions.
+    await sb.from('strategy_gates').upsert({
+      mode, direction,
+      win_rate: winRate,
+      sample_size: stats.total,
+      updated_at: now.toISOString(),
+    }, { onConflict: 'mode,direction', ignoreDuplicates: false });
 
-    if (!isCurrentlyBlocked && winRate < GATE_THRESHOLD) {
-      // Block it
-      const autoUnblock = new Date(now.getTime() + GATE_AUTO_UNBLOCK_DAYS * 86_400_000);
-      await sb.from('strategy_gates').upsert({
-        mode, direction, blocked: true,
-        win_rate: winRate, sample_size: stats.total,
-        blocked_at: now.toISOString(),
-        auto_unblock_at: autoUnblock.toISOString(),
-        reason: `Win rate ${(winRate * 100).toFixed(0)}% (${stats.wins}W/${stats.total - stats.wins}L over ${GATE_WINDOW_DAYS}d) below ${(GATE_THRESHOLD * 100).toFixed(0)}% threshold`,
-        updated_at: now.toISOString(),
-      });
-      console.log(`[GateEval] 🚫 ${mode} ${direction} BLOCKED | win rate ${(winRate * 100).toFixed(0)}% < ${(GATE_THRESHOLD * 100).toFixed(0)}% (${stats.wins}W/${stats.total}T)`);
-
-    } else if (isCurrentlyBlocked && winRate >= GATE_RECOVERY_THRESHOLD) {
-      // Unblock — strategy recovered
-      await sb.from('strategy_gates').upsert({
-        mode, direction, blocked: false,
-        win_rate: winRate, sample_size: stats.total,
-        blocked_at: null, auto_unblock_at: null,
-        reason: `Recovered: win rate ${(winRate * 100).toFixed(0)}% >= ${(GATE_RECOVERY_THRESHOLD * 100).toFixed(0)}% threshold`,
-        updated_at: now.toISOString(),
-      });
-      console.log(`[GateEval] ✅ ${mode} ${direction} UNBLOCKED | win rate ${(winRate * 100).toFixed(0)}% recovered`);
-
-    } else {
-      // Update win rate in place without changing blocked status
-      await sb.from('strategy_gates').upsert({
-        mode, direction,
-        blocked: isCurrentlyBlocked,
-        win_rate: winRate, sample_size: stats.total,
-        updated_at: now.toISOString(),
-      });
+    if (winRate < 0.30) {
+      console.log(`[GateEval] ⚠️  ${mode} ${direction}: ${(winRate * 100).toFixed(0)}% win rate (${stats.wins}W/${stats.total}T over ${GATE_WINDOW_DAYS}d) — below 30%, consider reviewing`);
     }
   }
 }

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -3283,17 +3283,43 @@ async function executeScannerTrade(
   // they are different instruments and managed by a separate pipeline.
   if (await hasActiveTrade(ticker, { excludeOptions: true })) return 'skipped:duplicate';
 
-  // ── Strategy Gate ─────────────────────────────────────────────────────────
-  // Hard block on (mode, direction) pairs that have proven no edge.
-  // Populated automatically by evaluateAndGateStrategies() and seeded manually.
-  // Non-blocking on error (checkStrategyGate returns null if Supabase is down).
+  // ── Manual strategy gate ─────────────────────────────────────────────────
+  // Checks strategy_gates.blocked — set ONLY by you manually, never auto-set.
+  // Use this when you explicitly decide to disable a direction (e.g. after a
+  // systematic review). The system will not block anything automatically.
   const gateBlock = await checkStrategyGate(mode, signal);
   if (gateBlock) {
-    log(`${ticker}: BLOCKED by strategy gate — ${gateBlock}`);
-    persistEvent(ticker, 'skipped', `Strategy gate active: ${mode} ${signal} has insufficient edge`, {
+    log(`${ticker}: BLOCKED by manual strategy gate — ${gateBlock}`);
+    persistEvent(ticker, 'skipped', `Manual strategy gate active: ${mode} ${signal}`, {
       action: 'skipped', source: 'scanner', mode, skip_reason: gateBlock,
     });
     return `skipped:${gateBlock}`;
+  }
+
+  // ── SWING SELL: SPY regime gate ───────────────────────────────────────────
+  // Shorting only makes sense when the broader market is in a downtrend.
+  // If SPY is above its 50-day SMA, we are in a bull market — SWING SELL signals
+  // are fighting the trend and have historically lost (14% WR, 1W/6L as of May 2026).
+  // Allow when SPY < SMA50 (mixed/bearish regime). Fully non-blocking on data failure.
+  if (mode === 'SWING_TRADE' && signal === 'SELL') {
+    try {
+      const spyBars = await fetchYahooDailyBars('SPY');
+      if (spyBars && spyBars.closes.length >= 50) {
+        const closes = spyBars.closes;
+        const spyPrice = closes[closes.length - 1];
+        const sma50 = closes.slice(-50).reduce((a: number, b: number) => a + b, 0) / 50;
+        if (spyPrice > sma50) {
+          log(`${ticker}: SWING SELL skipped — SPY $${spyPrice.toFixed(2)} above SMA50 $${sma50.toFixed(2)} (bullish regime, don't short)`);
+          persistEvent(ticker, 'skipped', `SWING SELL skipped: SPY above SMA50 (bullish regime)`, {
+            action: 'skipped', source: 'scanner', mode,
+            skip_reason: 'spy_bullish_no_shorts',
+            metadata: { spyPrice, sma50 },
+          });
+          return 'skipped:spy_bullish_no_shorts';
+        }
+        log(`${ticker}: SWING SELL allowed — SPY $${spyPrice.toFixed(2)} below SMA50 $${sma50.toFixed(2)} (bearish/mixed regime)`);
+      }
+    } catch { /* non-blocking — if SPY data unavailable, allow the trade */ }
   }
 
   // ── Same-day re-entry cooldown (DAY_TRADE only — penny has its own session state) ──


### PR DESCRIPTION
## Summary

- **Problem**: Hard blocking SWING SELL is a deadlock — no trades means no new data means win rate can never recover, so the gate never lifts.
- **Fix**: Replace the hard block with a structural regime check: SWING SELL is only allowed when SPY is below its 50-day SMA (bearish/mixed market). In a bull market (SPY > SMA50), shorts are fighting the trend and get skipped.
- **`evaluateAndGateStrategies()`**: Now read-only — updates `win_rate`/`sample_size` in `strategy_gates` for visibility only, never sets `blocked=true`. Blocking is a manual operator decision.
- **`strategy_gates.blocked`**: Manual-only field. Use it when you explicitly decide to disable a direction after a review.

## Behavior
- SPY above SMA50 → SWING SELL skipped, logged as `spy_bullish_no_shorts`
- SPY below SMA50 → SWING SELL allowed (with reduced size via win-rate multiplier at 14% WR)
- Data flows → win rate can improve over time → system learns

Made with [Cursor](https://cursor.com)