### PR TITLE
Fix IB error 399 duplicate sells and swing trade fallback close

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -423,6 +423,18 @@ export class IBConnection {
 
       if (reqId != null && this._pendingOrderCallbacks.has(reqId)) {
         const pending = this._pendingOrderCallbacks.get(reqId)!;
+
+        // Code 399 = "order repriced to avoid crossing a resting order" — this is a WARNING,
+        // not a rejection. IB reprices and fills the order anyway. If we reject and delete the
+        // callback here, the subsequent orderStatus:Filled event has nowhere to resolve, the
+        // placeMarketOrder promise rejects, the caller thinks the order failed and retries —
+        // creating duplicate sells. Confirmed: caused 3× IWM sells and a 20-share accidental short.
+        // Solution: swallow the warning, keep the callback alive, let the fill event resolve it.
+        if (code === 399) {
+          console.warn(`${this.tag} Order ${reqId} (${pending.symbol}) warning code=399: ${err.message} — order repriced by IB, still waiting for fill`);
+          return;
+        }
+
         clearTimeout(pending.timer);
         this._pendingOrderCallbacks.delete(reqId);
         const msg = `IB order ${reqId} (${pending.symbol}) rejected: code=${code} ${err.message}`;

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -5284,6 +5284,19 @@ async function _syncPositionsForAccount(
           log(`${trade.ticker}: Position still missing (${Math.round(missingFor / 60000)} min) — waiting for guard period`);
           continue;
         }
+
+        // Swing and long-term trades are multi-day holds. A 30-min IB disconnect
+        // (e.g. mobile app login kicking out the gateway session) is a normal transient
+        // event and must NOT trigger a fallback-quote close — that would close a good
+        // position at the wrong price. Confirmed: caused ABBV to close at $213.14
+        // instead of $217.12 (+$276 P&L difference) on 2026-05-26.
+        // Only day trades and penny trades use the fallback-quote close.
+        if (trade.mode === 'SWING_TRADE' || trade.mode === 'LONG_TERM') {
+          log(`[WARN] ${trade.ticker}: ${trade.mode} position missing for ${Math.round(missingFor / 60000)} min — NOT closing via fallback quote (IB disconnect suspected). Resetting guard to re-check next cycle.`);
+          await updatePaperTrade(trade.id, { missing_since: null }, syncAcct);
+          continue;
+        }
+
         log(`${trade.ticker}: Position missing for ${Math.round(missingFor / 60000)} min — proceeding with closure (fallback)`);
       }
 


### PR DESCRIPTION
## Bug 1 — IB error 399 → duplicate EOD sells → accidental short (IWM 2026-05-26)

Error 399 (`Your order was repriced so as not to cross a related resting order`) is a **warning**, not a rejection — IB reprices and still fills. Our error handler was deleting the pending callback and rejecting the promise before the fill event arrived. Soft close → hard sweep → safety sweep each fired a new sell. 3 sells on 10 shares = 20-share short overnight.

**Fix:** Don't reject or delete the callback on code 399. Log a warning, keep the callback alive, let the normal `orderStatus: Filled` event resolve it.

## Bug 2 — Swing trade closed at wrong price via fallback quote (ABBV 2026-05-26)

The 30-min position-missing guard applied to **all** filled trades regardless of mode. ABBV (SWING_TRADE) appeared missing during a mobile-login IB disconnect. After 30 min the fallback-quote close fired at $213.14 ($50 P&L) instead of the actual GTC TP at $217.12 ($327 P&L).

**Fix:** SWING_TRADE and LONG_TERM trades reset `missing_since` and skip the fallback close — a 30-min IB disconnect is a normal transient event for multi-day holds. Only DAY_TRADE / DAY_PENNY use the fallback-quote close.

Made with [Cursor](https://cursor.com)