### PR TITLE
Wire morning brief into trade scanner with IPO + sector context

### DIFF
--- a/auto-trader/src/lib/morning-brief.ts
+++ b/auto-trader/src/lib/morning-brief.ts
@@ -115,8 +115,11 @@ export async function generateMorningBrief(): Promise<void> {
 
   log(`Data collected — ${news.length} news items, ${earnings.length} earnings, ${economicEvents.length} econ events`);
 
-  if (news.length === 0 && earnings.length === 0) {
-    log('No data to synthesize — skipping (market may be closed)');
+  // Edge function always fetches IPO calendar + sector ETF moves on its own.
+  // Only skip if there's truly nothing (no earnings, no econ, and no news).
+  // Zero news is fine — edge function re-fetches with a wider 24h window.
+  if (earnings.length === 0 && economicEvents.length === 0 && news.length === 0) {
+    log('No data at all — skipping (market may be closed)');
     return;
   }
 

--- a/supabase/functions/generate-morning-brief/index.ts
+++ b/supabase/functions/generate-morning-brief/index.ts
@@ -54,13 +54,14 @@ Return ONLY a single JSON object (no markdown, no code blocks) with these exact 
 }
 
 Rules:
-- top_movers: max 5 names, ranked by likely intraday volatility
-- secondary_names: additional tickers from news, brief note only
+- top_movers: max 5 names, ranked by likely intraday volatility. ALWAYS populate this — if news is sparse, use sector ETF moves or upcoming IPO proxy plays (e.g. if an aerospace IPO is coming, list ASTS, RKLB as movers). Never return empty array if there are ANY sector moves or IPO data.
+- research_themes: ALWAYS identify 1-3 themes from the data provided. Use sector ETF moves to infer themes (XLK leading = "Tech Momentum", XLE leading = "Energy Rally", etc.). If upcoming IPOs exist, create a theme for the sector they're in. Never return empty array.
+- secondary_names: additional tickers from news or IPO proxies, brief note only
 - economic_events: today's releases only, sorted by time
 - earnings: pre-market AND after-close reporters for today
 - direction: "bullish" | "bearish" | "neutral" | "volatile"
 - importance: "high" | "medium" | "low"
-- If no data for a section, use empty array [] or empty string ""
+- For upcoming IPOs in the UPCOMING IPOs section: identify which public stocks will benefit as proxies and mention them in top_movers or research_themes
 - Be specific, concise, and trader-focused — avoid generic statements`;
 
 // ── Finnhub helpers ──────────────────────────────────────────────────────────
@@ -77,6 +78,31 @@ async function fetchFinnhub<T>(path: string, finnhubKey: string): Promise<T | nu
 
 function todayEt(): string {
   return new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' }); // YYYY-MM-DD
+}
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(`${dateStr}T12:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toLocaleDateString('en-CA', { timeZone: 'UTC' });
+}
+
+// Fetch sector ETF moves via Finnhub quote endpoint (authenticated, reliable)
+async function fetchSectorMoves(finnhubKey: string): Promise<Array<{ symbol: string; changePct: number }>> {
+  const SECTOR_ETFS = ['SPY', 'QQQ', 'XLK', 'XLE', 'XLY', 'XLF', 'XLV', 'XLI', 'ARKK'];
+  if (!finnhubKey) return [];
+  try {
+    const results = await Promise.all(
+      SECTOR_ETFS.map(async sym => {
+        const data = await fetchFinnhub<{ c: number; pc: number }>(`/quote?symbol=${sym}`, finnhubKey);
+        if (!data || !data.pc || data.pc === 0) return null;
+        const changePct = Math.round(((data.c - data.pc) / data.pc) * 1000) / 10;
+        return { symbol: sym, changePct };
+      })
+    );
+    return results.filter((r): r is { symbol: string; changePct: number } => r !== null);
+  } catch {
+    return [];
+  }
 }
 
 // ── Main handler ─────────────────────────────────────────────────────────────
@@ -100,30 +126,36 @@ Deno.serve(async (req: Request) => {
     let earnings = body.earnings;
     let economic_events = body.economic_events;
 
-    if (!news) {
-      const raw = await fetchFinnhub<{ id: number; headline: string; summary: string; related: string; datetime: number; source: string }[]>(
+    // Fetch all data in parallel — news, earnings, econ events, IPO calendar, sector ETFs
+    // Re-fetch news even if provided as empty array (auto-trader pre-fetch may have a narrower window)
+    const twoWeeksOut = addDays(brief_date, 14);
+    const [newsRaw, earningsRaw, econRaw, ipoRaw, sectorMoves] = await Promise.all([
+      (!news || news.length === 0) ? fetchFinnhub<Array<{ id: number; headline: string; summary: string; related: string; datetime: number; source: string }>>(
         `/news?category=general`, finnhubKey
-      );
-      // Filter to last 12 hours by datetime (Unix timestamp)
-      const twelveHoursAgo = Math.floor(Date.now() / 1000) - 12 * 3600;
-      news = (raw ?? []).filter(n => n.datetime >= twelveHoursAgo);
-      // Fall back to all available news if nothing recent
+      ) : Promise.resolve(null),
+      !earnings ? fetchFinnhub<{ earningsCalendar: Array<{ symbol: string; date: string; epsEstimate?: number; hour?: string }> }>(
+        `/calendar/earnings?from=${brief_date}&to=${brief_date}`, finnhubKey
+      ) : Promise.resolve(null),
+      !economic_events ? fetchFinnhub<{ economicCalendar: Array<{ event: string; time: string; prior?: string; estimate?: string; importance?: string }> }>(
+        `/calendar/economic?from=${brief_date}&to=${brief_date}`, finnhubKey
+      ) : Promise.resolve(null),
+      fetchFinnhub<{ ipoCalendar: Array<{ symbol: string; date: string; name: string; numberOfShares?: number; price?: string; status?: string }> }>(
+        `/calendar/ipo?from=${brief_date}&to=${twoWeeksOut}`, finnhubKey
+      ),
+      fetchSectorMoves(finnhubKey),
+    ]);
+
+    if (!news) {
+      const raw = newsRaw as Array<{ id: number; headline: string; summary: string; related: string; datetime: number; source: string }> | null;
+      // Widen window to 24 hours so premarket brief isn't empty when markets haven't opened yet
+      const twentyFourHoursAgo = Math.floor(Date.now() / 1000) - 24 * 3600;
+      news = (raw ?? []).filter(n => n.datetime >= twentyFourHoursAgo);
       if (news.length === 0) news = raw ?? [];
     }
+    if (!earnings) earnings = (earningsRaw as { earningsCalendar?: Array<{ symbol: string; date: string; epsEstimate?: number; hour?: string }> } | null)?.earningsCalendar ?? [];
+    if (!economic_events) economic_events = (econRaw as { economicCalendar?: Array<{ event: string; time: string; prior?: string; estimate?: string; importance?: string }> } | null)?.economicCalendar ?? [];
 
-    if (!earnings) {
-      const raw = await fetchFinnhub<{ earningsCalendar: Array<{ symbol: string; date: string; epsEstimate?: number; hour?: string }> }>(
-        `/calendar/earnings?from=${brief_date}&to=${brief_date}`, finnhubKey
-      );
-      earnings = raw?.earningsCalendar ?? [];
-    }
-
-    if (!economic_events) {
-      const raw = await fetchFinnhub<{ economicCalendar: Array<{ event: string; time: string; prior?: string; estimate?: string; importance?: string }> }>(
-        `/calendar/economic?from=${brief_date}&to=${brief_date}`, finnhubKey
-      );
-      economic_events = raw?.economicCalendar ?? [];
-    }
+    const upcomingIpos = (ipoRaw as { ipoCalendar?: Array<{ symbol: string; date: string; name: string; numberOfShares?: number; price?: string; status?: string }> } | null)?.ipoCalendar ?? [];
 
     // ── Build prompt ─────────────────────────────────────────────────────────
     // Headlines only — no summaries. Keeps prompt compact (~1500 tokens vs ~4000).
@@ -139,9 +171,20 @@ Deno.serve(async (req: Request) => {
       `${e.time} ET — ${e.event}${e.estimate ? ` (est: ${e.estimate}` : ''}${e.prior ? `, prior: ${e.prior})` : e.estimate ? ')' : ''}`
     ).join('\n');
 
+    const ipoSummary = upcomingIpos
+      .filter(ipo => ipo.status !== 'withdrawn')
+      .slice(0, 8)
+      .map(ipo => `${ipo.symbol || ipo.name} — ${ipo.date}${ipo.price ? ` @ $${ipo.price}` : ''}${ipo.numberOfShares ? ` (${(ipo.numberOfShares / 1e6).toFixed(1)}M shares)` : ''}`)
+      .join('\n');
+
+    const sectorSummary = sectorMoves
+      .sort((a, b) => Math.abs(b.changePct) - Math.abs(a.changePct))
+      .map(s => `${s.symbol}: ${s.changePct >= 0 ? '+' : ''}${s.changePct}%`)
+      .join('  |  ');
+
     const userPrompt = `Date: ${brief_date}
 
-=== MARKET NEWS (last 12 hours) ===
+=== MARKET NEWS (last 24 hours) ===
 ${newsSummary || 'No news items available.'}
 
 === EARNINGS TODAY ===
@@ -150,7 +193,14 @@ ${earningsSummary || 'No earnings reporters today.'}
 === ECONOMIC CALENDAR TODAY ===
 ${econSummary || 'No major economic releases scheduled.'}
 
-Generate the structured daily market briefing JSON for this trading day.`;
+=== UPCOMING IPOs (next 14 days) ===
+${ipoSummary || 'No major IPOs scheduled in next 14 days.'}
+
+=== SECTOR ETF MOVES TODAY ===
+${sectorSummary || 'Sector data unavailable.'}
+
+Generate the structured daily market briefing JSON for this trading day.
+Pay particular attention to any upcoming high-profile IPOs — they drive sector rotation and create proxy plays in related stocks.`;
 
     // ── Call LLM: Groq first, Gemini Flash fallback ──────────────────────────
     // Groq free tier: 100K tokens/day. Gemini Flash: 1M tokens/min, no daily cap.

--- a/supabase/functions/trade-scanner/index.ts
+++ b/supabase/functions/trade-scanner/index.ts
@@ -1083,6 +1083,7 @@ function formatKeyLevelForAI(setup: KeyLevelSetup, quote: YahooQuote, idx: numbe
 async function runTrack1KeyLevelIdeas(
   keyLevelSetups: KeyLevelSetup[],
   geminiKeys: string[],
+  marketContext?: string,
 ): Promise<TradeIdea[]> {
   if (keyLevelSetups.length === 0) return [];
 
@@ -1108,7 +1109,8 @@ async function runTrack1KeyLevelIdeas(
     .join('\n');
 
   try {
-    const raw = await callGemini(geminiKeys, TRACK1_SYSTEM, TRACK1_USER_PREFIX + stockData, 0.15, 1500);
+    const track1System = marketContext ? `${TRACK1_SYSTEM}\n\n${marketContext}` : TRACK1_SYSTEM;
+    const raw = await callGemini(geminiKeys, track1System, TRACK1_USER_PREFIX + stockData, 0.15, 1500);
     const evals = parseAIJsonArray(raw);
 
     console.log(`[Track 1] AI raw (${relevant.length} setups): ${evals.map(e => `${e.ticker}:${e.signal}/${e.confidence}`).join(', ')}`);
@@ -1692,6 +1694,7 @@ async function runPass2(
   quoteMap: Map<string, YahooQuote>,
   mode: 'DAY_TRADE' | 'SWING_TRADE',
   geminiKeys: string[],
+  marketContext?: string,
 ): Promise<TradeIdea[]> {
   const tickers = pass1.map(e => e.ticker);
   console.log(`[Trade Scanner] Pass 2 (FA-prompt): ${tickers.length} ${mode === 'DAY_TRADE' ? 'day' : 'swing'} candidates...`);
@@ -1799,7 +1802,8 @@ async function runPass2(
   // Sequential processing stays within TPM even under fallback.
   // Day trades still run parallel (Gemini is primary; Groq fallback is rare for day scans).
   const useSequential = mode === 'SWING_TRADE'; // Swing always sequential — safer under any quota
-  const systemPrompt = mode === 'DAY_TRADE' ? DAY_TRADE_SYSTEM : SWING_TRADE_SYSTEM;
+  const baseSystem = mode === 'DAY_TRADE' ? DAY_TRADE_SYSTEM : SWING_TRADE_SYSTEM;
+  const systemPrompt = marketContext ? `${baseSystem}\n\n${marketContext}` : baseSystem;
   const faTemplate = mode === 'DAY_TRADE' ? FA_DAY_USER : FA_SWING_USER;
 
   async function evalTicker(ticker: string): Promise<AIEval | null> {
@@ -2042,6 +2046,44 @@ Deno.serve(async (req) => {
     }
 
     const sb = getSupabase();
+
+    // ── Fetch today's morning brief for macro/sector context ──────────────────
+    // Injected into every Gemini prompt so the AI knows about IPO themes,
+    // sector rotations, and macro tone — not just raw price technicals.
+    let marketContextBlock = '';
+    try {
+      const todayBriefDate = formatDateToEtIso(new Date());
+      const { data: briefRow } = await sb
+        .from('morning_briefs')
+        .select('macro_snapshot, research_themes, top_movers')
+        .eq('brief_date', todayBriefDate)
+        .single();
+
+      if (briefRow) {
+        type ResearchTheme = { theme: string; tickers: string[]; note: string };
+        type TopMover = { ticker: string; direction: string; catalyst: string };
+        const themes = ((briefRow.research_themes as ResearchTheme[]) ?? [])
+          .slice(0, 4)
+          .map(t => `- ${t.theme} (${(t.tickers ?? []).join(', ')}): ${t.note}`)
+          .join('\n');
+        const movers = ((briefRow.top_movers as TopMover[]) ?? [])
+          .slice(0, 5)
+          .map(m => `- ${m.ticker} (${m.direction}): ${m.catalyst}`)
+          .join('\n');
+
+        const parts: string[] = [];
+        if (briefRow.macro_snapshot) parts.push(`MACRO: ${briefRow.macro_snapshot.slice(0, 400)}`);
+        if (themes) parts.push(`KEY THEMES:\n${themes}`);
+        if (movers) parts.push(`TODAY'S MOVERS:\n${movers}`);
+
+        if (parts.length > 0) {
+          marketContextBlock = `--- TODAY'S MARKET CONTEXT ---\n${parts.join('\n\n')}\n---\nFactor this context into your directional bias: boost confidence for setups that align with hot themes/sectors, be skeptical of counter-trend shorts in a risk-on tape.`;
+          console.log('[Trade Scanner] Morning brief context loaded for Gemini');
+        }
+      }
+    } catch (e) {
+      console.warn('[Trade Scanner] Morning brief fetch failed (non-blocking):', String(e));
+    }
 
     // ── Read cached results from DB ──
     const [dayRow, swingRow] = await Promise.all([
@@ -2286,7 +2328,8 @@ Deno.serve(async (req) => {
 
         try {
           // ── Pass 1: Quick scan with lightweight indicators ──
-          const raw = await callGemini(GEMINI_KEYS, DAY_TRADE_SYSTEM, prompt, 0.15, 2000);
+          const daySystem = marketContextBlock ? `${DAY_TRADE_SYSTEM}\n\n${marketContextBlock}` : DAY_TRADE_SYSTEM;
+          const raw = await callGemini(GEMINI_KEYS, daySystem, prompt, 0.15, 2000);
           dayAISucceeded = true;
           const evals: AIEval[] = parseAIJsonArray(raw);
           const quoteMap = new Map(candidates.map(q => [q.symbol, q]));
@@ -2302,7 +2345,7 @@ Deno.serve(async (req) => {
 
           // ── Pass 2: Full shared indicator analysis ──
           if (pass1.length > 0) {
-            const newIdeas = await runPass2(pass1, quoteMap, 'DAY_TRADE', GEMINI_KEYS);
+            const newIdeas = await runPass2(pass1, quoteMap, 'DAY_TRADE', GEMINI_KEYS, marketContextBlock);
             // Merge new ideas with existing — don't overwrite the day's earlier picks
             const existingTickers = new Set(dayIdeas.map(d => d.ticker));
             for (const idea of newIdeas) {
@@ -2326,7 +2369,7 @@ Deno.serve(async (req) => {
       // Runs after the mover scan. Merges key-level ideas into dayIdeas,
       // skipping any tickers already covered by the mover scan above.
       try {
-        const track1Ideas = await runTrack1KeyLevelIdeas(keyLevelSetups, GEMINI_KEYS);
+        const track1Ideas = await runTrack1KeyLevelIdeas(keyLevelSetups, GEMINI_KEYS, marketContextBlock);
         if (track1Ideas.length > 0) {
           const existingTickers = new Set(dayIdeas.map(d => d.ticker));
           for (const idea of track1Ideas) {
@@ -2410,11 +2453,12 @@ Deno.serve(async (req) => {
           // Split into batches of 20 to keep AI JSON output manageable
           const SWING_BATCH = 20;
           const evals: AIEval[] = [];
+          const swingSystem = marketContextBlock ? `${SWING_TRADE_SYSTEM}\n\n${marketContextBlock}` : SWING_TRADE_SYSTEM;
           for (let bi = 0; bi < candidates.length; bi += SWING_BATCH) {
             const batch = candidates.slice(bi, bi + SWING_BATCH);
             const stockData = batch.map((q, i) => formatQuoteForAI(q, bi + i)).join('\n');
             const prompt = SWING_SCAN_USER.replace('{{STOCK_DATA}}', stockData);
-            const raw = await callGemini(GEMINI_KEYS, SWING_TRADE_SYSTEM, prompt, 0.15, 3000);
+            const raw = await callGemini(GEMINI_KEYS, swingSystem, prompt, 0.15, 3000);
             const batchEvals = parseAIJsonArray(raw);
             evals.push(...batchEvals);
           }
@@ -2455,7 +2499,7 @@ Deno.serve(async (req) => {
           // ── Pass 2: Full shared indicator analysis ──
           swingDebugInfo.push(`Pass1→Pass2: ${pass1.map(e => `${e.ticker}:${e.signal}/${e.confidence}`).join(', ') || 'none'}`);
           if (pass1.length > 0) {
-            const newIdeas = await runPass2(pass1, quoteMap, 'SWING_TRADE', GEMINI_KEYS);
+            const newIdeas = await runPass2(pass1, quoteMap, 'SWING_TRADE', GEMINI_KEYS, marketContextBlock);
             swingDebugInfo.push(`Pass2: ${newIdeas.length > 0 ? newIdeas.map(d => `${d.ticker}:${d.signal}/${d.confidence}`).join(', ') : 'all HOLD — no actionable setups in current market'}`);
             // Merge new ideas with existing — don't overwrite earlier picks
             const existingTickers = new Set(swingIdeas.map(d => d.ticker));


### PR DESCRIPTION
## Summary

- **Morning brief enriched**: now fetches IPO calendar (next 14 days via Finnhub) + sector ETF moves (SPY/QQQ/XLK/XLE/XLY etc.) in parallel with news/earnings/econ data
- **News window widened**: 12h → 24h so the premarket brief isn't empty when markets haven't opened yet
- **Empty-news fallback**: if the auto-trader's pre-fetch returns 0 news items, the edge function re-fetches fresh instead of using the empty array
- **LLM prompt strengthened**: always populates `research_themes` and `top_movers` — uses sector ETF moves and IPO proxy stocks even when news is sparse
- **Trade scanner wired to brief**: at the start of each scan run, the scanner reads today's `morning_briefs` record and injects `macro_snapshot` + `research_themes` + `top_movers` into every Gemini system prompt (Track 1, day Pass 1/2, swing Pass 1/2)

## Why

The morning brief was being generated and saved to DB but never used anywhere in trading decisions. The scanner was purely technical (price levels, RSI, VWAP) with zero awareness of macro context, sector rotation, or major catalysts.

With this change, Gemini now knows:
- Today is risk-off (US-Iran tensions) → more skeptical of BUY signals broadly
- Space/aerospace stocks in play (SpaceX IPO June 12) → higher confidence for ASTS/RKLB BUY setups
- Sector ETF flows (XLK leading = tech momentum, XLE leading = energy rally)

## Test plan
- [ ] Morning brief regenerates with IPO + sector data (verified in edge function logs)
- [ ] Trade scanner logs show `Morning brief context loaded for Gemini`
- [ ] Scanner Gemini prompts reflect today's macro tone in directional bias

Made with [Cursor](https://cursor.com)