### PR TITLE
Add IREN, NBIS, MP, PENG to watchlist screener and swing scanner

### DIFF
--- a/auto-trader/src/lib/watchlist-screener.ts
+++ b/auto-trader/src/lib/watchlist-screener.ts
@@ -40,6 +40,8 @@ const CANDIDATE_UNIVERSE = [
   // High-IV Momentum
   'MSTR', 'COIN', 'HOOD', 'SOFI', 'UPST', 'AFRM', 'RIVN', 'LCID', 'NIO', 'XPEV',
   'ARM', 'SMCI', 'DELL', 'HPQ', 'STX', 'WDC', 'MU', 'GFS', 'UMC',
+  // AI infrastructure & strategic materials (2030 growth thesis)
+  'IREN', 'NBIS', 'MP', 'PENG',
   // ETFs with good options liquidity
   'SPY', 'QQQ', 'IWM', 'XLF', 'XLE', 'XLK', 'XLV', 'XLU', 'GLD', 'SLV',
   'EEM', 'FXI', 'KWEB', 'ARKK', 'ARKW', 'TLT', 'HYG', 'LQD',

--- a/supabase/functions/trade-scanner/index.ts
+++ b/supabase/functions/trade-scanner/index.ts
@@ -183,6 +183,8 @@ const SWING_CORE = [
   'CRWD', 'PLTR',
   // LatAm & emerging market growth
   'SE', 'NU', 'MELI',
+  // AI infrastructure & strategic materials (2030 growth thesis)
+  'IREN', 'NBIS', 'MP', 'PENG',
 ];
 
 // Sector ETFs for momentum rotation


### PR DESCRIPTION
## Summary

Researched the 10 influencer-suggested tickers ($IREN $AMZN $TE $MP $NBIS $UUUU $ONDS $OSS $PENG $SOFI) and added the 4 that clear the liquidity/size bar for automated options + swing trading:

| Ticker | Price | Mkt Cap | Beta | Tier | Thesis |
|---|---|---|---|---|---|
| **IREN** | $62 | $22.8B | 4.3 | HIGH_VOL | AI data centers + Bitcoin mining |
| **NBIS** | $222 | $50.7B | 1.0 | GROWTH | Yandex AI spinoff, EU cloud infra |
| **MP** | $64 | $11.9B | 1.9 | HIGH_VOL | Only active US rare earth miner |
| **PENG** | $56 | $2.7B | 2.9 | HIGH_VOL | AI/HPC memory infrastructure |

**Skipped:**
- AMZN, SOFI — already in universe
- UUUU — options spreads too wide (384% IV, near-zero OI)
- ONDS, OSS, TE — too small or too cheap for wheel strategy

## Changes
- `watchlist-screener.ts` — added 4 tickers to `CANDIDATE_UNIVERSE`; tiers auto-assigned from beta via existing `assignTier()` logic
- `trade-scanner/index.ts` — added 4 tickers to `SWING_CORE` so they appear in swing trade ideas immediately

## Deploy
- `trade-scanner` edge function already deployed
- Auto-trader rebuilt and restarted


Made with [Cursor](https://cursor.com)