### PR TITLE
Block swing short entries in bull markets and on oversold stocks

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -3869,9 +3869,59 @@ async function executeScannerTrade(
     log(`${ticker}: confidence sizing — conf ${scannerConf} ${signal} → ${confMultiplier}x cap ($${scannerPositionCap.toFixed(0)})`);
   }
 
+  // ── Swing SELL (short) hard gates ─────────────────────────────────────────
+  // Shorting individual stocks is high-risk in a bull market. Three gates must
+  // ALL pass before a swing SELL executes:
+  //   Gate A: SPY must be BELOW its 50-day SMA (i.e. not a bull market).
+  //           In a bull market the macro bid lifts even weak stocks above stops.
+  //   Gate B: Stock RSI must be ABOVE 35. Shorting an already-oversold stock
+  //           (RSI < 35) is the classic squeeze setup — "a bounce is likely."
+  //   Gate C: Stock must NOT be extended downward (< 12% drop in 10 days).
+  //           Chasing an extended move gives poor risk/reward.
+  // Failure = skip the trade entirely (not just reduce size).
+  if (mode === 'SWING_TRADE' && signal === 'SELL') {
+    try {
+      const spyBars = await fetchYahooDailyBars('SPY');
+      if (spyBars && spyBars.closes.length >= 50) {
+        const closes = spyBars.closes;
+        const price = closes[closes.length - 1];
+        const sma50 = closes.slice(-50).reduce((a: number, b: number) => a + b, 0) / 50;
+        if (price >= sma50) {
+          log(`${ticker}: swing SELL blocked — SPY ($${price.toFixed(2)}) above SMA50 ($${sma50.toFixed(2)}) — bull market, no shorting`);
+          return 'skipped:swing_short_bull_market';
+        }
+      }
+    } catch { /* non-blocking — if we can't check SPY, allow the trade */ }
+
+    try {
+      const rsiData = await finnhubFetch<{ rsi?: number[] }>(
+        `${FINNHUB_BASE}/indicator?symbol=${ticker}&resolution=D&indicator=rsi&timeperiod=14&token=${FINNHUB_KEY}`
+      );
+      const rsiValues = rsiData?.rsi ?? [];
+      const latestRsi = rsiValues[rsiValues.length - 1];
+      if (typeof latestRsi === 'number' && latestRsi < 35) {
+        log(`${ticker}: swing SELL blocked — RSI ${latestRsi.toFixed(1)} < 35 (oversold — bounce risk, not a short candidate)`);
+        return 'skipped:swing_short_oversold';
+      }
+    } catch { /* non-blocking */ }
+
+    try {
+      const stockBars = await fetchYahooDailyBars(ticker);
+      if (stockBars && stockBars.closes.length >= 11) {
+        const closes = stockBars.closes;
+        const today = closes[closes.length - 1];
+        const tenDaysAgo = closes[closes.length - 11];
+        const pctDrop = (tenDaysAgo - today) / tenDaysAgo * 100;
+        if (pctDrop > 12) {
+          log(`${ticker}: swing SELL blocked — stock already down ${pctDrop.toFixed(1)}% in 10 days (extended move, poor risk/reward)`);
+          return 'skipped:swing_short_extended';
+        }
+      }
+    } catch { /* non-blocking */ }
+  }
+
   // SPY regime multiplier for swing BUY: reduce size in bearish macro conditions.
-  // SELL signals (closing longs or shorts) benefit from bearish markets — no reduction.
-  // Non-blocking: defaults to 1.0 on any data failure.
+  // SELL signals handled above with hard gates. Non-blocking: defaults to 1.0 on failure.
   let spyRegimeMult = 1.0;
   if (mode === 'SWING_TRADE' && signal === 'BUY') {
     try {
@@ -3879,8 +3929,8 @@ async function executeScannerTrade(
       if (spyBars && spyBars.closes.length >= 200) {
         const closes = spyBars.closes;
         const price = closes[closes.length - 1];
-        const sma50 = closes.slice(-50).reduce((a, b) => a + b, 0) / 50;
-        const sma200 = closes.slice(-200).reduce((a, b) => a + b, 0) / 200;
+        const sma50 = closes.slice(-50).reduce((a: number, b: number) => a + b, 0) / 50;
+        const sma200 = closes.slice(-200).reduce((a: number, b: number) => a + b, 0) / 200;
         if (price < sma200) {
           spyRegimeMult = 0.4;
           log(`${ticker}: SPY below SMA200 — swing BUY size ×0.4 (bearish regime)`);


### PR DESCRIPTION
## Problem

3 consecutive days of losses last week, almost entirely from swing SELL (short) trades:

| Trade | Context | Loss |
|---|---|---|
| NU short 1160@$12.92 | RSI=26.9, scanner said *"bounce is likely"* | -$255 |
| VFC short 919@$16.31 | Already -18.1% in 10 days (extended move) | -$809 |
| CHWY short 706@$21.33 | No reason logged, full bull market | -$741 |

**Total swing short losses: -$1,805.** Without these, the week was net ~+$440.

The system had a SPY regime multiplier for swing BUYs but **zero gate for swing SELLs**. Short entries executed at full $15K position size regardless of macro conditions.

## Fix — 3 hard gates on swing SELL execution

**Gate A (SPY SMA50):** SPY must be below its 50-day SMA to allow swing shorts. If SPY is in uptrend, macro bid lifts even weak stocks above stops → skip.

**Gate B (RSI):** Stock RSI must be ≥35. Shorting an already-oversold stock (RSI < 35) is the classic squeeze setup. NU's own scanner reason said "a bounce is likely" yet the system shorted it.

**Gate C (Extended move):** Stock must not have dropped >12% in 10 days. Chasing an extended move gives poor risk/reward on entries.

All gates are **non-blocking** (fail-open on data errors) and log the specific block reason.

Made with [Cursor](https://cursor.com)