### PR TITLE
Fix LT profit-taking (mode=off bug) + exclude ghost trades from analytics

### DIFF
--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -296,7 +296,15 @@ export async function getDayTradeValidationReport(): Promise<DayTradeValidationR
   if (error) throw new Error(`Failed to fetch day trades: ${error.message}`);
   const trades = (data ?? []) as PaperTrade[];
 
-  const scannerTrades = trades.filter(t => t.entry_trigger_type === 'bracket_limit' && t.fill_price != null && t.pnl != null);
+  // Exclude zero-P&L ghost trades: positions that technically have a fill_price recorded
+  // but closed with essentially $0 P&L (cancelled before real execution, ACTIVE-status ghosts,
+  // or EOD-closed no-fill orders). These are not real executed trades and skew win rate.
+  const scannerTrades = trades.filter(t =>
+    t.entry_trigger_type === 'bracket_limit' &&
+    t.fill_price != null &&
+    t.pnl != null &&
+    Math.abs(t.pnl) > 0.10
+  );
   const withMarket = scannerTrades.filter(t => t.market_condition);
 
   const trendVsChop = ['trend', 'chop'].map(mc => {

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -6546,10 +6546,15 @@ async function checkProfitTakeOpportunities(
   const trimmedTickers = new Set<string>();
   if (!config.profitTakeEnabled || !config.accountId) return trimmedTickers;
 
+  // Profit-taking must run even when LONG_TERM mode is 'off' (off = no new entries,
+  // NOT "ignore existing positions"). Fall back to paper connection when mode is off.
   let ptConnections: RoutedConnection[];
   try {
     ptConnections = getConnectionForMode('LONG_TERM', config).connections;
-  } catch { return trimmedTickers; }
+  } catch {
+    // Mode is off — still manage existing filled LT positions via paper connection
+    ptConnections = [{ connection: getConnectionForAccount('paper'), accountType: 'paper' }];
+  }
   const ptAcct = ptConnections[0].accountType;
 
   const activeTrades = await getActiveTrades(ptAcct);

--- a/supabase/functions/paper-trading-performance/index.ts
+++ b/supabase/functions/paper-trading-performance/index.ts
@@ -208,8 +208,15 @@ Deno.serve(async (req) => {
 
     const trades = (tradesData ?? []) as PaperTradeRow[];
 
-    // Exclude dip-buy add-ons (same as trade_performance_log)
-    const filteredTrades = trades.filter(t => !(t.notes ?? '').startsWith('Dip buy'));
+    // Exclude dip-buy add-ons (same as trade_performance_log).
+    // Also exclude zero-P&L ghost trades — positions that have a fill_price recorded but closed
+    // with essentially $0 P&L (cancelled before real execution, ACTIVE-status ghosts,
+    // or EOD-closed no-fill orders from May 13-15 bug). These inflate trade count and
+    // drag down win rate without representing actual executed trades.
+    const filteredTrades = trades.filter(t =>
+      !(t.notes ?? '').startsWith('Dip buy') &&
+      Math.abs(t.pnl ?? 0) > 0.10
+    );
 
     // Equity trades: standard P&L = (exit - entry) × qty
     const equityTrades = filteredTrades.filter(t =>


### PR DESCRIPTION
## Bug 1: LT profit-taking silently disabled when mode=off

`checkProfitTakeOpportunities` called `getConnectionForMode('LONG_TERM', config)` which **throws** when `mode_routing.LONG_TERM = 'off'`. The catch block returned early — so profit-taking never ran.

**Root cause:** `off` should mean "don't open new positions." It was incorrectly blocking management of existing ones too.

**Fix:** Catch the throw, fall back to paper connection. Profit-take tiers (8%/15%/25%) now fire regardless of whether new LT entries are enabled.

**Positions that were never trimmed:** CSCO +46%, MU +28%, AMAT +20%, ENPH +23%

## Bug 2: Zero-P&L ghost trades counted as losses in analytics

26 trades from the May 13-15 ACTIVE-status bug had `fill_price` set but `pnl ≈ $0`. These were being counted as losses in:
- System Learning win rate diagnostics (AI trades appeared as 25% WR instead of actual 54%)
- Performance tab trade counts and win rates

**Fix:** Added `Math.abs(pnl) > 0.10` filter in both `paperTradesApi.ts` and `paper-trading-performance/index.ts`.

Made with [Cursor](https://cursor.com)