### PR TITLE
feat: show mode + source in Open Orders panel

### DIFF
--- a/app/src/components/PaperTrading/index.tsx
+++ b/app/src/components/PaperTrading/index.tsx
@@ -65,6 +65,8 @@ import {
   getDayTradeValidationReport,
   getSwingTradeValidationReport,
   clearSharedTradesCache,
+  getOrderTradeContext,
+  type OrderTradeContext,
 } from '../../lib/paperTradesApi';
 import { getTotalDeployed, getMarketRegime, calculateKellyMultiplier, type MarketRegime } from '../../lib/autoTrader';
 import { useAccountView, type AccountView } from '../../contexts/AccountContext';
@@ -147,6 +149,7 @@ export function PaperTrading() {
   const [performance, setPerformance] = useState<TradePerformance | null>(cached?.performance ?? null);
   const [ibPositions, setIbPositions] = useState<IBPosition[]>(cached?.ibPositions ?? []);
   const [ibOrders, setIbOrders] = useState<IBLiveOrder[]>(cached?.ibOrders ?? []);
+  const [orderTradeContext, setOrderTradeContext] = useState<Map<number, OrderTradeContext>>(new Map());
   const [persistedEvents, setPersistedEvents] = useState<AutoTradeEventRecord[]>(cached?.persistedEvents ?? []);
   const [todaysExecuted, setTodaysExecuted] = useState<AutoTradeEventRecord[]>(cached?.todaysExecuted ?? []);
   const [todayTrades, setTodayTrades] = useState<PaperTrade[]>(cached?.todayTrades ?? []);
@@ -218,14 +221,16 @@ export function PaperTrading() {
   const loadIBData = useCallback(async () => {
     if (!connected) return;
     try {
-      const [positions, orders, pnl] = await Promise.all([
+      const [positions, orders, pnl, tradeCtx] = await Promise.all([
         getPositions(config.accountId ?? ''),
         getLiveOrders(),
         getAccountPnL(),
+        getOrderTradeContext(),
       ]);
       setIbPositions(positions);
       setIbOrders(orders);
       setIbAccountPnl(pnl);
+      setOrderTradeContext(tradeCtx);
     } catch (err) {
       console.error('Failed to load IB data:', err);
     }
@@ -679,6 +684,7 @@ export function PaperTrading() {
             <PortfolioTab
               positions={ibPositions}
               orders={ibOrders}
+              orderTradeContext={orderTradeContext}
               pendingSignals={pendingSignals}
               connected={connected}
               onRefresh={loadIBData}

--- a/app/src/components/PaperTrading/tabs/PortfolioTab.tsx
+++ b/app/src/components/PaperTrading/tabs/PortfolioTab.tsx
@@ -10,7 +10,7 @@ import {
   AlertTriangle,
 } from 'lucide-react';
 import type { IBPosition, IBLiveOrder } from '../../../lib/ibClient';
-import type { PendingStrategySignal } from '../../../lib/paperTradesApi';
+import type { PendingStrategySignal, OrderTradeContext } from '../../../lib/paperTradesApi';
 import type { AccountView } from '../../../contexts/AccountContext';
 import { fmtUsd } from '../utils';
 import { StatusBadge } from '../shared';
@@ -35,16 +35,41 @@ function getPortfolioSortValue(pos: IBPosition, key: PortfolioSortKey): number |
   }
 }
 
+const MODE_LABELS: Record<string, string> = {
+  DAY_TRADE: 'Day',
+  SWING_TRADE: 'Swing',
+  OPTIONS_SCALP: 'Scalp',
+  OPTIONS_PUT: 'Put',
+  OPTIONS_CALL: 'Call',
+  CREDIT_SPREAD: 'Spread',
+  LONG_TERM: 'Long Term',
+  DAY_PENNY: 'Penny',
+};
+
+function getSourceLabel(ctx: OrderTradeContext): string {
+  const reason = ctx.scanner_reason ?? '';
+  if (reason.includes('External strategy signal')) {
+    const match = reason.match(/from ([^|]+)/);
+    return match ? match[1].trim() : 'External';
+  }
+  const trigger = ctx.entry_trigger_type ?? '';
+  if (trigger === 'dip_buy') return 'Dip Buy';
+  if (trigger === 'loss_cut') return 'Loss Cut';
+  if (trigger === 'profit_take') return 'Profit Take';
+  return 'Auto';
+}
+
 export interface PortfolioTabProps {
   positions: IBPosition[];
   orders: IBLiveOrder[];
+  orderTradeContext?: Map<number, OrderTradeContext>;
   pendingSignals: PendingStrategySignal[];
   connected: boolean;
   onRefresh: () => void;
   accountView?: AccountView;
 }
 
-export function PortfolioTab({ positions, orders, pendingSignals, connected, onRefresh, accountView: _accountView }: PortfolioTabProps) {
+export function PortfolioTab({ positions, orders, orderTradeContext, pendingSignals, connected, onRefresh, accountView: _accountView }: PortfolioTabProps) {
   const [sortKey, setSortKey] = useState<PortfolioSortKey>('costBasis');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
 
@@ -202,6 +227,7 @@ export function PortfolioTab({ positions, orders, pendingSignals, connected, onR
                 <th className="text-left px-4 py-2.5 font-medium">Side</th>
                 <th className="text-right px-4 py-2.5 font-medium">Qty</th>
                 <th className="px-4 py-2.5 font-medium">Protection</th>
+                <th className="text-left px-4 py-2.5 font-medium">Source</th>
                 <th className="text-left px-4 py-2.5 font-medium">Status</th>
               </tr>
             </thead>
@@ -225,6 +251,25 @@ export function PortfolioTab({ positions, orders, pendingSignals, connected, onR
                 }
 
                 const rows: React.ReactNode[] = [];
+
+                const ctx = orderTradeContext ?? new Map<number, OrderTradeContext>();
+
+                const SourceCell = ({ orderId, parentId }: { orderId: number; parentId?: number }) => {
+                  const trade = ctx.get(parentId ?? orderId) ?? ctx.get(orderId);
+                  if (!trade) return <td className="px-4 py-3" />;
+                  const modeLabel = MODE_LABELS[trade.mode] ?? trade.mode;
+                  const sourceLabel = getSourceLabel(trade);
+                  return (
+                    <td className="px-4 py-3">
+                      <div className="flex flex-col gap-0.5">
+                        <span className="inline-flex w-fit px-1.5 py-0.5 rounded text-[10px] font-semibold bg-violet-50 text-violet-700">
+                          {modeLabel}
+                        </span>
+                        <span className="text-[10px] text-[hsl(var(--muted-foreground))]">{sourceLabel}</span>
+                      </div>
+                    </td>
+                  );
+                };
 
                 // Bracket pairs — one row per bracket
                 bracketMap.forEach((group, parentId) => {
@@ -256,6 +301,7 @@ export function PortfolioTab({ positions, orders, pendingSignals, connected, onR
                             </span>
                           </div>
                         </td>
+                        <SourceCell orderId={representative.orderId} parentId={parentId} />
                         <td className="px-4 py-3">
                           <span className={`inline-flex px-2 py-0.5 rounded text-[10px] font-bold ${
                             statusOrder === 'Filled' ? 'bg-emerald-100 text-emerald-700'
@@ -300,6 +346,7 @@ export function PortfolioTab({ positions, orders, pendingSignals, connected, onR
                           </span>
                         )}
                       </td>
+                      <SourceCell orderId={order.orderId} parentId={order.parentId} />
                       <td className="px-4 py-3">
                         <span className={`inline-flex px-2 py-0.5 rounded text-[10px] font-bold ${
                           order.status === 'Filled' ? 'bg-emerald-100 text-emerald-700'

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -1877,6 +1877,41 @@ export async function getStrategyTuneLogs(limit = 10): Promise<TuneLogEntry[]> {
   return (data ?? []) as TuneLogEntry[];
 }
 
+// ── Order trade context ────────────────────────────────────────────────────
+// Lightweight record used to enrich IB Open Orders with mode + source info.
+export interface OrderTradeContext {
+  mode: string;
+  scanner_reason: string | null;
+  entry_trigger_type: string | null;
+  notes: string | null;
+}
+
+/**
+ * Returns a map of IB order ID → trade context for all active/submitted trades.
+ * Used by the Open Orders panel to show mode and source without a full trade fetch.
+ */
+export async function getOrderTradeContext(): Promise<Map<number, OrderTradeContext>> {
+  const { data } = await supabase
+    .from('paper_trades')
+    .select('ib_order_id, mode, scanner_reason, entry_trigger_type, notes')
+    .in('status', ['ACTIVE', 'SUBMITTED', 'FILLED'])
+    .not('ib_order_id', 'is', null);
+
+  const map = new Map<number, OrderTradeContext>();
+  for (const row of data ?? []) {
+    const id = Number(row.ib_order_id);
+    if (!isNaN(id)) {
+      map.set(id, {
+        mode: row.mode ?? '',
+        scanner_reason: row.scanner_reason ?? null,
+        entry_trigger_type: row.entry_trigger_type ?? null,
+        notes: row.notes ?? null,
+      });
+    }
+  }
+  return map;
+}
+
 export async function triggerAutoTune(): Promise<{ ok: boolean; decisionsCount: number; decisions: TuneDecision[]; error?: string }> {
   const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
   const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;


### PR DESCRIPTION
## Summary
- Open Orders table had no context about what kind of trade each order belonged to
- Added a **Source** column that cross-references `paper_trades` via `ib_order_id`
- Shows mode badge (Day / Swing / Put / Spread / Long Term) + origin label (Somesh / Auto / Dip Buy / etc.)
- Bracket child rows look up their parent's order ID for context
- Zero performance impact — single lightweight DB fetch alongside the existing IB data load

## Test plan
- [ ] IB Portfolio tab → Open Orders shows Source column with mode + origin for each row
- [ ] FCX bracket rows show "Swing · Auto"
- [ ] TSLA bracket shows "Day · Somesh"
- [ ] Options puts (ORCL, EW, GOOGL, VIK, ADI) show "Put · Auto"

Made with [Cursor](https://cursor.com)