### PR TITLE
feat: nightly ORB pre-session scanner with morning execution

### DIFF
--- a/app/src/components/TradeIdeas.tsx
+++ b/app/src/components/TradeIdeas.tsx
@@ -16,6 +16,7 @@ import {
   ArrowDownRight,
   Ban,
   Coins,
+  SunMedium,
 } from 'lucide-react';
 import { cn } from '../lib/utils';
 import {
@@ -29,7 +30,7 @@ import {
   type ScanEvaluations,
 } from '../lib/tradeScannerApi';
 import { getAutoTraderConfig } from '../lib/autoTrader';
-import { getActiveTrades, getAllTrades } from '../lib/paperTradesApi';
+import { getActiveTrades, getAllTrades, getTonightsPresessionSetups, getTodaysPresessionSetups, type PresessionSetup } from '../lib/paperTradesApi';
 import { Spinner } from './Spinner';
 
 // ── Market hours ─────────────────────────────────────────
@@ -113,7 +114,7 @@ interface TradeIdeasProps {
   onSelectTicker: (ticker: string, mode: 'DAY_TRADE' | 'SWING_TRADE' | 'DAY_PENNY') => void;
 }
 
-type Tab = 'day' | 'swing' | 'penny' | 'gameplan';
+type Tab = 'day' | 'swing' | 'penny' | 'gameplan' | 'orb';
 
 function formatScanAge(ts: number): string {
   const diffMs = Date.now() - ts;
@@ -136,6 +137,7 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
   const [tradedTickers, setTradedTickers] = useState<Set<string>>(new Set());
   const [evaluations, setEvaluations] = useState<ScanEvaluations>({});
   const [pennyTrades, setPennyTrades] = useState<TradeIdea[]>([]);
+  const [orbSetups, setOrbSetups] = useState<PresessionSetup[]>([]);
   const [marketOpen, setMarketOpen] = useState(() => isMarketHoursWindow());
 
   // Re-check market hours every minute so the badge updates as windows open/close.
@@ -178,6 +180,28 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
     const interval = setInterval(() => {
       fetchScanEvaluations().then(setEvaluations).catch(() => {});
     }, 2 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Load ORB pre-session setups. During market hours (before 10:30 AM), show today's
+  // setups with live status (PENDING/TRIGGERED/EXPIRED). After 10:30 AM or pre-market,
+  // show tomorrow's nightly setups so the user can review what the scanner planned.
+  useEffect(() => {
+    const loadOrb = async () => {
+      try {
+        const nowET = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
+        const etMinutes = nowET.getHours() * 60 + nowET.getMinutes();
+        // Show today's setups during ORB window (9:30–10:30 AM)
+        if (etMinutes >= 9 * 60 + 30 && etMinutes < 10 * 60 + 30) {
+          const today = await getTodaysPresessionSetups();
+          if (today.length > 0) { setOrbSetups(today); return; }
+        }
+        // Otherwise show tonight's (next trading day's) setups
+        setOrbSetups(await getTonightsPresessionSetups());
+      } catch { /* silent */ }
+    };
+    loadOrb();
+    const interval = setInterval(loadOrb, 2 * 60 * 1000);
     return () => clearInterval(interval);
   }, []);
 
@@ -465,10 +489,31 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
                 </span>
               )}
             </button>
+            <button
+              type="button"
+              onClick={() => setTab('orb')}
+              className={cn(
+                'flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-all',
+                tab === 'orb'
+                  ? 'bg-orange-50 text-orange-700 border border-orange-200 shadow-sm'
+                  : 'text-[hsl(var(--muted-foreground))] hover:bg-[hsl(var(--secondary))]'
+              )}
+            >
+              <SunMedium className="w-3.5 h-3.5" />
+              ORB
+              {orbSetups.length > 0 && (
+                <span className={cn(
+                  'ml-0.5 text-[10px] px-1.5 rounded-full font-semibold',
+                  tab === 'orb' ? 'bg-orange-200/70 text-orange-700' : 'bg-[hsl(var(--secondary))] text-[hsl(var(--muted-foreground))]'
+                )}>
+                  {orbSetups.length}
+                </span>
+              )}
+            </button>
           </div>
 
           {/* Banner */}
-          {tab !== 'gameplan' && (
+          {tab !== 'gameplan' && tab !== 'orb' && (
             <div className="mx-4 mt-2.5 flex items-start gap-2 rounded-lg bg-amber-50 border border-amber-200/70 px-3 py-2">
               <AlertTriangle className="w-3.5 h-3.5 text-amber-500 mt-0.5 flex-shrink-0" />
               <p className="text-[11px] leading-snug text-amber-700">
@@ -483,6 +528,15 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
               <p className="text-[11px] leading-snug text-violet-700">
                 Pure price structure — no AI bias. Both sides pre-planned from prev-day high/low, SMAs, and round numbers.
                 <span className="font-semibold"> Let price pick a side.</span>
+              </p>
+            </div>
+          )}
+          {tab === 'orb' && (
+            <div className="mx-4 mt-2.5 flex items-start gap-2 rounded-lg bg-orange-50 border border-orange-200/70 px-3 py-2">
+              <SunMedium className="w-3.5 h-3.5 text-orange-500 mt-0.5 flex-shrink-0" />
+              <p className="text-[11px] leading-snug text-orange-700">
+                Nightly ORB brackets from prior-day high/low. Executes 9:35–10:30 AM when price breaks the level
+                <span className="font-semibold"> with RVOL ≥ 1.2×.</span>
               </p>
             </div>
           )}
@@ -501,7 +555,7 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
             )}
 
             {/* Day / Swing tab content */}
-            {tab !== 'gameplan' && (
+            {tab !== 'gameplan' && tab !== 'orb' && (
               <>
                 {ideas.length === 0 && !loading && !error && (data || tab === 'penny') && (
                   <div className="flex flex-col items-center py-6 gap-2 text-center">
@@ -558,6 +612,90 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
                         onSelect={() => onSelectTicker(setup.ticker, 'DAY_TRADE')}
                       />
                     ))}
+                  </div>
+                )}
+              </>
+            )}
+
+            {/* ORB Pre-session setups tab */}
+            {tab === 'orb' && (
+              <>
+                {orbSetups.length === 0 && (
+                  <div className="flex flex-col items-center py-6 gap-2 text-center">
+                    <SunMedium className="w-8 h-8 text-[hsl(var(--muted-foreground))] opacity-40" />
+                    <p className="text-sm text-[hsl(var(--muted-foreground))]">
+                      No ORB setups yet.
+                    </p>
+                    <p className="text-xs text-[hsl(var(--muted-foreground))] opacity-70">
+                      The nightly scan runs at 4:25 PM ET — check back after market close.
+                    </p>
+                  </div>
+                )}
+                {orbSetups.length > 0 && (
+                  <div className="overflow-x-auto -mx-1">
+                    <table className="w-full text-[11px]">
+                      <thead>
+                        <tr className="text-[hsl(var(--muted-foreground))] border-b border-[hsl(var(--border))]">
+                          <th className="text-left py-1.5 px-2 font-medium">Ticker</th>
+                          <th className="text-left py-1.5 px-2 font-medium">Signal</th>
+                          <th className="text-right py-1.5 px-2 font-medium">Trigger</th>
+                          <th className="text-right py-1.5 px-2 font-medium">Stop</th>
+                          <th className="text-right py-1.5 px-2 font-medium">T1</th>
+                          <th className="text-right py-1.5 px-2 font-medium">T2</th>
+                          <th className="text-right py-1.5 px-2 font-medium">RVOL</th>
+                          <th className="text-left py-1.5 px-2 font-medium">Trend</th>
+                          <th className="text-left py-1.5 px-2 font-medium">Status</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-[hsl(var(--border))]/50">
+                        {orbSetups.map((s) => {
+                          const statusColor =
+                            s.status === 'TRIGGERED' ? 'text-emerald-600 bg-emerald-50' :
+                            s.status === 'EXPIRED'   ? 'text-[hsl(var(--muted-foreground))] bg-[hsl(var(--secondary))]' :
+                            s.status === 'SKIPPED'   ? 'text-amber-600 bg-amber-50' :
+                            'text-blue-600 bg-blue-50'; // PENDING
+                          const trendColor =
+                            s.trend_4h === 'up'   ? 'text-emerald-600' :
+                            s.trend_4h === 'down' ? 'text-red-500' : 'text-[hsl(var(--muted-foreground))]';
+                          return (
+                            <tr
+                              key={`${s.ticker}-${s.signal}`}
+                              className="hover:bg-[hsl(var(--secondary))]/40 cursor-pointer"
+                              onClick={() => onSelectTicker(s.ticker, 'DAY_TRADE')}
+                            >
+                              <td className="py-2 px-2 font-bold text-[hsl(var(--foreground))]">{s.ticker}</td>
+                              <td className="py-2 px-2">
+                                <span className={cn(
+                                  'inline-flex px-1.5 py-0.5 rounded text-[10px] font-bold',
+                                  s.signal === 'BUY'
+                                    ? 'bg-emerald-100 text-emerald-700'
+                                    : 'bg-red-100 text-red-700'
+                                )}>
+                                  {s.signal}
+                                </span>
+                              </td>
+                              <td className="py-2 px-2 text-right tabular-nums font-medium">${s.trigger_price.toFixed(2)}</td>
+                              <td className="py-2 px-2 text-right tabular-nums text-red-500">${s.stop_loss.toFixed(2)}</td>
+                              <td className="py-2 px-2 text-right tabular-nums text-emerald-600">${s.take_profit1.toFixed(2)}</td>
+                              <td className="py-2 px-2 text-right tabular-nums text-emerald-600 opacity-70">
+                                {s.take_profit2 ? `$${s.take_profit2.toFixed(2)}` : '—'}
+                              </td>
+                              <td className="py-2 px-2 text-right tabular-nums">
+                                {s.rvol != null ? `${s.rvol.toFixed(1)}×` : '—'}
+                              </td>
+                              <td className={cn('py-2 px-2 font-medium', trendColor)}>
+                                {s.trend_4h ?? '—'}
+                              </td>
+                              <td className="py-2 px-2">
+                                <span className={cn('inline-flex px-1.5 py-0.5 rounded text-[10px] font-semibold', statusColor)}>
+                                  {s.status}
+                                </span>
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
                   </div>
                 )}
               </>

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -1941,3 +1941,61 @@ export async function triggerAutoTune(): Promise<{ ok: boolean; decisionsCount: 
   if (!res.ok) return { ok: false, decisionsCount: 0, decisions: [], error: data?.error ?? `HTTP ${res.status}` };
   return data as { ok: boolean; decisionsCount: number; decisions: TuneDecision[] };
 }
+
+// ── Pre-session ORB setups ──────────────────────────────────────────────────
+
+export interface PresessionSetup {
+  id: string;
+  ticker: string;
+  trade_date: string;
+  signal: 'BUY' | 'SELL';
+  trigger_price: number;
+  stop_loss: number;
+  take_profit1: number;
+  take_profit2: number | null;
+  prior_day_high: number;
+  prior_day_low: number;
+  prior_day_close: number;
+  avg_volume_10d: number | null;
+  rvol: number | null;
+  trend_4h: string | null;
+  atr: number;
+  reason: string;
+  status: 'PENDING' | 'TRIGGERED' | 'EXPIRED' | 'SKIPPED';
+  triggered_at: string | null;
+  created_at: string;
+}
+
+/** Fetch tonight's (next trading day's) ORB pre-session setups */
+export async function getTonightsPresessionSetups(): Promise<PresessionSetup[]> {
+  // Compute next trading date from ET perspective
+  const nowET = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
+  const d = new Date(nowET);
+  // If before 4 PM, "tonight" = today's setups; after 4 PM = tomorrow
+  if (nowET.getHours() >= 16) d.setDate(d.getDate() + 1);
+  while (d.getDay() === 0 || d.getDay() === 6) d.setDate(d.getDate() + 1);
+  const targetDate = d.toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+
+  const { data, error } = await supabase
+    .from('pre_session_setups')
+    .select('*')
+    .eq('trade_date', targetDate)
+    .order('ticker');
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as PresessionSetup[];
+}
+
+/** Fetch today's ORB setups (for morning tracking) */
+export async function getTodaysPresessionSetups(): Promise<PresessionSetup[]> {
+  const todayET = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+  const { data, error } = await supabase
+    .from('pre_session_setups')
+    .select('*')
+    .eq('trade_date', todayET)
+    .order('status', { ascending: true })  // PENDING first
+    .order('ticker');
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as PresessionSetup[];
+}

--- a/auto-trader/src/lib/presession-scan.ts
+++ b/auto-trader/src/lib/presession-scan.ts
@@ -1,0 +1,347 @@
+/**
+ * Pre-Session ORB (Opening Range Breakout) Scanner
+ *
+ * Runs nightly after market close (~4:15 PM ET). For each ticker in the
+ * universe, computes key levels from the prior day's price action and stores
+ * conditional bracket setups for the next trading day:
+ *
+ *   BUY  if price breaks ABOVE prior day high + buffer → with-trend momentum
+ *   SELL if price breaks BELOW prior day low  - buffer → with-trend breakdown
+ *
+ * Inspired by Somesh's nightly bracket approach: levels are defined from prior
+ * day structure, not from intraday RSI/MACD noise.
+ *
+ * At market open, checkPresessionTriggers() polls every 2 min (9:30–10:30 AM).
+ * A setup only executes when:
+ *   1. Price crosses the trigger level
+ *   2. RVOL >= 1.2x (institutional volume confirmation)
+ *   3. 4H trend aligns with signal direction
+ */
+
+import { fetchDailyBars, fetchQuote } from './yahoo-finance.js';
+import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
+import { getSupabase } from './supabase.js';
+import { checkTrendFilter } from './trend-filter.js';
+
+const LOG_PREFIX = '[PresessionScan]';
+const log = (...args: unknown[]) => console.log(LOG_PREFIX, ...args);
+
+// Liquid day-trade universe — high volume, institutionally traded
+const ORB_UNIVERSE = [
+  'AAPL', 'MSFT', 'NVDA', 'AMZN', 'GOOGL', 'META', 'TSLA', 'AMD',
+  'PLTR', 'NFLX', 'COIN', 'ARM', 'AVGO', 'CRM', 'UBER', 'SHOP',
+  'MU', 'PYPL', 'SMH', 'QQQ', 'SPY', 'RKLB', 'HOOD', 'APP',
+  'SNOW', 'PANW', 'NOW', 'DOCU', 'AMAT', 'ASML',
+];
+
+// Minimum prior-day RVOL to be worth scanning (avoids dead stocks)
+const MIN_PRIOR_RVOL = 0.8;
+
+// Breakout buffer: price must clear prior high/low by this % to avoid false breaks
+const BREAKOUT_BUFFER_PCT = 0.002; // 0.2%
+
+// Risk:Reward targets
+const RR_T1 = 2.0;  // T1 = 1:2
+const RR_T2 = 3.0;  // T2 = 1:3
+
+// RVOL gate applied at execution time (not scan time)
+export const MIN_EXEC_RVOL = 1.2;
+
+// Only scan tickers with prior day price range >= this %
+const MIN_DAY_RANGE_PCT = 0.008; // 0.8%
+
+interface PresessionSetup {
+  ticker: string;
+  trade_date: string;
+  signal: 'BUY' | 'SELL';
+  trigger_price: number;
+  stop_loss: number;
+  take_profit1: number;
+  take_profit2: number;
+  prior_day_high: number;
+  prior_day_low: number;
+  prior_day_close: number;
+  prior_day_volume: number;
+  avg_volume_10d: number | null;
+  rvol: number | null;
+  trend_4h: string | null;
+  ema100_4h: number | null;
+  atr: number;
+  reason: string;
+}
+
+/** Fetch 10-day average volume from Finnhub metrics */
+async function fetch10dAvgVolume(ticker: string): Promise<number | null> {
+  if (!FINNHUB_KEY) return null;
+  try {
+    const data = await finnhubFetch<{ metric?: { '10DayAverageTradingVolume'?: number } }>(
+      `https://finnhub.io/api/v1/stock/metric?symbol=${ticker}&metric=all&token=${FINNHUB_KEY}`
+    );
+    const avg = data?.metric?.['10DayAverageTradingVolume'];
+    return avg ? avg * 1_000_000 : null;
+  } catch { return null; }
+}
+
+/** Compute ATR from last 14 daily bars */
+function computeAtr(bars: { high: number; low: number; close: number }[]): number {
+  if (bars.length < 2) return 0;
+  const last14 = bars.slice(-15);
+  const trs: number[] = [];
+  for (let i = 1; i < last14.length; i++) {
+    const prev = last14[i - 1];
+    const cur = last14[i];
+    trs.push(Math.max(
+      cur.high - cur.low,
+      Math.abs(cur.high - prev.close),
+      Math.abs(cur.low  - prev.close),
+    ));
+  }
+  return trs.reduce((a, b) => a + b, 0) / trs.length;
+}
+
+/** Next trading date string (YYYY-MM-DD) in ET — avoids toISOString() UTC drift */
+function nextTradingDate(): string {
+  const todayET = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+  const [y, m, d] = todayET.split('-').map(Number);
+  // Build a pure local-time Date (no timezone offset) so getDay() is reliable
+  const date = new Date(y, m - 1, d + 1);
+  while (date.getDay() === 0 || date.getDay() === 6) date.setDate(date.getDate() + 1);
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, '0'),
+    String(date.getDate()).padStart(2, '0'),
+  ].join('-');
+}
+
+/**
+ * Nightly scan — runs at ~4:15 PM ET after market close.
+ * Generates ORB bracket setups for tomorrow and upserts into pre_session_setups.
+ */
+export async function runNightlyPresessionScan(): Promise<void> {
+  const tradeDate = nextTradingDate();
+  log(`Starting nightly ORB scan for ${tradeDate} — ${ORB_UNIVERSE.length} tickers`);
+
+  const sb = getSupabase();
+  const setups: PresessionSetup[] = [];
+  const BATCH = 5;
+
+  for (let i = 0; i < ORB_UNIVERSE.length; i += BATCH) {
+    const batch = ORB_UNIVERSE.slice(i, i + BATCH);
+    await Promise.all(batch.map(async (ticker) => {
+      try {
+        // ── 1. Fetch prior day bars ──────────────────────────────────────
+        const bars = await fetchDailyBars(ticker, '3mo');
+        if (!bars || bars.length < 15) {
+          log(`  ${ticker}: skip — insufficient bars`);
+          return;
+        }
+
+        const prev = bars[bars.length - 1]; // most recent completed day
+        const { high: pdh, low: pdl, close: pdc, volume: pdv } = prev;
+
+        // Day range filter — skip flat / illiquid days
+        const dayRangePct = (pdh - pdl) / pdc;
+        if (dayRangePct < MIN_DAY_RANGE_PCT) {
+          log(`  ${ticker}: skip — day range too small (${(dayRangePct * 100).toFixed(2)}%)`);
+          return;
+        }
+
+        // ── 2. Volume / RVOL ────────────────────────────────────────────
+        const avg10d = await fetch10dAvgVolume(ticker);
+        const rvol = avg10d && avg10d > 0 ? pdv / avg10d : null;
+        if (rvol !== null && rvol < MIN_PRIOR_RVOL) {
+          log(`  ${ticker}: skip — low prior RVOL (${rvol.toFixed(2)}x)`);
+          return;
+        }
+
+        // ── 3. ATR ──────────────────────────────────────────────────────
+        const atr = computeAtr(bars);
+        if (atr <= 0) return;
+
+        // ── 4. 4H trend ─────────────────────────────────────────────────
+        const [buyTrend, sellTrend] = await Promise.all([
+          checkTrendFilter(ticker, 'BUY').catch(() => ({ pass: false, ema100: null })),
+          checkTrendFilter(ticker, 'SELL').catch(() => ({ pass: false, ema100: null })),
+        ]);
+        const trend4h = buyTrend.pass ? 'up' : sellTrend.pass ? 'down' : 'neutral';
+        const ema100_4h = (buyTrend as { ema100?: number | null }).ema100
+          ?? (sellTrend as { ema100?: number | null }).ema100
+          ?? null;
+
+        // ── 5. Generate setups ───────────────────────────────────────────
+        const buffer = pdc * BREAKOUT_BUFFER_PCT;
+
+        // BUY setup: price breaks above prior day high (bullish ORB)
+        if (trend4h !== 'down') {
+          const trigger = pdh + buffer;
+          const stop    = pdh - atr * 0.8;   // stop just below prior day high
+          const risk    = trigger - stop;
+          if (risk > 0) {
+            setups.push({
+              ticker, trade_date: tradeDate, signal: 'BUY',
+              trigger_price:  Math.round(trigger * 100) / 100,
+              stop_loss:      Math.round(stop * 100) / 100,
+              take_profit1:   Math.round((trigger + risk * RR_T1) * 100) / 100,
+              take_profit2:   Math.round((trigger + risk * RR_T2) * 100) / 100,
+              prior_day_high: pdh, prior_day_low: pdl, prior_day_close: pdc,
+              prior_day_volume: pdv, avg_volume_10d: avg10d, rvol,
+              trend_4h: trend4h, ema100_4h, atr: Math.round(atr * 100) / 100,
+              reason: `ORB BUY: break above prior day high $${pdh.toFixed(2)} | ATR $${atr.toFixed(2)} | trend: ${trend4h} | RVOL: ${rvol?.toFixed(2) ?? 'n/a'}x`,
+            });
+          }
+        }
+
+        // SELL setup: price breaks below prior day low (bearish ORB)
+        if (trend4h !== 'up') {
+          const trigger = pdl - buffer;
+          const stop    = pdl + atr * 0.8;   // stop just above prior day low
+          const risk    = stop - trigger;
+          if (risk > 0) {
+            setups.push({
+              ticker, trade_date: tradeDate, signal: 'SELL',
+              trigger_price:  Math.round(trigger * 100) / 100,
+              stop_loss:      Math.round(stop * 100) / 100,
+              take_profit1:   Math.round((trigger - risk * RR_T1) * 100) / 100,
+              take_profit2:   Math.round((trigger - risk * RR_T2) * 100) / 100,
+              prior_day_high: pdh, prior_day_low: pdl, prior_day_close: pdc,
+              prior_day_volume: pdv, avg_volume_10d: avg10d, rvol,
+              trend_4h: trend4h, ema100_4h, atr: Math.round(atr * 100) / 100,
+              reason: `ORB SELL: break below prior day low $${pdl.toFixed(2)} | ATR $${atr.toFixed(2)} | trend: ${trend4h} | RVOL: ${rvol?.toFixed(2) ?? 'n/a'}x`,
+            });
+          }
+        }
+
+        log(`  ${ticker}: ✓ ${trend4h} | PDH $${pdh.toFixed(2)} PDL $${pdl.toFixed(2)} | RVOL ${rvol?.toFixed(2) ?? 'n/a'}x`);
+      } catch (err) {
+        log(`  ${ticker}: error — ${err}`);
+      }
+    }));
+
+    if (i + BATCH < ORB_UNIVERSE.length) await new Promise(r => setTimeout(r, 500));
+  }
+
+  if (setups.length === 0) {
+    log('No setups generated — nothing to upsert');
+    return;
+  }
+
+  // Insert setups; ignore conflicts so a re-run never overwrites TRIGGERED/EXPIRED rows.
+  const { error } = await sb
+    .from('pre_session_setups')
+    .upsert(setups, { onConflict: 'ticker,trade_date,signal', ignoreDuplicates: true });
+
+  if (error) {
+    log(`ERROR upserting setups: ${error.message}`);
+  } else {
+    log(`✓ Upserted ${setups.length} ORB setups for ${tradeDate}`);
+  }
+}
+
+export interface OrbTrigger {
+  setupId:      string;
+  ticker:       string;
+  signal:       'BUY' | 'SELL';
+  price:        number;   // live price at trigger time
+  stopLoss:     number;
+  takeProfit1:  number;
+  takeProfit2:  number | null;
+  liveRvol:     number | null;
+  reason:       string;
+}
+
+/**
+ * Morning trigger checker — runs every 2 min from 9:30–10:30 AM ET.
+ * Returns setups whose price + RVOL conditions are met. Caller (scheduler)
+ * handles execution via executeScannerTrade() to avoid circular imports.
+ */
+export async function checkPresessionTriggers(): Promise<OrbTrigger[]> {
+  const sb = getSupabase();
+  const todayET = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+
+  const { data: setups, error } = await sb
+    .from('pre_session_setups')
+    .select('*')
+    .eq('trade_date', todayET)
+    .eq('status', 'PENDING');
+
+  if (error || !setups?.length) return [];
+
+  const triggered: OrbTrigger[] = [];
+
+  for (const setup of setups) {
+    try {
+      const quote = await fetchQuote(setup.ticker);
+      if (!quote?.price) continue;
+      const price = quote.price;
+
+      const priceTriggered =
+        setup.signal === 'BUY'  ? price >= setup.trigger_price :
+        setup.signal === 'SELL' ? price <= setup.trigger_price : false;
+
+      if (!priceTriggered) continue;
+
+      // Intraday RVOL: project live volume to a full-day equivalent and compare to 10d avg.
+      const liveVolume = quote.volume ?? 0;
+      const avg10d     = setup.avg_volume_10d ?? 0;
+      const etNow      = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
+      // Clamp to at least 1 minute to avoid divide-by-zero at exactly 9:30/9:35
+      const minElapsed = Math.max(1, (etNow.getHours() - 9) * 60 + etNow.getMinutes() - 30);
+      const projected  = liveVolume * (390 / minElapsed);
+      const liveRvol   = avg10d > 0 ? projected / avg10d : null;
+
+      if (liveRvol !== null && liveRvol < MIN_EXEC_RVOL) {
+        log(`${setup.ticker}: ORB ${setup.signal} @ $${price.toFixed(2)} — RVOL too low (${liveRvol.toFixed(2)}x, need ${MIN_EXEC_RVOL}x)`);
+        continue;
+      }
+
+      log(`${setup.ticker}: ORB ${setup.signal} triggered @ $${price.toFixed(2)} | RVOL ${liveRvol?.toFixed(2) ?? 'n/a'}x`);
+      triggered.push({
+        setupId:     setup.id,
+        ticker:      setup.ticker,
+        signal:      setup.signal as 'BUY' | 'SELL',
+        price,
+        stopLoss:    setup.stop_loss,
+        takeProfit1: setup.take_profit1,
+        takeProfit2: setup.take_profit2 ?? null,
+        liveRvol,
+        reason:      setup.reason,
+      });
+    } catch (err) {
+      log(`${setup.ticker}: error — ${err}`);
+    }
+  }
+
+  return triggered;
+}
+
+/** Mark a setup's status after the scheduler attempts execution */
+export async function markPresessionSetupStatus(
+  setupId: string,
+  status: 'TRIGGERED' | 'SKIPPED',
+  tradeId?: string,
+): Promise<void> {
+  const sb = getSupabase();
+  await sb
+    .from('pre_session_setups')
+    .update({
+      status,
+      triggered_at:       new Date().toISOString(),
+      triggered_trade_id: tradeId ?? null,
+    })
+    .eq('id', setupId);
+}
+
+/**
+ * Expire all PENDING setups from today that were never triggered.
+ * Called at 10:30 AM ET when the ORB window closes.
+ */
+export async function expirePresessionSetups(): Promise<void> {
+  const sb = getSupabase();
+  const todayET = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+  const { count } = await sb
+    .from('pre_session_setups')
+    .update({ status: 'EXPIRED' })
+    .eq('trade_date', todayET)
+    .eq('status', 'PENDING');
+  if ((count ?? 0) > 0) log(`Expired ${count} untriggered ORB setups for ${todayET}`);
+}

--- a/auto-trader/src/lib/yahoo-finance.ts
+++ b/auto-trader/src/lib/yahoo-finance.ts
@@ -111,6 +111,7 @@ export function sma(closes: number[], period: number): number | null {
 
 export interface YahooQuote {
   price:        number;
+  volume:       number | null;  // current day's volume (intraday or EOD)
   beta:         number | null;
   high52w:      number | null;
   earningsTs:   number | null;  // Unix ms, next earnings
@@ -123,7 +124,7 @@ export interface YahooQuote {
  */
 export async function fetchQuote(symbol: string): Promise<YahooQuote | null> {
   try {
-    const fields = 'regularMarketPrice,beta,fiftyTwoWeekHigh,earningsTimestamp';
+    const fields = 'regularMarketPrice,regularMarketVolume,beta,fiftyTwoWeekHigh,earningsTimestamp';
     const url = `https://query2.finance.yahoo.com/v7/finance/quote?symbols=${encodeURIComponent(symbol)}&fields=${fields}`;
     const res = await fetch(url, {
       headers: YAHOO_HEADERS,
@@ -138,6 +139,7 @@ export async function fetchQuote(symbol: string): Promise<YahooQuote | null> {
     if (!price) return null;
     return {
       price,
+      volume:     (q.regularMarketVolume as number | undefined) ?? null,
       beta:       (q.beta       as number | undefined) ?? null,
       high52w:    (q.fiftyTwoWeekHigh as number | undefined) ?? null,
       earningsTs: (q.earningsTimestamp as number | undefined)

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -110,6 +110,12 @@ import { warmPositionPriceCache } from './routes/positions.js';
 import { generateMorningBrief } from './lib/morning-brief.js';
 import { validateOrder } from './lib/validateOrder.js';
 import {
+  runNightlyPresessionScan,
+  checkPresessionTriggers,
+  expirePresessionSetups,
+  markPresessionSetupStatus,
+} from './lib/presession-scan.js';
+import {
   runPennyDiscovery,
   checkPennyEntry,
   checkPennyExit,
@@ -458,6 +464,18 @@ export function startScheduler(): void {
     }
   }, { timezone: 'America/New_York' });
   log('EOD loss analysis: 4:20 PM ET');
+
+  // Nightly pre-session ORB scan — 4:25 PM ET: after market close + reconciliation.
+  // Computes key S/R levels from prior day price action for each ticker in the
+  // ORB universe and upserts conditional bracket setups for tomorrow's open.
+  cron.schedule('25 16 * * 1-5', async () => {
+    try {
+      await runNightlyPresessionScan();
+    } catch (err) {
+      console.error('[PresessionScan] Nightly scan failed:', err instanceof Error ? err.message : err);
+    }
+  }, { timezone: 'America/New_York' });
+  log('Nightly ORB pre-session scan: 4:25 PM ET');
 
   // Earnings IV-crush scanner — 2:30 PM ET, enter calendar spreads for tonight's AMC
   // and tomorrow morning's BMO earnings announcements.
@@ -7457,6 +7475,70 @@ async function runSchedulerCycle(): Promise<void> {
       // Write evaluation results to DB so the UI can show Armed/Watching/Blocked badges
       if (Object.keys(dayEvals).length > 0)   writeScanEvaluations('day_trades', dayEvals).catch(() => {});
       if (Object.keys(swingEvals).length > 0)  writeScanEvaluations('swing_trades', swingEvals).catch(() => {});
+    }
+
+    // 10b. Pre-session ORB trigger check (nightly bracket setups).
+    // Compares live price against nightly-computed prior-day high/low brackets.
+    // Only fires during the first 60 min after open (9:35–10:30 ET) when RVOL >= 1.2x.
+    // After 10:30 ET, all remaining PENDING setups are expired.
+    if (isModeEnabled(config, 'DAY_TRADE')) {
+      const etNowForOrb = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
+      const etMinutesForOrb = etNowForOrb.getHours() * 60 + etNowForOrb.getMinutes();
+      const ORB_OPEN_MIN  = 9 * 60 + 35;  // 9:35 AM
+      const ORB_CLOSE_MIN = 10 * 60 + 30; // 10:30 AM
+
+      if (etMinutesForOrb >= ORB_OPEN_MIN && etMinutesForOrb < ORB_CLOSE_MIN) {
+        try {
+          const orbTriggers = await checkPresessionTriggers();
+          for (const orb of orbTriggers) {
+            // Per-ticker try/catch: one bad execution must not abort the rest
+            try {
+              if (await hasActiveTrade(orb.ticker, { excludeOptions: true })) {
+                log(`[ORB] ${orb.ticker} already has an active trade — skipping`);
+                await markPresessionSetupStatus(orb.setupId, 'SKIPPED');
+                continue;
+              }
+              const orbIdea: TradeIdea = {
+                ticker:        orb.ticker,
+                name:          orb.ticker,
+                price:         orb.price,
+                change:        0,
+                changePercent: 0,
+                signal:        orb.signal,
+                confidence:    7,
+                reason:        `[ORB] ${orb.reason}`,
+                tags:          ['orb', 'presession', 'prior_day_level'],
+                mode:          'DAY_TRADE',
+                entryPrice:    orb.price,
+                stopLoss:      orb.stopLoss,
+                targetPrice:   orb.takeProfit1,
+                targetPrice2:  orb.takeProfit2 ?? undefined,
+              };
+              const refreshedForOrb = await getEnrichedPositions();
+              const orbResult = await executeScannerTrade(orbIdea, config, refreshedForOrb);
+              log(`[ORB] ${orb.ticker} ${orb.signal}: ${orbResult}`);
+              const wasExecuted = orbResult.startsWith('executed');
+              await markPresessionSetupStatus(orb.setupId, wasExecuted ? 'TRIGGERED' : 'SKIPPED');
+              persistEvent(orb.ticker, wasExecuted ? 'success' : 'skipped',
+                `ORB ${orb.signal} trigger: ${orbResult}`, {
+                  source: 'presession_orb',
+                  trigger_price: orb.price,
+                  live_rvol: orb.liveRvol,
+                });
+            } catch (tickerErr) {
+              log(`[ORB] ${orb.ticker}: execution error — ${tickerErr instanceof Error ? tickerErr.message : tickerErr}`);
+            }
+          }
+        } catch (err) {
+          log(`[ORB] Error checking triggers: ${err instanceof Error ? err.message : err}`);
+        }
+      } else if (etMinutesForOrb >= ORB_CLOSE_MIN) {
+        // Expire any PENDING setups once the ORB window closes.
+        // expirePresessionSetups() only touches PENDING rows, so repeated calls are safe.
+        await expirePresessionSetups().catch(err =>
+          log(`[ORB] Expire error: ${err instanceof Error ? err.message : err}`)
+        );
+      }
     }
 
     // 11. SPX key-level breakout-retest scanner (Somesh's strategy)

--- a/supabase/migrations/20260601000001_pre_session_setups.sql
+++ b/supabase/migrations/20260601000001_pre_session_setups.sql
@@ -1,0 +1,42 @@
+-- Pre-session ORB setups: generated nightly after market close.
+-- Each row is a conditional bracket for the next trading day:
+--   BUY if price breaks above trigger_price (prior day high + buffer)
+--   SELL if price breaks below trigger_price (prior day low - buffer)
+-- Executed at market open only when price confirms AND RVOL >= 1.2x.
+
+CREATE TABLE IF NOT EXISTS pre_session_setups (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  ticker          TEXT NOT NULL,
+  trade_date      DATE NOT NULL,                   -- the day this setup should execute
+  signal          TEXT NOT NULL CHECK (signal IN ('BUY', 'SELL')),
+  trigger_price   NUMERIC(12,4) NOT NULL,           -- break above (BUY) or below (SELL)
+  stop_loss       NUMERIC(12,4) NOT NULL,
+  take_profit1    NUMERIC(12,4) NOT NULL,           -- T1 (1:2 R:R)
+  take_profit2    NUMERIC(12,4),                    -- T2 (1:3 R:R)
+  prior_day_high  NUMERIC(12,4) NOT NULL,
+  prior_day_low   NUMERIC(12,4) NOT NULL,
+  prior_day_close NUMERIC(12,4) NOT NULL,
+  prior_day_volume BIGINT,
+  avg_volume_10d  BIGINT,                           -- 10-day avg volume
+  rvol            NUMERIC(6,2),                     -- prior_day_volume / avg_volume_10d
+  trend_4h        TEXT,                             -- 'up' | 'down' | 'neutral'
+  ema100_4h       NUMERIC(12,4),
+  atr             NUMERIC(12,4),                    -- Average True Range (for sizing stops)
+  reason          TEXT,                             -- human-readable rationale
+  status          TEXT NOT NULL DEFAULT 'PENDING'
+                  CHECK (status IN ('PENDING','TRIGGERED','EXPIRED','SKIPPED')),
+  triggered_trade_id UUID REFERENCES paper_trades(id),
+  triggered_at    TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_pre_session_setups_date   ON pre_session_setups (trade_date);
+CREATE INDEX idx_pre_session_setups_status ON pre_session_setups (status);
+CREATE UNIQUE INDEX idx_pre_session_setups_unique
+  ON pre_session_setups (ticker, trade_date, signal);
+
+ALTER TABLE pre_session_setups ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can read pre_session_setups"  ON pre_session_setups FOR SELECT USING (true);
+CREATE POLICY "Anyone can insert pre_session_setups" ON pre_session_setups FOR INSERT WITH CHECK (true);
+CREATE POLICY "Anyone can update pre_session_setups" ON pre_session_setups FOR UPDATE USING (true);
+CREATE POLICY "Anyone can delete pre_session_setups" ON pre_session_setups FOR DELETE USING (true);


### PR DESCRIPTION
## Summary

- **New `pre_session_setups` table**: stores nightly ORB bracket setups (BUY above prior-day high, SELL below prior-day low) for every ticker in the 30-stock universe. Unique on `(ticker, trade_date, signal)` so re-runs never overwrite `TRIGGERED` rows.
- **`presession-scan.ts`**: nightly scan (4:25 PM ET) computes prior-day high/low, ATR-based stops, RVOL from Finnhub, and 4H trend filter. Morning check (9:35–10:30 AM) polls live price + projected RVOL ≥ 1.2× before returning triggers to the scheduler.
- **Scheduler wiring**: per-ticker try/catch so one bad execution can't abort others; expiry uses `>=` not `===` to never silently miss 10:30 AM.
- **ORB tab in Trade Signals UI**: compact table showing tonight's setups (trigger/stop/T1/T2/RVOL/trend/status). Smart: shows live status during the morning window, tomorrow's setups otherwise.

## Bug fixes (from party-mode review)
- STOP-1: Divide-by-zero guard on `minElapsed` (`Math.max(1, ...)`)
- STOP-2: Expiry `>=` instead of `===` (exact equality can silently miss when scheduler fires at 10:31)
- STOP-3: `nextTradingDate()` uses local `Date` construction instead of `toISOString()` (UTC drift on Friday → Saturday)
- STOP-4: Upsert `ignoreDuplicates: true` so TRIGGERED/EXPIRED rows aren't reset to PENDING on service restart
- STOP-5: Per-ticker try/catch in ORB execution loop

## Test plan
- [ ] ORB tab appears in Trade Signals UI and shows empty state before 4:25 PM today
- [ ] Tonight at 4:25 PM: check logs for `[PresessionScan] ✓ Upserted N ORB setups`
- [ ] ORB tab populates with tomorrow's setups after 4:25 PM
- [ ] Tomorrow 9:35 AM: check logs for any `[ORB] TRIGGERED` entries if price breaks levels

Made with [Cursor](https://cursor.com)