### PR TITLE
fix: separate system vs influencer day trades in performance + exclude from learning

### DIFF
--- a/app/src/components/PaperTrading/tabs/ValidationTab.tsx
+++ b/app/src/components/PaperTrading/tabs/ValidationTab.tsx
@@ -274,7 +274,7 @@ export function ValidationTab({ dayReport, swingReport, onRefresh }: ValidationT
           <div>
             <h2 className="text-base font-semibold">System Learning</h2>
             <p className="text-xs text-[hsl(var(--muted-foreground))]">
-              Analyzes your last 30 days of closed trades and adjusts scanner confidence, position sizing, and allocation thresholds automatically.
+              Analyzes our system's closed trades (influencer signals excluded) and adjusts scanner confidence, position sizing, and allocation thresholds automatically.
             </p>
           </div>
         </div>
@@ -342,7 +342,7 @@ export function ValidationTab({ dayReport, swingReport, onRefresh }: ValidationT
             {
               icon: <TrendingUp className="w-4 h-4 text-emerald-500" />,
               title: 'Winning strategy → scale up',
-              desc: 'If influencer day trades hit profit factor ≥1.5 + 52% WR, position size grows by 20%. If scanner wins consistently, confidence bar lowers to let more trades through.',
+              desc: 'If system day trades hit profit factor ≥1.5 + 52% WR, position size grows by 20%. If scanner wins consistently, confidence bar lowers to let more trades through.',
             },
             {
               icon: <TrendingDown className="w-4 h-4 text-red-500" />,

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -954,12 +954,15 @@ export async function recalculatePerformanceByCategory(accountView: AccountView 
       filter: (t) => t.mode === 'DAY_TRADE',
     },
     {
+      // Our system's own AI signals: no influencer source, no strategy video
       key: 'scanner_day_trade',
-      filter: (t) => t.mode === 'DAY_TRADE' && !t.strategy_video_id,
+      filter: (t) => t.mode === 'DAY_TRADE' && !t.strategy_video_id && !t.strategy_source,
     },
     {
+      // External influencer signals: either from a strategy video (YouTube) or
+      // a named influencer source (e.g. Somesh's Instagram bracket signals)
       key: 'influencer_day_trade',
-      filter: (t) => t.mode === 'DAY_TRADE' && !!t.strategy_video_id,
+      filter: (t) => t.mode === 'DAY_TRADE' && (!!t.strategy_video_id || !!t.strategy_source),
     },
     {
       key: 'day_penny',

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -5724,11 +5724,18 @@ async function _syncPositionsForAccount(
         pnl: pnlVal,
         pnl_percent: pnlPct,
       };
-      analyzeCompletedTrade(closedTrade)
-        .then(ok => {
-          if (ok) updatePerformancePatterns().catch(() => {});
-        })
-        .catch(err => log(`Trade analysis failed for ${trade.ticker}: ${err instanceof Error ? err.message : 'unknown'}`));
+      // Only learn from our own system's trades — influencer signals have no
+      // feedback loop value since we can't tune their external strategy.
+      const isInfluencerTrade = !!(closedTrade.strategy_source || closedTrade.strategy_video_id);
+      if (!isInfluencerTrade) {
+        analyzeCompletedTrade(closedTrade)
+          .then(ok => {
+            if (ok) updatePerformancePatterns().catch(() => {});
+          })
+          .catch(err => log(`Trade analysis failed for ${trade.ticker}: ${err instanceof Error ? err.message : 'unknown'}`));
+      } else {
+        log(`${trade.ticker}: skipping system learning — influencer trade (source: ${closedTrade.strategy_source ?? closedTrade.strategy_video_id})`);
+      }
       if (trade.mode === 'LONG_TERM' && !(trade.notes ?? '').startsWith('Dip buy')) {
         const tradeForLog = {
           ...closedTrade,


### PR DESCRIPTION
## Summary

- **Performance breakdown fix**: `scanner_day_trade` incorrectly included Somesh's Instagram signals because the old filter only checked `!strategy_video_id`. Somesh's signals have `strategy_source` set (e.g. "Somesh") but no `strategy_video_id` (that's YouTube-only). Fixed to `!strategy_video_id && !strategy_source`. The `influencer_day_trade` bucket now captures both.
- **System Learning exclusion**: `analyzeCompletedTrade()` now skips any trade with `strategy_source` or `strategy_video_id` set. Influencer signals can't improve our scanner since we don't control their strategy — learning from their wins/losses just adds noise to our confidence thresholds.
- **UI copy**: Updated System Learning description to clarify influencer signals are excluded.

## Test plan
- [ ] Performance tab: "Scanner Day Trades" count decreases (Somesh's trades move to "Influencer Day Trades")
- [ ] "Influencer Day Trades" count increases to include strategy_source trades
- [ ] Logs show "skipping system learning — influencer trade (source: Somesh)" for closed external signals

Made with [Cursor](https://cursor.com)