### PR TITLE
fix: scanner trades execute independently of active influencer positions

### DIFF
--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -300,7 +300,16 @@ export async function getLongTermExposureByTag(): Promise<{
 
 export async function hasActiveTrade(
   ticker: string,
-  opts?: { excludeMode?: 'LONG_TERM'; signal?: 'BUY' | 'SELL'; excludeOptions?: boolean; accountType?: AccountType }
+  opts?: {
+    excludeMode?: 'LONG_TERM';
+    signal?: 'BUY' | 'SELL';
+    excludeOptions?: boolean;
+    accountType?: AccountType;
+    /** When true, only counts trades from our own system (strategy_source IS NULL
+     *  and strategy_video_id IS NULL). Allows our scanner to trade a ticker
+     *  independently even when an influencer signal already has a position open. */
+    systemTradesOnly?: boolean;
+  }
 ): Promise<boolean> {
   const sb = getSupabase();
   let query = sb
@@ -316,6 +325,9 @@ export async function hasActiveTrade(
   }
   if (opts?.signal) {
     query = query.eq('signal', opts.signal);
+  }
+  if (opts?.systemTradesOnly) {
+    query = query.is('strategy_source', null).is('strategy_video_id', null);
   }
   const { count } = await query;
   return (count ?? 0) > 0;

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -3456,7 +3456,10 @@ async function executeScannerTrade(
 
   // Options positions on the same ticker don't block stock day/swing trades —
   // they are different instruments and managed by a separate pipeline.
-  if (await hasActiveTrade(ticker, { excludeOptions: true })) return 'skipped:duplicate';
+  // systemTradesOnly: true — our scanner only blocks on another SYSTEM trade for this
+  // ticker. An influencer position (Somesh's TSLA) doesn't block our own TSLA signal.
+  // Each has its own paper_trade record with its own quantity, so close logic is independent.
+  if (await hasActiveTrade(ticker, { excludeOptions: true, systemTradesOnly: true })) return 'skipped:duplicate';
 
   // ── Manual strategy gate ─────────────────────────────────────────────────
   // Checks strategy_gates.blocked — set ONLY by you manually, never auto-set.


### PR DESCRIPTION
## Summary

Our scanner was blocked from trading TSLA/PLTR whenever Somesh had an active position, because `hasActiveTrade()` counted all sources equally. This meant we couldn't test our system's own stop-loss and profit-taking logic on those tickers.

**Fix**: Added `systemTradesOnly` option to `hasActiveTrade()` that filters to only our own trades (`strategy_source IS NULL AND strategy_video_id IS NULL`). Our scanner now uses this flag — it deduplicates against itself but not against influencer positions.

**Safety**: Each position has its own `paper_trade` record with its own `quantity`. The close logic uses `trade.quantity` from the specific record, so two independent positions closing at their own stop/target prices remain independent.

## Test plan
- [ ] Somesh has TSLA open → our scanner also executes TSLA → two separate `paper_trades` rows
- [ ] Each closes independently at its own STP/TP
- [ ] Somesh still can't open a second TSLA if he already has one (external signal duplicate check unchanged)

Made with [Cursor](https://cursor.com)