### PR TITLE
feat(options): clarify P&L display — premium in play as headline

### DIFF
--- a/app/src/components/PaperTrading/tabs/OptionsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/OptionsTab.tsx
@@ -959,12 +959,12 @@ function StatsHeader({
   openPositions: OpenOptionsPosition[];
   openPrices: Map<string, TickerQuote>;
 }) {
-  // Unrealized P&L across all open positions (negative = losing on premium value)
+  // Unrealized P&L across all open positions (negative = premium moved against us)
   const totalUnrealizedPnl = openPositions.reduce((s, p) => s + (p.pnl ?? 0), 0);
-  // Net income = premiums locked in from closed trades minus open position losses
-  // This is the honest number: if you had to close everything today, this is what you keep.
-  const netIncome = stats.premiumCollected + totalUnrealizedPnl;
-  const netProgress = Math.min(Math.max(netIncome, 0) / MONTHLY_INCOME_TARGET, 1);
+  // Progress = realized + premium in play vs monthly target
+  // (premium in play = cash already collected from open positions, kept if they expire OTM)
+  const potentialIncome = stats.premiumCollected + stats.openPremiumAtRisk;
+  const netProgress = Math.min(Math.max(potentialIncome, 0) / MONTHLY_INCOME_TARGET, 1);
   const netProgressPct = Math.round(netProgress * 100);
   const barColor = netProgress > 0.5 ? 'bg-emerald-500' : netProgress > 0.25 ? 'bg-amber-400' : 'bg-red-400';
 
@@ -999,51 +999,69 @@ function StatsHeader({
             <span className="text-xs font-semibold text-emerald-800">Monthly Income Target</span>
           </div>
           <span className="text-[10px] text-emerald-700">
-            Projected: <span className="font-semibold">{fmtUsd(stats.projectedMonthlyIncome, 0)}</span> if all held
+            Target: <span className="font-semibold">{fmtUsd(MONTHLY_INCOME_TARGET, 0)}</span>/mo
           </span>
         </div>
-        <div className="space-y-1">
-          <div className="flex items-center justify-between text-xs">
-            <span className="font-bold text-emerald-800">
-              Net this month: {fmtUsd(netIncome, 0)} / {fmtUsd(MONTHLY_INCOME_TARGET, 0)}
+
+        {/* Premium in play — the primary number for a premium seller */}
+        <div className="grid grid-cols-3 gap-2">
+          <div className="rounded-lg bg-emerald-100/80 px-3 py-2">
+            <p className="text-[9px] text-emerald-600 font-medium uppercase tracking-wide">Premium in Play</p>
+            <p className="text-sm font-bold text-emerald-800">{fmtUsd(stats.openPremiumAtRisk, 0)}</p>
+            <p className="text-[9px] text-emerald-600">{stats.openPositions} open position{stats.openPositions !== 1 ? 's' : ''}</p>
+          </div>
+          <div className="rounded-lg bg-white/70 px-3 py-2">
+            <p className="text-[9px] text-[hsl(var(--muted-foreground))] font-medium uppercase tracking-wide">Realized</p>
+            <p className={cn('text-sm font-bold', stats.premiumCollected >= 0 ? 'text-emerald-800' : 'text-red-700')}>
+              {fmtUsd(stats.premiumCollected, 0, true)}
+            </p>
+            <p className="text-[9px] text-[hsl(var(--muted-foreground))]">
+              {stats.wins}W / {stats.losses}L
+              {stats.expiredWorthless > 0 && <span className="ml-1 text-emerald-600">· {stats.expiredWorthless} expired ✓</span>}
+            </p>
+          </div>
+          <div className="rounded-lg bg-white/70 px-3 py-2">
+            <p className="text-[9px] text-[hsl(var(--muted-foreground))] font-medium uppercase tracking-wide">Cost to Close Now</p>
+            <p className={cn('text-sm font-bold', totalUnrealizedPnl >= 0 ? 'text-emerald-800' : 'text-amber-700')}>
+              {fmtUsd(totalUnrealizedPnl, 0, true)}
+            </p>
+            <p className="text-[9px] text-[hsl(var(--muted-foreground))]">MTM vs collected</p>
+          </div>
+        </div>
+
+        {/* Scalp P&L row — only shown if there are scalp trades */}
+        {stats.scalpTrades > 0 && (
+          <div className="flex items-center gap-2 rounded-lg bg-sky-50 border border-sky-100 px-3 py-1.5">
+            <span className="text-[10px] font-semibold text-sky-700">⚡ Scalp P&L</span>
+            <span className={cn('text-[10px] font-bold', stats.scalpPnl >= 0 ? 'text-emerald-700' : 'text-red-600')}>
+              {fmtUsd(stats.scalpPnl, 0, true)}
             </span>
-            <span className={cn(
-              'font-bold text-[10px]',
-              netProgress > 0.5 ? 'text-emerald-700' : netProgress > 0.25 ? 'text-amber-600' : 'text-red-600'
-            )}>
+            <span className="text-[9px] text-sky-500">({stats.scalpTrades} trade{stats.scalpTrades !== 1 ? 's' : ''})</span>
+          </div>
+        )}
+
+        {/* Progress toward target */}
+        <div className="space-y-1">
+          <div className="flex items-center justify-between text-[10px]">
+            <span className="text-emerald-700">
+              Potential this month: <span className="font-semibold">{fmtUsd(stats.premiumCollected + stats.openPremiumAtRisk, 0)}</span>
+              <span className="text-[hsl(var(--muted-foreground))] ml-1">(realized + in play)</span>
+            </span>
+            <span className={cn('font-bold', netProgress > 0.5 ? 'text-emerald-700' : netProgress > 0.25 ? 'text-amber-600' : 'text-red-600')}>
               {netProgressPct}%
             </span>
           </div>
-          <div className="h-2 rounded-full bg-emerald-100 overflow-hidden">
+          <div className="h-1.5 rounded-full bg-emerald-100 overflow-hidden">
             <div
               className={cn('h-full rounded-full transition-all duration-500', barColor)}
               style={{ width: `${netProgressPct}%` }}
             />
           </div>
-          {/* Honest three-line breakdown */}
-          <div className="flex flex-col gap-0.5 text-[10px] pt-0.5">
-            <div className="flex items-center gap-2">
-              <span className="text-emerald-700">
-                ✅ Realized (closed): <span className="font-semibold">{fmtUsd(stats.premiumCollected, 0)}</span>
-              </span>
-              <span className="text-[hsl(var(--muted-foreground))]">·</span>
-              <span className={cn(totalUnrealizedPnl >= 0 ? 'text-emerald-700' : 'text-red-600')}>
-                Mark-to-market: <span className="font-semibold">{fmtUsd(totalUnrealizedPnl, 0, true)}</span>
-              </span>
-            </div>
-            {stats.openPremiumAtRisk > 0 && (
-              <span className="text-amber-700">
-                💰 Cash collected (open, unearned): <span className="font-semibold">{fmtUsd(stats.openPremiumAtRisk, 0)}</span>
-                <span className="text-[hsl(var(--muted-foreground))] ml-1">— kept when positions close profitably</span>
-              </span>
-            )}
-          </div>
         </div>
-        <div className="flex items-center gap-3 text-[10px] text-emerald-700">
-          <span>{stats.wins}W / {stats.losses}L · {stats.winRate.toFixed(0)}% win rate</span>
-          <span>·</span>
-          <span>{stats.annualizedReturn.toFixed(0)}% annualized</span>
-        </div>
+
+        {stats.annualizedReturn > 0 && (
+          <p className="text-[10px] text-emerald-600">{stats.annualizedReturn.toFixed(0)}% annualized on deployed capital</p>
+        )}
       </div>
 
       {/* Crash scenario card — honest tail risk visibility */}

--- a/app/src/lib/optionsApi.ts
+++ b/app/src/lib/optionsApi.ts
@@ -148,6 +148,9 @@ export interface OptionsMonthlyStats {
   annualizedReturn: number;
   projectedMonthlyIncome: number; // total premium locked in from all currently open puts
   openPremiumAtRisk: number;      // cash already received from open positions, not yet earned
+  expiredWorthless: number;       // count of trades that expired OTM this month
+  scalpPnl: number;               // realized P&L from OPTIONS_SCALP trades this month
+  scalpTrades: number;            // count of closed scalp trades this month
 }
 
 // ── Watchlist ────────────────────────────────────────────
@@ -297,10 +300,10 @@ export async function getOptionsMonthlyStats(): Promise<OptionsMonthlyStats> {
   monthStart.setDate(1);
   monthStart.setHours(0, 0, 0, 0);
 
-  const [{ data: closed }, { data: open }] = await Promise.all([
+  const [{ data: closed }, { data: open }, { data: scalps }] = await Promise.all([
     supabase
       .from('paper_trades')
-      .select('pnl, option_capital_req')
+      .select('pnl, option_capital_req, close_reason')
       .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
       .in('status', [...CLOSED_STATUSES])
       .gte('closed_at', monthStart.toISOString()),
@@ -309,29 +312,31 @@ export async function getOptionsMonthlyStats(): Promise<OptionsMonthlyStats> {
       .select('id, option_premium, option_contracts')
       .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
       .in('status', [...ACTIVE_STATUSES]),
+    supabase
+      .from('paper_trades')
+      .select('pnl')
+      .eq('mode', 'OPTIONS_SCALP')
+      .in('status', [...CLOSED_STATUSES])
+      .gte('closed_at', monthStart.toISOString()),
   ]);
 
   // Only count trades with meaningful P&L (> $1) — excludes spurious $0 closes
-  const trades = (closed ?? []).filter(t => Math.abs(t.pnl ?? 0) > 1);
-  const wins = trades.filter(t => (t.pnl ?? 0) > 0);
-  const losses = trades.filter(t => (t.pnl ?? 0) < 0);
-  // Net realized P&L across ALL closed trades (wins + losses) — the true closed income figure.
-  // Previously only summed wins, causing losses like JPM -$105 to be silently excluded.
+  const trades = (closed ?? []).filter((t: { pnl: number | null }) => Math.abs(t.pnl ?? 0) > 1);
+  const wins = trades.filter((t: { pnl: number | null }) => (t.pnl ?? 0) > 0);
+  const losses = trades.filter((t: { pnl: number | null }) => (t.pnl ?? 0) < 0);
+  const expiredWorthless = (closed ?? []).filter((t: { close_reason: string | null }) => t.close_reason === 'expired_worthless').length;
+
   const premiumCollected = trades.reduce((s: number, t: { pnl: number | null }) => s + (t.pnl ?? 0), 0);
   const totalCapital = trades.reduce((s: number, t: { option_capital_req: number | null }) => s + (t.option_capital_req ?? 0), 0);
   const daysInMonth = new Date().getDate();
   const annualizedReturn = totalCapital > 0 ? (premiumCollected / totalCapital) * (365 / daysInMonth) * 100 : 0;
 
-  // Projected income = total premium locked in across all currently open puts
-  // (premium/share × contracts × 100 shares/contract)
   const projectedMonthlyIncome = (open ?? []).reduce((sum: number, t: { option_premium: number | null; option_contracts: number | null }) => {
     return sum + (t.option_premium ?? 0) * (t.option_contracts ?? 1) * 100;
   }, 0);
 
-  // Premium at risk = cash already received from open positions, but not yet earned.
-  // This is the same as projectedMonthlyIncome — shown separately so the UI can
-  // display it as "collected but unearned" rather than hiding it in a footnote.
-  const openPremiumAtRisk = projectedMonthlyIncome;
+  const scalpTrades = (scalps ?? []).filter((t: { pnl: number | null }) => Math.abs(t.pnl ?? 0) > 1);
+  const scalpPnl = scalpTrades.reduce((s: number, t: { pnl: number | null }) => s + (t.pnl ?? 0), 0);
 
   return {
     premiumCollected,
@@ -341,7 +346,10 @@ export async function getOptionsMonthlyStats(): Promise<OptionsMonthlyStats> {
     openPositions: (open ?? []).length,
     annualizedReturn,
     projectedMonthlyIncome,
-    openPremiumAtRisk,
+    openPremiumAtRisk: projectedMonthlyIncome,
+    expiredWorthless,
+    scalpPnl,
+    scalpTrades: scalpTrades.length,
   };
 }
 


### PR DESCRIPTION
## Problem

The options stats header was leading with 'Net this month: -\$616' which is a mark-to-market number. The actual story — \$6,977 of premium collected from 9 open positions — was buried in tiny text labeled 'unearned'. OPTIONS_SCALP P&L was completely invisible.

## Changes

**`optionsApi.ts`**
- `getOptionsMonthlyStats` now also fetches `close_reason` to count `expired_worthless` trades
- Adds `scalpPnl` and `scalpTrades` by querying `OPTIONS_SCALP` closed trades this month

**`OptionsTab.tsx` — StatsHeader**
- New 3-card grid: **Premium in Play** (hero) · **Realized** · **Cost to Close Now**
- Premium in Play = open premium × contracts = cash you keep if all expire OTM  
- Realized shows W/L count + "X expired ✓" when applicable
- Cost to Close Now = MTM (renamed from confusing 'Mark-to-market')
- ⚡ Scalp P&L row appears when scalp trades exist this month
- Progress bar tracks `realized + in-play` vs \$5k target (not MTM)

Made with [Cursor](https://cursor.com)