### PR TITLE
fix: restore DAY_PENNY constraint + log all bracket/direct-sell closes

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -909,6 +909,12 @@ async function closeAllDayTrades(config: AutoTraderConfig): Promise<void> {
                 accountType: acctType,
               });
               log(`${trade.ticker}: EOD — recorded bracket close (${childType}) @ $${cf.fill_price}, P&L ≈ $${pnl.toFixed(2)}`);
+              persistEvent(trade.ticker, 'success',
+                `${childType === 'TP' ? 'Target hit' : 'Stop loss hit'}: sold ${qty} @ $${cf.fill_price.toFixed(2)} | P&L $${pnl >= 0 ? '+' : ''}${pnl.toFixed(2)} (bracket ${childType})`,
+                { action: 'sell', source: 'system', mode: trade.mode as string,
+                  metadata: { close_reason: childType === 'TP' ? 'target_hit' : 'stop_loss_hit', pnl, bracket_order_id: cf.order_id } },
+                acctType,
+              ).catch(() => {});
               continue;
             }
           }
@@ -5633,7 +5639,29 @@ async function _syncPositionsForAccount(
       const slId = trade.ib_sl_order_id ? parseInt(trade.ib_sl_order_id, 10) : NaN;
       const tpFill = !Number.isNaN(tpId) ? await getOrderFillPriceWithFallback(tpId) : undefined;
       const slFill = !Number.isNaN(slId) ? await getOrderFillPriceWithFallback(slId) : undefined;
-      const ibExitFill = tpFill ?? slFill;
+      let ibExitFill = tpFill ?? slFill;
+
+      // Fallback for direct market sells (no bracket IDs): when the auto-trader placed
+      // a sell order that timed out or disconnected before the fill arrived, the paper_trade
+      // stays FILLED but the ib_fills table has the actual close price keyed by ticker+side.
+      // Check for a SLD fill for this ticker today so we can recover without a fallback quote.
+      if (ibExitFill === undefined && !trade.ib_tp_order_id && !trade.ib_sl_order_id) {
+        const todayStart = new Date();
+        todayStart.setHours(0, 0, 0, 0);
+        const { data: tickerFill } = await getSupabase()
+          .from(syncAcct === 'live' ? 'live_fills' : 'ib_fills')
+          .select('fill_price, filled_at')
+          .eq('ticker', trade.ticker.toUpperCase())
+          .in('side', ['SLD', 'SELL'])
+          .gte('filled_at', todayStart.toISOString())
+          .order('filled_at', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+        if (tickerFill) {
+          ibExitFill = (tickerFill as { fill_price: number }).fill_price;
+          log(`${trade.ticker}: Recovered exit fill $${ibExitFill} from ib_fills by ticker (direct sell, no bracket IDs)`);
+        }
+      }
 
       // If we have a confirmed IB exit fill, close immediately (no guard needed)
       const hasConfirmedFill = ibExitFill !== undefined;
@@ -5733,6 +5761,16 @@ async function _syncPositionsForAccount(
         extraUpdates: { r_multiple: rMultiple, missing_since: null },
       } as Parameters<typeof recordTradeClose>[0]);
       log(`${trade.ticker}: Closed [${syncAcct}] (${closeReason}) — P&L $${pnl.toFixed(2)}${hasConfirmedFill ? '' : ' [fallback price]'}`);
+      const closeLabel = status === 'TARGET_HIT' ? 'Target hit'
+        : status === 'STOPPED' ? 'Stop loss hit'
+        : closeReason === 'stop_loss' ? 'Stop loss hit'
+        : 'Closed';
+      persistEvent(trade.ticker, 'success',
+        `${closeLabel}: sold ${qty} @ $${actual.toFixed(2)} | P&L $${pnl >= 0 ? '+' : ''}${pnl.toFixed(2)}${hasConfirmedFill ? '' : ' [estimated]'}`,
+        { action: 'sell', source: 'system', mode: trade.mode as string,
+          metadata: { close_reason: closeReason, pnl: pnlVal, confirmed_fill: hasConfirmedFill } },
+        syncAcct,
+      ).catch(() => {});
       const closedTrade = {
         ...trade,
         status,

--- a/supabase/migrations/20260602000001_restore_day_penny_earnings_calendar_mode.sql
+++ b/supabase/migrations/20260602000001_restore_day_penny_earnings_calendar_mode.sql
@@ -1,0 +1,20 @@
+-- Restore DAY_PENNY and EARNINGS_CALENDAR to paper_trades_mode_check.
+-- Migration 20260601000002 dropped both when it added OPTIONS_SCALP.
+-- This caused all DAY_PENNY trades (penny influencer videos) to fail with
+-- a constraint violation since June 1, 2026.
+
+ALTER TABLE paper_trades DROP CONSTRAINT IF EXISTS paper_trades_mode_check;
+
+ALTER TABLE paper_trades ADD CONSTRAINT paper_trades_mode_check
+  CHECK (mode IN (
+    'DAY_TRADE',
+    'SWING_TRADE',
+    'LONG_TERM',
+    'DAY_PENNY',
+    'OPTIONS_PUT',
+    'OPTIONS_CALL',
+    'OPTIONS_SCALP',
+    'CREDIT_SPREAD',
+    'CALENDAR_SPREAD',
+    'EARNINGS_CALENDAR'
+  ));


### PR DESCRIPTION
## Summary

- **DAY_PENNY constraint restored**: Migration `20260601000002` accidentally dropped `DAY_PENNY` and `EARNINGS_CALENDAR` from `paper_trades_mode_check` when adding `OPTIONS_SCALP`. All penny influencer video trades have been failing since Jun 1. New migration `20260602000001` restores them.
- **Missing activity log events**: `syncPositions` and the EOD bracket-detection path both called `recordTradeClose` without ever calling `persistEvent`, so bracket TP/SL hits and direct-sell recoveries were completely invisible in the activity feed. Both now emit activity events.
- **Ticker-based ib_fills fallback**: When a SWING/LT position disappears from IB with no bracket order IDs (direct market sell that timed out during an IB disconnect), `syncPositions` now checks `ib_fills` by `ticker + side=SLD + today` before giving up. Fixes the FCX case where order 21243 filled after reconnect but the paper_trade stayed FILLED forever.

## Test plan
- [ ] Penny influencer video signals (ABTS, HKIT) no longer fail with `paper_trades_mode_check`
- [ ] Bracket TP/SL closes appear in activity log with "Target hit" / "Stop loss hit" message
- [ ] FCX-style direct-sell timeouts are recovered by the ticker fallback on next cycle
- [ ] EOD reconciliation at 4:15 PM still runs and corrects any close prices as before

Made with [Cursor](https://cursor.com)