### PR TITLE
feat: use Instagram oEmbed API for creator handle resolution

### DIFF
--- a/supabase/functions/fix-unknown-strategy-sources/index.ts
+++ b/supabase/functions/fix-unknown-strategy-sources/index.ts
@@ -1,6 +1,12 @@
 /**
  * Fix strategy_videos with source_name = 'Unknown': re-resolve source from URL.
  * Call POST to repair misclassified videos.
+ *
+ * Resolution order:
+ *  1. source_handle already set in DB → use it directly
+ *  2. Instagram oEmbed API → returns author_name + author_url (reliable, no auth needed)
+ *  3. Handle in URL path regex (for URLs like instagram.com/handle/reel/ID)
+ *  4. Full page HTML fetch → last resort, often 403'd by Instagram
  */
 
 import { createClient } from 'jsr:@supabase/supabase-js@2';
@@ -15,17 +21,14 @@ const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (
 
 const INSTAGRAM_REEL = /instagram\.com\/(?:([^/]+)\/)?reels?\/([A-Za-z0-9_-]+)/i;
 
-// Instagram system paths / CDN paths that are never real account handles
 const IG_SYSTEM_PATHS = new Set([
   'reel', 'p', 'stories', 'explore', 'accounts', 'direct', 'static',
   'rsrc.php', 'favicon.ico', 'about', 'legal', 'privacy', 'help',
 ]);
 
-/** Returns true if the string looks like a CDN path or system resource (not a real IG handle) */
 function isIgSystemPath(handle: string): boolean {
   const h = handle.toLowerCase();
   if (IG_SYSTEM_PATHS.has(h)) return true;
-  // Anything ending in a file extension (.php, .js, .css, .png, etc.) is a CDN path
   if (/\.[a-z]{2,4}$/.test(h)) return true;
   return false;
 }
@@ -37,24 +40,47 @@ function toSourceName(handle: string): string {
     .trim();
 }
 
-/** Extract handle from Instagram URL or page HTML */
-async function extractInstagramHandle(url: string): Promise<string | null> {
+/**
+ * Instagram oEmbed API — public, no auth, returns author_name + author_url.
+ * This is the most reliable way to get the creator handle server-side.
+ * Returns { handle, displayName } or null if unavailable.
+ */
+async function resolveViaOEmbed(reelUrl: string): Promise<{ handle: string; displayName: string } | null> {
+  try {
+    const oembedUrl = `https://www.instagram.com/api/v1/oembed/?url=${encodeURIComponent(reelUrl)}`;
+    const res = await fetch(oembedUrl, {
+      headers: { 'User-Agent': UA },
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (!res.ok) return null;
+    const data = await res.json() as { author_name?: string; author_url?: string };
+    const authorUrl = data.author_url ?? '';
+    // author_url is like https://www.instagram.com/kianstrades — extract handle
+    const m = /instagram\.com\/([a-zA-Z0-9_.]+)\/?$/.exec(authorUrl);
+    const handle = m?.[1]?.toLowerCase() ?? data.author_name?.toLowerCase() ?? null;
+    if (!handle || isIgSystemPath(handle)) return null;
+    const displayName = data.author_name ?? handle;
+    return { handle, displayName };
+  } catch {
+    return null;
+  }
+}
+
+/** Fallback: extract handle from URL path or page HTML */
+async function extractInstagramHandleFallback(url: string): Promise<string | null> {
+  // Try URL path regex first (fast, no network)
   const m = INSTAGRAM_REEL.exec(url);
   if (m?.[1] && !isIgSystemPath(m[1])) return m[1].trim().toLowerCase();
 
+  // Full page fetch — often 403'd but worth trying
   try {
     const res = await fetch(url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(10_000) });
     const html = await res.text();
-    // Prefer og:url — most reliable
     const ogUrl = html.match(/<meta[^>]+property="og:url"[^>]+content="([^"]*)"/i)?.[1] ?? '';
     const m2 = /instagram\.com\/([^/]+)\/(?:reels?|p)\//i.exec(ogUrl);
     if (m2?.[1] && !isIgSystemPath(m2[1])) return m2[1].trim().toLowerCase();
-
-    // Fallback: first instagram.com/<handle>/ match in HTML
     const profileMatch = html.match(/instagram\.com\/([a-zA-Z0-9_.]+)(?:\/|["'\s>])/);
-    if (profileMatch?.[1] && !isIgSystemPath(profileMatch[1])) {
-      return profileMatch[1].trim().toLowerCase();
-    }
+    if (profileMatch?.[1] && !isIgSystemPath(profileMatch[1])) return profileMatch[1].trim().toLowerCase();
   } catch {
     // ignore
   }
@@ -97,31 +123,36 @@ Deno.serve(async (req) => {
       continue;
     }
 
-    // Prefer the already-stored source_handle before doing any URL/page work.
-    // Instagram page fetches frequently return 403 from Supabase edge servers, so
-    // relying solely on URL parsing left videos stuck as Unknown forever.
-    const storedHandle = (row.source_handle ?? '').trim().toLowerCase();
-
-    // When reel_url/canonical_url are null (e.g. video was ingested via a path that
-    // didn't persist the original URL), reconstruct it from the video_id so the page
-    // fetch at least has a chance.
+    // Reconstruct reel_url from video_id if neither URL field is populated,
+    // and backfill it so future calls don't have to reconstruct.
     let url = (row.reel_url ?? row.canonical_url ?? '').trim();
     if (!url && row.video_id) {
       url = `https://www.instagram.com/reel/${row.video_id}/`;
-      // Backfill the URL in the DB so future calls don't need to reconstruct it.
-      await supabase
-        .from('strategy_videos')
-        .update({ reel_url: url })
-        .eq('id', row.id);
+      await supabase.from('strategy_videos').update({ reel_url: url }).eq('id', row.id);
     }
 
-    const handle = storedHandle || (url ? await extractInstagramHandle(url) : null);
+    // Resolution order: stored handle → oEmbed → URL/page fallback
+    let handle: string | null = (row.source_handle ?? '').trim().toLowerCase() || null;
+    let displayName: string | null = null;
+
+    if (!handle && url) {
+      const oembed = await resolveViaOEmbed(url);
+      if (oembed) {
+        handle = oembed.handle;
+        displayName = oembed.displayName;
+      }
+    }
+
+    if (!handle && url) {
+      handle = await extractInstagramHandleFallback(url);
+    }
 
     if (!handle) {
       results.push({ video_id: row.video_id, source_name: 'Unknown', status: 'failed' });
       continue;
     }
 
+    // Look up canonical source_name from existing videos with this handle
     const { data: existing } = await supabase
       .from('strategy_videos')
       .select('source_name, source_handle')
@@ -131,7 +162,10 @@ Deno.serve(async (req) => {
       .limit(1)
       .maybeSingle();
 
-    const sourceName = existing?.source_name?.trim() ?? toSourceName(handle);
+    // Prefer existing canonical name → oEmbed display name → humanized handle
+    const sourceName = existing?.source_name?.trim()
+      ?? (displayName && displayName !== handle ? toSourceName(displayName) : null)
+      ?? toSourceName(handle);
     const sourceHandle = existing?.source_handle ?? handle;
 
     const { error: updateErr } = await supabase

--- a/supabase/functions/fix-unknown-strategy-sources/index.ts
+++ b/supabase/functions/fix-unknown-strategy-sources/index.ts
@@ -77,7 +77,7 @@ Deno.serve(async (req) => {
 
   const { data: unknowns, error: fetchErr } = await supabase
     .from('strategy_videos')
-    .select('id, video_id, platform, reel_url, canonical_url')
+    .select('id, video_id, platform, reel_url, canonical_url, source_handle')
     .eq('status', 'tracked')
     .eq('source_name', 'Unknown')
     .limit(50);
@@ -92,13 +92,31 @@ Deno.serve(async (req) => {
   const results: { video_id: string; source_name: string; status: 'fixed' | 'failed' }[] = [];
 
   for (const row of unknowns) {
-    const url = (row.reel_url ?? row.canonical_url ?? '').trim();
-    if (!url || row.platform !== 'instagram') {
+    if (row.platform !== 'instagram') {
       results.push({ video_id: row.video_id, source_name: 'Unknown', status: 'failed' });
       continue;
     }
 
-    const handle = await extractInstagramHandle(url);
+    // Prefer the already-stored source_handle before doing any URL/page work.
+    // Instagram page fetches frequently return 403 from Supabase edge servers, so
+    // relying solely on URL parsing left videos stuck as Unknown forever.
+    const storedHandle = (row.source_handle ?? '').trim().toLowerCase();
+
+    // When reel_url/canonical_url are null (e.g. video was ingested via a path that
+    // didn't persist the original URL), reconstruct it from the video_id so the page
+    // fetch at least has a chance.
+    let url = (row.reel_url ?? row.canonical_url ?? '').trim();
+    if (!url && row.video_id) {
+      url = `https://www.instagram.com/reel/${row.video_id}/`;
+      // Backfill the URL in the DB so future calls don't need to reconstruct it.
+      await supabase
+        .from('strategy_videos')
+        .update({ reel_url: url })
+        .eq('id', row.id);
+    }
+
+    const handle = storedHandle || (url ? await extractInstagramHandle(url) : null);
+
     if (!handle) {
       results.push({ video_id: row.video_id, source_name: 'Unknown', status: 'failed' });
       continue;

--- a/supabase/functions/process-strategy-video-queue/index.ts
+++ b/supabase/functions/process-strategy-video-queue/index.ts
@@ -58,12 +58,14 @@ const KNOWN_SIGNAL_HANDLES = new Set([
 const KNOWN_PENNY_GENERATORS = new Set([
   'Ross Cameron',
   'Warrior Trading',
+  'Kianstrades',
 ]);
 
 const KNOWN_PENNY_HANDLES = new Set([
   'warrior_trading',
   'warriortrading',
   'rosscameron',
+  'kianstrades',
 ]);
 
 function isKnownSignalGenerator(sourceName: string, sourceHandle: string | null): boolean {
@@ -87,17 +89,34 @@ function isIgSystemPath(handle: string): boolean {
   return false;
 }
 
-/** For instagram.com/reel/ID (no handle in path), fetch page and extract handle */
+/**
+ * For instagram.com/reel/ID (no handle in URL path), resolve via oEmbed API first,
+ * then fall back to full page HTML fetch.
+ * oEmbed is the preferred approach: public API, returns structured JSON, no auth needed.
+ */
 async function fetchInstagramHandle(url: string): Promise<string | null> {
+  // 1. oEmbed API — most reliable, works server-side without auth
+  try {
+    const oembedUrl = `https://www.instagram.com/api/v1/oembed/?url=${encodeURIComponent(url)}`;
+    const res = await fetch(oembedUrl, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(8_000) });
+    if (res.ok) {
+      const data = await res.json() as { author_url?: string; author_name?: string };
+      const authorUrl = data.author_url ?? '';
+      const m = /instagram\.com\/([a-zA-Z0-9_.]+)\/?$/.exec(authorUrl);
+      const h = m?.[1]?.toLowerCase() ?? data.author_name?.toLowerCase() ?? null;
+      if (h && !isIgSystemPath(h)) return h;
+    }
+  } catch {
+    // fall through to page fetch
+  }
+
+  // 2. Full page HTML fetch — often 403'd but kept as last resort
   try {
     const res = await fetch(url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(10_000) });
     const html = await res.text();
-    // Prefer og:url — most reliable
     const ogUrl = html.match(/<meta[^>]+property="og:url"[^>]+content="([^"]*)"/i)?.[1] ?? '';
     const m = /instagram\.com\/([^/]+)\/(?:reels?|p)\//i.exec(ogUrl);
     if (m?.[1] && !isIgSystemPath(m[1])) return m[1].trim().toLowerCase();
-
-    // Fallback: first instagram.com/<handle>/ match in HTML
     const profileMatch = html.match(/instagram\.com\/([a-zA-Z0-9_.]+)(?:\/|["'\s>])/);
     if (profileMatch?.[1]) {
       const h = profileMatch[1].toLowerCase();


### PR DESCRIPTION
## Summary
- Instagram page-scraping (previous approach) returns 403 from Supabase edge servers — new influencer videos were stuck as Unknown forever
- Switches both `fix-unknown-strategy-sources` and `process-strategy-video-queue` to use Instagram's public oEmbed API (`/api/v1/oembed/`) which returns `author_name` + `author_url` reliably server-side, no auth needed
- Adds `kianstrades` to known penny handles — future uploads auto-detect and auto-categorize as `daily_penny`
- Fixes the DZENGOURceh video: now shows as "Kianstrades" ✓

## Test plan
- [ ] Upload a new reel from kianstrades → auto-detects as Kianstrades / daily_penny, no Unknown
- [ ] Upload a reel from an unknown new creator → oEmbed resolves their handle, shows as humanized name instead of Unknown

Made with [Cursor](https://cursor.com)