### PR TITLE
fix: clear Unknown signal strays that outlast the video fix

### DIFF
--- a/app/src/components/PaperTrading/tabs/StrategyPerformanceTab.tsx
+++ b/app/src/components/PaperTrading/tabs/StrategyPerformanceTab.tsx
@@ -349,7 +349,13 @@ export function StrategyPerformanceTab({ sources, videos, statuses, onRefresh }:
     setFixing(true);
     fixUnknownSources()
       .then(({ fixed }) => {
-        if (fixed > 0) onRefresh();
+        if (fixed > 0) {
+          // Reset guard so that if the refresh surfaces new Unknown entries
+          // (e.g. signals created between the last fix and now), the effect
+          // fires again on the next render cycle.
+          autoFixAttempted.current = false;
+          onRefresh();
+        }
       })
       .finally(() => setFixing(false));
   }, [hasUnknown, onRefresh]);

--- a/supabase/functions/fix-unknown-strategy-sources/index.ts
+++ b/supabase/functions/fix-unknown-strategy-sources/index.ts
@@ -194,8 +194,48 @@ Deno.serve(async (req) => {
     }
   }
 
+  // Phase 2: fix orphaned signals — strategy_videos was already corrected but
+  // signals created after the fix still carry source_name = 'Unknown'.
+  // Cross-reference by strategy_video_id to pull the authoritative source name.
+  let signalStrayFixed = 0;
+  try {
+    const { data: unknownSignals } = await supabase
+      .from('external_strategy_signals')
+      .select('strategy_video_id, source_name')
+      .eq('source_name', 'Unknown')
+      .not('strategy_video_id', 'is', null)
+      .limit(200);
+
+    if (unknownSignals && unknownSignals.length > 0) {
+      const videoIds = [...new Set((unknownSignals as Array<{ strategy_video_id: string }>).map(r => r.strategy_video_id))];
+      const { data: resolvedVideos } = await supabase
+        .from('strategy_videos')
+        .select('video_id, source_name, source_handle, reel_url')
+        .in('video_id', videoIds)
+        .not('source_name', 'eq', 'Unknown')
+        .not('source_name', 'is', null);
+
+      if (resolvedVideos && resolvedVideos.length > 0) {
+        for (const vid of resolvedVideos as Array<{ video_id: string; source_name: string; source_handle: string | null; reel_url: string | null }>) {
+          const handle = vid.source_handle ?? vid.source_name.toLowerCase().replace(/\s+/g, '');
+          const sourceUrl = `https://www.instagram.com/${handle}/`;
+          const { count } = await supabase
+            .from('external_strategy_signals')
+            .update({ source_name: vid.source_name, source_url: sourceUrl, updated_at: new Date().toISOString() })
+            .eq('strategy_video_id', vid.video_id)
+            .eq('source_name', 'Unknown')
+            .select('id', { count: 'exact', head: true });
+          signalStrayFixed += (count ?? 0);
+        }
+      }
+    }
+  } catch {
+    // non-blocking
+  }
+
+  const totalFixed = results.filter(r => r.status === 'fixed').length + signalStrayFixed;
   return new Response(
-    JSON.stringify({ ok: true, fixed: results.filter(r => r.status === 'fixed').length, results }),
+    JSON.stringify({ ok: true, fixed: totalFixed, results, signalStrayFixed }),
     { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
   );
 });


### PR DESCRIPTION
## Summary
- **Phase 2 in fix-unknown edge function**: after patching `strategy_videos`, now also scans `external_strategy_signals` directly for any Unknown rows whose video was already resolved — fixes signals created after the initial fix ran
- **Frontend auto-fix guard reset**: `autoFixAttempted.current` now resets after a `fixed > 0` refresh so new stragglers that appear between fix runs don't get silently skipped
- **DB hotfix**: directly patched the stray ABTS signal (bcaaed30) that was the root of this report

## Root cause
The ABTS/DZENGOURceh signal was created at 1:52 PM ET, after the fix-unknown had already set `strategy_videos.source_name = 'Kianstrades'`. Because fix-unknown only queries `strategy_videos WHERE source_name = 'Unknown'`, it never saw DZENGOURceh again and left the stray signal untouched. The frontend guard (`autoFixAttempted.current`) prevented a retry.

## Test plan
- [ ] Reload Strategy Performance tab — Unknown section should be gone
- [ ] Upload a new video and let it process with Unknown source; confirm fix-unknown clears both the video row and any signals

Made with [Cursor](https://cursor.com)