### PR TITLE
fix: DAY_PENNY signals no longer blocked by $20 influencer floor

### DIFF
--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -515,6 +515,9 @@ export async function findExternalStrategySignal(params: {
   strategyVideoId?: string;
 }): Promise<ExternalStrategySignal | null> {
   const sb = getSupabase();
+  // Only treat a signal as "already exists" if it is actionable (PENDING /
+  // EXECUTED / EXECUTING). FAILED, SKIPPED, and EXPIRED signals must not block
+  // re-creation — the auto-trader should get a fresh PENDING attempt.
   let query = sb
     .from('external_strategy_signals')
     .select('*')
@@ -523,6 +526,7 @@ export async function findExternalStrategySignal(params: {
     .eq('signal', params.signal)
     .eq('mode', params.mode)
     .eq('execute_on_date', params.executeOnDate)
+    .in('status', ['PENDING', 'EXECUTED', 'EXECUTING'])
     .order('created_at', { ascending: false });
 
   if (params.strategyVideoId) {

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -1989,7 +1989,10 @@ async function autoQueueDailySignalsFromTrackedVideos(): Promise<void> {
     if (!sourceName) continue;
     const sourceUrl = inferSourceUrl(video);
     const heading = (video.videoHeading ?? video.videoId).trim();
-    const mode = video.timeframe ?? 'DAY_TRADE';
+    // daily_penny videos are explicitly penny-stock plays; always use DAY_PENNY
+    // so they bypass the $20 influencer day-trade floor (which targets illiquid
+    // mid-caps, not intentional penny signals).
+    const mode = video.strategyType === 'daily_penny' ? 'DAY_PENNY' : (video.timeframe ?? 'DAY_TRADE');
 
     for (const setup of (video.extractedSignals ?? [])) {
       const ticker = String(setup.ticker ?? '').trim().toUpperCase();


### PR DESCRIPTION
## Summary
- `autoQueueDailySignalsFromTrackedVideos` now assigns `mode = 'DAY_PENNY'` for `daily_penny` strategy videos instead of falling through to the `DAY_TRADE` default, which hit the \$20 influencer floor gate
- `findExternalStrategySignal` dedup now excludes `FAILED`/`SKIPPED`/`EXPIRED` signals so new PENDING attempts can be created after a previous cycle fails

## Root cause
Kianstrades videos have `strategy_type = 'daily_penny'` but `timeframe = 'DAY_TRADE'`. The signal creation code used `timeframe` for mode — every signal got `DAY_TRADE` mode and the \$20 floor blocked all of them. The dedup then prevented re-creation because the FAILED signals were still blocking.

## Recovery
The three orphaned IB positions (ABTS/1857, HKIT/4854, TGHL/5807) were bought successfully but had no paper_trade records. Manually created FILLED paper_trades using the actual fill prices from `ib_fills`. Cancelled the duplicate PENDING signals to prevent double-buying.

## Test plan
- [ ] Upload a new Kianstrades video tomorrow — signals should be created with `mode = DAY_PENNY` and should NOT be blocked by the \$20 floor
- [ ] Auto-trader EOD sweep should close ABTS/HKIT/TGHL at market today

Made with [Cursor](https://cursor.com)