### PR TITLE
fix: ib_fills empty ticker causes fill_price=null, missing P&L in performance

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -180,6 +180,9 @@ export class IBConnection {
   private _orderFillPrices = new Map<number, number>();
   private _pendingReqCallbacks = new Map<number, (code: number, msg: string) => void>();
   private _pendingOrderCallbacks = new Map<number, PendingOrder>();
+  /** Persists orderId → ticker even after the order callback resolves — used as
+   *  fallback in execDetails when IB sends contract.symbol = '' */
+  private _orderIdToSymbol = new Map<number, string>();
 
   private _activeRequests = 0;
   private _requestQueue: Array<() => void> = [];
@@ -552,11 +555,13 @@ export class IBConnection {
       const qty = execution?.shares ?? execution?.cumQty ?? 0;
       const execId = execution?.execId ?? null;
       const side = execution?.side ?? '';
-      const ticker = contract?.symbol ?? '';
+      // IB sometimes sends contract.symbol = '' for bracket TP/SL fills.
+      // Fall back to our persistent orderIdToSymbol map registered at order placement.
+      const ticker = (contract?.symbol || this._orderIdToSymbol.get(orderId) || '');
 
       if (orderId && price > 0) {
         this._orderFillPrices.set(orderId, price);
-        console.log(`${this.tag} ExecDetails: order ${orderId} ${side} ${qty}x ${ticker} @ $${price.toFixed(4)} (execId=${execId})`);
+        console.log(`${this.tag} ExecDetails: order ${orderId} ${side} ${qty}x ${ticker || '?'} @ $${price.toFixed(4)} (execId=${execId})`);
         insertIbFill({
           order_id: orderId,
           exec_id: execId,
@@ -806,6 +811,12 @@ export class IBConnection {
       // verify/close it later. We never reject on timeout alone because IB paper
       // frequently accepts bracket orders but sends the ack >30s later, creating
       // orphaned IB positions with no corresponding DB record.
+      // Track all three order IDs so execDetails can look up ticker by orderId
+      // when IB sends contract.symbol = '' (happens ~5% of fills).
+      this._orderIdToSymbol.set(parentId, symbol);
+      this._orderIdToSymbol.set(tpId, symbol);
+      this._orderIdToSymbol.set(slId, symbol);
+
       let ackResolved = false;
       const ACK_TIMEOUT_MS = 30_000;
 
@@ -886,6 +897,7 @@ export class IBConnection {
       }, MKT_ORDER_TIMEOUT_MS);
 
       this._pendingOrderCallbacks.set(orderId, { resolve, reject, timer, symbol });
+      this._orderIdToSymbol.set(orderId, symbol);
 
       try {
         this.ib!.placeOrder(orderId, contract, order);
@@ -1078,6 +1090,7 @@ export class IBConnection {
       }, OPT_ORDER_TIMEOUT_MS);
 
       this._pendingOrderCallbacks.set(orderId, { resolve, reject, timer, symbol });
+      this._orderIdToSymbol.set(orderId, symbol);
 
       const actionLabel = params.action === 'BUY' ? 'BUY' : 'SELL';
       try {

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -6728,6 +6728,9 @@ async function checkProfitTakeOpportunities(
         });
 
         const realizedPnl = actualTrimQty * (avgFillPrice - ibPos.avgCost);
+        const realizedPct = ibPos.avgCost > 0
+          ? parseFloat(((avgFillPrice - ibPos.avgCost) / ibPos.avgCost * 100).toFixed(2))
+          : null;
 
         await createPaperTrade({
           ticker: trade.ticker, mode: 'LONG_TERM', signal: 'SELL',
@@ -6738,6 +6741,7 @@ async function checkProfitTakeOpportunities(
           status: 'CLOSED',
           ib_order_id: String(orderId),
           pnl: realizedPnl,
+          pnl_percent: realizedPct,
           pnl_source: 'ib_fill_calculated',
           close_reason: 'profit_take',
           closed_at: new Date().toISOString(),

--- a/supabase/migrations/20260602000002_backfill_ib_fills_ticker_and_fix_trigger.sql
+++ b/supabase/migrations/20260602000002_backfill_ib_fills_ticker_and_fix_trigger.sql
@@ -1,0 +1,224 @@
+-- Fix ib_fills sync trigger and backfill empty ticker rows.
+--
+-- Root cause: IB's execDetails callback sometimes sends contract.symbol = ''
+-- for bracket TP/SL fills. The sync trigger skips empty-ticker rows, so
+-- fill_price never gets written to paper_trades for those orders.
+--
+-- Also removes stale updated_at = NOW() references from the existing trigger —
+-- paper_trades does not have an updated_at column (it was never added).
+--
+-- IMPORTANT: Rewrite the function FIRST so that the backfill UPDATEs below
+-- (which fire this trigger) use the corrected version.
+
+-- ── Step 1: Rewrite paper account trigger (remove updated_at, add fill_price repair) ──
+CREATE OR REPLACE FUNCTION sync_ib_fill_to_paper_trades()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Skip rows without ticker (orderStatus noise before execDetails arrives)
+  IF NEW.ticker IS NULL OR NEW.ticker = '' THEN
+    RETURN NEW;
+  END IF;
+
+  -- ENTRY FILL: update fill_price + promote PENDING/SUBMITTED → FILLED.
+  -- Also repairs fill_price = NULL on already-closed trades (TARGET_HIT,
+  -- STOPPED, CLOSED) in case the entry fill arrived with ticker = '' initially
+  -- and was skipped by this trigger at insert time.
+  UPDATE paper_trades SET
+    fill_price  = CASE WHEN fill_price IS NULL THEN NEW.fill_price ELSE fill_price END,
+    filled_at   = COALESCE(filled_at, NEW.filled_at),
+    status      = CASE WHEN status IN ('PENDING', 'SUBMITTED') THEN 'FILLED' ELSE status END,
+    pnl         = CASE
+                    WHEN fill_price IS NULL AND status IN ('TARGET_HIT', 'STOPPED', 'CLOSED')
+                         AND close_price IS NOT NULL AND quantity IS NOT NULL
+                    THEN ROUND((
+                           (close_price - NEW.fill_price) * quantity
+                           * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                         )::numeric, 2)
+                    ELSE pnl
+                  END,
+    pnl_percent = CASE
+                    WHEN fill_price IS NULL AND status IN ('TARGET_HIT', 'STOPPED', 'CLOSED')
+                         AND close_price IS NOT NULL AND NEW.fill_price > 0
+                    THEN ROUND((
+                           (close_price - NEW.fill_price) / NEW.fill_price * 100
+                           * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                         )::numeric, 2)
+                    ELSE pnl_percent
+                  END
+  WHERE ib_order_id = NEW.order_id::text
+    AND (status IN ('PENDING', 'SUBMITTED', 'FILLED') OR fill_price IS NULL);
+
+  -- TP FILL: close trade as TARGET_HIT with IB's exact P&L when available
+  UPDATE paper_trades SET
+    close_price = NEW.fill_price,
+    closed_at   = COALESCE(closed_at, NEW.filled_at),
+    status      = 'TARGET_HIT',
+    pnl         = COALESCE(
+                    NEW.realized_pnl,
+                    (NEW.fill_price - fill_price) * quantity
+                      * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                  ),
+    pnl_percent = CASE WHEN fill_price > 0 THEN
+                    ROUND((
+                      (NEW.fill_price - fill_price) / fill_price * 100
+                      * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                    )::numeric, 2)
+                  ELSE NULL END,
+    pnl_source  = CASE WHEN NEW.realized_pnl IS NOT NULL
+                    THEN 'ib_realized'
+                    ELSE 'ib_fill_calculated'
+                  END,
+    close_reason = 'target_hit'
+  WHERE ib_tp_order_id = NEW.order_id::text
+    AND status = 'FILLED';
+
+  -- SL FILL: close trade as STOPPED with IB's exact P&L when available
+  UPDATE paper_trades SET
+    close_price = NEW.fill_price,
+    closed_at   = COALESCE(closed_at, NEW.filled_at),
+    status      = 'STOPPED',
+    pnl         = COALESCE(
+                    NEW.realized_pnl,
+                    (NEW.fill_price - fill_price) * quantity
+                      * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                  ),
+    pnl_percent = CASE WHEN fill_price > 0 THEN
+                    ROUND((
+                      (NEW.fill_price - fill_price) / fill_price * 100
+                      * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                    )::numeric, 2)
+                  ELSE NULL END,
+    pnl_source  = CASE WHEN NEW.realized_pnl IS NOT NULL
+                    THEN 'ib_realized'
+                    ELSE 'ib_fill_calculated'
+                  END,
+    close_reason = 'stopped'
+  WHERE ib_sl_order_id = NEW.order_id::text
+    AND status = 'FILLED';
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ── Step 2: Rewrite live account trigger (same fix) ───────────────────────────
+CREATE OR REPLACE FUNCTION sync_live_ib_fill_to_live_trades()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.ticker IS NULL OR NEW.ticker = '' THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE live_trades SET
+    fill_price  = CASE WHEN fill_price IS NULL THEN NEW.fill_price ELSE fill_price END,
+    filled_at   = COALESCE(filled_at, NEW.filled_at),
+    status      = CASE WHEN status IN ('PENDING', 'SUBMITTED') THEN 'FILLED' ELSE status END,
+    pnl         = CASE
+                    WHEN fill_price IS NULL AND status IN ('TARGET_HIT', 'STOPPED', 'CLOSED')
+                         AND close_price IS NOT NULL AND quantity IS NOT NULL
+                    THEN ROUND((
+                           (close_price - NEW.fill_price) * quantity
+                           * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                         )::numeric, 2)
+                    ELSE pnl
+                  END,
+    pnl_percent = CASE
+                    WHEN fill_price IS NULL AND status IN ('TARGET_HIT', 'STOPPED', 'CLOSED')
+                         AND close_price IS NOT NULL AND NEW.fill_price > 0
+                    THEN ROUND((
+                           (close_price - NEW.fill_price) / NEW.fill_price * 100
+                           * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                         )::numeric, 2)
+                    ELSE pnl_percent
+                  END
+  WHERE ib_order_id = NEW.order_id::text
+    AND (status IN ('PENDING', 'SUBMITTED', 'FILLED') OR fill_price IS NULL);
+
+  UPDATE live_trades SET
+    close_price  = NEW.fill_price,
+    closed_at    = COALESCE(closed_at, NEW.filled_at),
+    status       = 'TARGET_HIT',
+    pnl          = COALESCE(
+                     NEW.realized_pnl,
+                     (NEW.fill_price - fill_price) * quantity
+                       * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                   ),
+    pnl_percent  = CASE WHEN fill_price > 0 THEN
+                     ROUND((
+                       (NEW.fill_price - fill_price) / fill_price * 100
+                       * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                     )::numeric, 2)
+                   ELSE NULL END,
+    pnl_source   = CASE WHEN NEW.realized_pnl IS NOT NULL THEN 'ib_realized' ELSE 'ib_fill_calculated' END,
+    close_reason = 'target_hit'
+  WHERE ib_tp_order_id = NEW.order_id::text
+    AND status = 'FILLED';
+
+  UPDATE live_trades SET
+    close_price  = NEW.fill_price,
+    closed_at    = COALESCE(closed_at, NEW.filled_at),
+    status       = 'STOPPED',
+    pnl          = COALESCE(
+                     NEW.realized_pnl,
+                     (NEW.fill_price - fill_price) * quantity
+                       * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                   ),
+    pnl_percent  = CASE WHEN fill_price > 0 THEN
+                     ROUND((
+                       (NEW.fill_price - fill_price) / fill_price * 100
+                       * CASE WHEN signal = 'SELL' THEN -1 ELSE 1 END
+                     )::numeric, 2)
+                   ELSE NULL END,
+    pnl_source   = CASE WHEN NEW.realized_pnl IS NOT NULL THEN 'ib_realized' ELSE 'ib_fill_calculated' END,
+    close_reason = 'stopped'
+  WHERE ib_sl_order_id = NEW.order_id::text
+    AND status = 'FILLED';
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ── Step 3: Backfill ib_fills.ticker from paper_trades order ID columns ───────
+-- Now that the trigger function is fixed (no updated_at), these UPDATEs can
+-- safely fire the trigger to repair fill_price on closed trades.
+
+UPDATE ib_fills f
+SET ticker = pt.ticker
+FROM paper_trades pt
+WHERE (f.ticker IS NULL OR f.ticker = '')
+  AND pt.ib_order_id = f.order_id::text
+  AND pt.ticker IS NOT NULL AND pt.ticker != '';
+
+UPDATE ib_fills f
+SET ticker = pt.ticker
+FROM paper_trades pt
+WHERE (f.ticker IS NULL OR f.ticker = '')
+  AND pt.ib_tp_order_id = f.order_id::text
+  AND pt.ticker IS NOT NULL AND pt.ticker != '';
+
+UPDATE ib_fills f
+SET ticker = pt.ticker
+FROM paper_trades pt
+WHERE (f.ticker IS NULL OR f.ticker = '')
+  AND pt.ib_sl_order_id = f.order_id::text
+  AND pt.ticker IS NOT NULL AND pt.ticker != '';
+
+UPDATE live_ib_fills f
+SET ticker = lt.ticker
+FROM live_trades lt
+WHERE (f.ticker IS NULL OR f.ticker = '')
+  AND lt.ib_order_id = f.order_id::text
+  AND lt.ticker IS NOT NULL AND lt.ticker != '';
+
+UPDATE live_ib_fills f
+SET ticker = lt.ticker
+FROM live_trades lt
+WHERE (f.ticker IS NULL OR f.ticker = '')
+  AND lt.ib_tp_order_id = f.order_id::text
+  AND lt.ticker IS NOT NULL AND lt.ticker != '';
+
+UPDATE live_ib_fills f
+SET ticker = lt.ticker
+FROM live_trades lt
+WHERE (f.ticker IS NULL OR f.ticker = '')
+  AND lt.ib_sl_order_id = f.order_id::text
+  AND lt.ticker IS NOT NULL AND lt.ticker != '';


### PR DESCRIPTION
## Summary

- **Root cause**: IB's `execDetails` callback sometimes sends `contract.symbol = ''` for bracket TP/SL fills (~5% of fills). The DB trigger skips empty-ticker rows, so `fill_price` is never written to the paper trade — silently excluding trades from all performance calculations.
- **PLTR (Jun 1 TARGET_HIT +\$32.40)** was missing from Performance due to `fill_price = null`.
- **GE / ASML profit-take trades** had `pnl_percent = null` (Return% showed "—").

## Changes

- **`ib-connection.ts`**: Add `_orderIdToSymbol` map populated at order placement (bracket parent/TP/SL, market, options). Used as fallback in `execDetails` when `contract.symbol` is empty.
- **`scheduler.ts`**: Pass `pnl_percent` to `createPaperTrade` in the profit-take code path.
- **Migration `20260602000002`**: Fix sync trigger (remove stale `updated_at` refs that never existed on `paper_trades`), add repair path for `fill_price = NULL` on already-closed trades, backfill existing empty-ticker `ib_fills` rows from paper_trades order ID columns.

## DB patches applied
- PLTR `fill_price = 158.5` (manually + trigger re-ran)
- GE `pnl_percent = 9.16%`
- ASML `pnl_percent = 12.86%`

## Test plan
- [ ] Verify Performance tab shows PLTR day trade with P&L in Scanner Day Trades scorecard
- [ ] Verify GE and ASML show Return% in Recent Closed Trades table
- [ ] Verify future bracket fills have correct ticker in ib_fills

Made with [Cursor](https://cursor.com)