### PR TITLE
fix: prevent scheduler crash on duplicate external strategy signal

### DIFF
--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -479,14 +479,21 @@ export async function upsertSwingMetrics(params: {
 
 export async function createExternalStrategySignal(
   signal: Record<string, unknown>
-): Promise<ExternalStrategySignal> {
+): Promise<ExternalStrategySignal | null> {
   const sb = getSupabase();
   const { data, error } = await sb
     .from('external_strategy_signals')
     .insert(signal)
     .select()
     .single();
-  if (error) throw new Error(`createExternalStrategySignal: ${error.message}`);
+  if (error) {
+    // 23505 = unique_violation — a PENDING signal for this (ticker, signal,
+    // entry_price, execute_on_date) already exists (race between cycle and
+    // realtime execution, or two videos with the same ticker+entry today).
+    // Treat it as a dedup hit rather than crashing the entire cycle.
+    if (error.code === '23505') return null;
+    throw new Error(`createExternalStrategySignal: ${error.message}`);
+  }
   return data as ExternalStrategySignal;
 }
 

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -2023,7 +2023,7 @@ async function autoQueueDailySignalsFromTrackedVideos(): Promise<void> {
           const stopNote = rawStop != null && rawStop >= setup.longTriggerAbove
             ? ` | stop adjusted: ${rawStop} >= entry ${setup.longTriggerAbove} → fallback ${longStop}`
             : '';
-          await createExternalStrategySignal({
+          const newLong = await createExternalStrategySignal({
             source_name: sourceName,
             source_url: sourceUrl,
             strategy_video_id: video.videoId,
@@ -2038,7 +2038,7 @@ async function autoQueueDailySignalsFromTrackedVideos(): Promise<void> {
             execute_on_date: todayET,
             notes: `Auto from video ${video.videoId} | ${heading} | long breakout${stopNote}`,
           });
-          created += 1;
+          if (newLong) { created += 1; } else { deduped += 1; }
         } else {
           deduped += 1;
         }
@@ -2063,7 +2063,7 @@ async function autoQueueDailySignalsFromTrackedVideos(): Promise<void> {
           const stopNote = rawStop != null && rawStop <= setup.shortTriggerBelow
             ? ` | stop adjusted: ${rawStop} <= entry ${setup.shortTriggerBelow} → fallback ${shortStop}`
             : '';
-          await createExternalStrategySignal({
+          const newShort = await createExternalStrategySignal({
             source_name: sourceName,
             source_url: sourceUrl,
             strategy_video_id: video.videoId,
@@ -2078,7 +2078,7 @@ async function autoQueueDailySignalsFromTrackedVideos(): Promise<void> {
             execute_on_date: todayET,
             notes: `Auto from video ${video.videoId} | ${heading} | short breakdown${stopNote}`,
           });
-          created += 1;
+          if (newShort) { created += 1; } else { deduped += 1; }
         } else {
           deduped += 1;
         }
@@ -2294,7 +2294,7 @@ async function autoQueueGenericSignalsFromTrackedVideos(
           ? `ev=${bucket.ev.toFixed(2)} wr=${(bucket.evWinRate * 100).toFixed(0)}% n=${bucket.evTrades}`
           : `ev=unproven n=${bucket.evTrades}`;
 
-        await createExternalStrategySignal({
+        const newGeneric = await createExternalStrategySignal({
           source_name: bucket.sourceName,
           source_url: bucket.sourceUrl,
           strategy_video_id: bucket.videoId,
@@ -2310,8 +2310,13 @@ async function autoQueueGenericSignalsFromTrackedVideos(
           notes: `Generic strategy auto from video ${bucket.videoId} | ${bucket.heading} | scanner candidate: ${candidate.reason} | allocation group: ${topBuckets.length} | ${evNote}`,
         });
 
-        created += 1;
-        createdForTicker = true;
+        if (newGeneric) {
+          created += 1;
+          createdForTicker = true;
+        } else {
+          deduped += 1;
+          existingForTicker = true;
+        }
       }
 
       if (createdForTicker || existingForTicker) {


### PR DESCRIPTION
## Summary
- `createExternalStrategySignal` now returns `null` on Postgres unique_violation (23505) instead of throwing — prevents the entire execution cycle from crashing when two tracked videos produce the same signal for the same ticker/date
- All 3 call sites in `autoQueueDailySignalsFromTrackedVideos` handle the null return gracefully (count as dedup, not created)
- Root cause: `runCycle` and `runTradeExecutionOnly` both call `autoQueueDailySignalsFromTrackedVideos` concurrently; if two videos have the same ticker+entry+date, one succeeds and the other was previously crashing the cycle

## Test plan
- [ ] Build passes (`tsc` clean)
- [ ] Scheduler cycles complete without "duplicate key" errors in logs
- [ ] `Daily strategy signals already queued (N duplicates skipped)` appears instead of crash

Made with [Cursor](https://cursor.com)