### PR TITLE
fix: hydrate orderId→symbol map on IB connection startup

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -13,7 +13,7 @@
 import { IBApi, EventName, Contract, Order, OrderAction, OrderType, SecType, TimeInForce, OptionType, ScanCode, LocationCode, Instrument } from '@stoqey/ib';
 import type { ScannerSubscription } from '@stoqey/ib';
 export { LocationCode } from '@stoqey/ib';
-import { insertIbFill, updateIbFillCommission, getTodayFillPrices, getFillPriceByOrderId, saveConfigPartial, createAutoTradeEvent } from './lib/supabase.js';
+import { insertIbFill, updateIbFillCommission, getTodayFillPrices, getFillPriceByOrderId, getOpenOrderIdToSymbol, saveConfigPartial, createAutoTradeEvent } from './lib/supabase.js';
 import type { AccountType } from '../../shared/trade-types.js';
 
 // ── Constants ────────────────────────────────────────────
@@ -589,6 +589,7 @@ export class IBConnection {
     });
 
     this.hydrateOrderFillPrices().catch(() => {});
+    this.hydrateOrderIdToSymbol().catch(() => {});
 
     console.log(`${this.tag} Connecting to ${IB_HOST}:${this.port} (clientId=${this.clientId})...`);
     ib.connect();
@@ -630,6 +631,24 @@ export class IBConnection {
       }
     } catch (err) {
       console.warn(`${this.tag} Failed to hydrate fill prices from DB:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  private async hydrateOrderIdToSymbol(): Promise<void> {
+    try {
+      const map = await getOpenOrderIdToSymbol(this.label);
+      let count = 0;
+      for (const [orderId, ticker] of map) {
+        if (!this._orderIdToSymbol.has(orderId)) {
+          this._orderIdToSymbol.set(orderId, ticker);
+          count++;
+        }
+      }
+      if (count > 0) {
+        console.log(`${this.tag} Hydrated ${count} orderId→symbol mappings from DB`);
+      }
+    } catch (err) {
+      console.warn(`${this.tag} Failed to hydrate orderId→symbol:`, err instanceof Error ? err.message : err);
     }
   }
 

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -843,6 +843,30 @@ export async function getTodayFillPrices(accountType: AccountType = 'paper'): Pr
   return map;
 }
 
+/**
+ * Returns a Map<orderId, ticker> for all open (FILLED) positions that have IB
+ * order IDs recorded.  Used on startup to seed _orderIdToSymbol so that TP/SL
+ * execDetails arriving after a restart can still resolve the ticker even when
+ * IB sends contract.symbol = ''.
+ */
+export async function getOpenOrderIdToSymbol(accountType: AccountType = 'paper'): Promise<Map<number, string>> {
+  const sb = getSupabase();
+  const table = accountType === 'live' ? 'live_trades' : 'paper_trades';
+  const { data, error } = await sb
+    .from(table)
+    .select('ticker, ib_order_id, ib_tp_order_id, ib_sl_order_id')
+    .eq('status', 'FILLED')
+    .not('ib_order_id', 'is', null);
+  if (error || !data) return new Map();
+  const map = new Map<number, string>();
+  for (const row of data) {
+    if (row.ib_order_id)    map.set(Number(row.ib_order_id),    row.ticker);
+    if (row.ib_tp_order_id) map.set(Number(row.ib_tp_order_id), row.ticker);
+    if (row.ib_sl_order_id) map.set(Number(row.ib_sl_order_id), row.ticker);
+  }
+  return map;
+}
+
 export async function getFillPriceByOrderId(orderId: number, accountType: AccountType = 'paper'): Promise<number | undefined> {
   const sb = getSupabase();
   const { data } = await sb


### PR DESCRIPTION
## Summary
- On restart, `_orderIdToSymbol` was empty — any open bracket order placed in a previous run had no ticker fallback when IB sent `contract.symbol = ''` in `execDetails`
- Adds `getOpenOrderIdToSymbol()` in `supabase.ts` to query all FILLED `paper_trades` for their `ib_order_id`, `ib_tp_order_id`, `ib_sl_order_id` at startup
- `hydrateOrderIdToSymbol()` seeds the map on connect, same pattern as `hydrateOrderFillPrices()`
- Confirmed working: `[IB:paper] Hydrated 16 orderId→symbol mappings from DB` on first connect after restart
- FCX #2 today was the concrete example: TP order 21246 filled with empty `contract.symbol`, fill dropped → manually patched; this fix prevents recurrence

Made with [Cursor](https://cursor.com)