### PR TITLE
fix: don't close options scalp in DB when premium=0 and not yet expired

### DIFF
--- a/auto-trader/src/lib/options-scalp.ts
+++ b/auto-trader/src/lib/options-scalp.ts
@@ -544,6 +544,21 @@ async function closeScalpPosition(
 
   const pnl = (closePremium - premiumPaid) * 100;
 
+  // If the premium is $0, check whether the option has actually expired.
+  // If expiry is still in the future, IB still holds the position — don't
+  // mark the DB closed without a matching IB execution (IB / DB must agree).
+  if (closePremium <= 0) {
+    const expiryDate = new Date(expiry);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    expiryDate.setHours(0, 0, 0, 0);
+    if (expiryDate > today) {
+      console.log(`[Options Scalp] ${ticker} premium=$0 but expires ${expiry} — leaving FILLED, will expire naturally in IB`);
+      return;
+    }
+    // Expiry is today or past: option expired worthless, safe to close in DB.
+  }
+
   // Place sell-to-close order in IB
   if (isConnected() && closePremium > 0) {
     try {


### PR DESCRIPTION
## Summary
- `closeScalpPosition` was unconditionally updating the DB to CLOSED even when `closePremium=0` (no IB sell order placed) and the option hadn't expired yet
- IB rule: DB and IB must always agree — closing the DB without a matching IB execution is a bug
- Fix: if `closePremium <= 0` and expiry is still in the future, skip both the IB order and the DB update; leave as FILLED so it expires naturally in IB
- If expiry is today/past, still close in DB (expired worthless is legitimate)
- Restored SOFI paper_trade to FILLED (incorrectly closed today; IB holds the Jun 5 $18 put)

## Test plan
- [ ] At 3:45 PM, options scalps with current premium > 0 → sell order placed + DB closed ✓
- [ ] Options scalps with premium = $0 but expiry future → logged "leaving FILLED, will expire naturally" + DB stays FILLED ✓
- [ ] Options scalps with premium = $0 and expiry today/past → DB closed (expired worthless) ✓

Made with [Cursor](https://cursor.com)