### PR TITLE
fix: cancel IB GTC order when options scalp/leap no-fill times out

### DIFF
--- a/auto-trader/src/lib/options-leap.ts
+++ b/auto-trader/src/lib/options-leap.ts
@@ -18,7 +18,7 @@
  */
 
 import { getSupabase, createAutoTradeEvent } from './supabase.js';
-import { isConnected, placeOptionsOrder, getDefaultAccount } from '../ib-connection.js';
+import { isConnected, placeOptionsOrder, cancelOrder, getDefaultAccount } from '../ib-connection.js';
 import { getOptionsChain } from './options-chain.js';
 import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
 
@@ -325,6 +325,16 @@ async function executeLeap(p: LeapParams): Promise<void> {
   }
 
   if (result.timedOut || !result.avgFillPrice || result.avgFillPrice <= 0) {
+    // Cancel the live GTC order in IB — without this the order stays open and can
+    // ghost-fill the next morning even though the DB already shows CANCELLED.
+    if (result.orderId && isConnected()) {
+      try {
+        cancelOrder(result.orderId);
+        console.log(`[LEAP] ${p.ticker} — cancelled IB order #${result.orderId} (no fill)`);
+      } catch (cancelErr) {
+        console.warn(`[LEAP] ${p.ticker} — cancel IB #${result.orderId} failed:`, cancelErr instanceof Error ? cancelErr.message : cancelErr);
+      }
+    }
     await sb.from('paper_trades').update({
       status: 'CANCELLED', close_reason: 'no_fill', closed_at: new Date().toISOString(),
     }).eq('id', trade.id);

--- a/auto-trader/src/lib/options-scalp.ts
+++ b/auto-trader/src/lib/options-scalp.ts
@@ -19,7 +19,7 @@
  */
 
 import { getSupabase, createAutoTradeEvent } from './supabase.js';
-import { isConnected, placeOptionsOrder, getDefaultAccount } from '../ib-connection.js';
+import { isConnected, placeOptionsOrder, cancelOrder, getDefaultAccount } from '../ib-connection.js';
 import { findAtmStrike, getOptionGreeksForContract } from './options-chain.js';
 import { finnhubFetch, FINNHUB_KEY } from './finnhub.js';
 import { detectVwapReclaim, VWAP_RELIABLE_HOUR_ET } from './vwap.js';
@@ -386,6 +386,16 @@ async function executeScalp(p: ScalpParams): Promise<boolean> {
   }
 
   if (result.timedOut || !result.avgFillPrice || result.avgFillPrice <= 0) {
+    // Cancel the live GTC order in IB — without this the order stays open and can
+    // ghost-fill the next morning even though the DB already shows CANCELLED.
+    if (result.orderId && isConnected()) {
+      try {
+        cancelOrder(result.orderId);
+        console.log(`[Options Scalp] ${p.ticker} — cancelled IB order #${result.orderId} (no fill)`);
+      } catch (cancelErr) {
+        console.warn(`[Options Scalp] ${p.ticker} — cancel IB #${result.orderId} failed:`, cancelErr instanceof Error ? cancelErr.message : cancelErr);
+      }
+    }
     await sb.from('paper_trades').update({
       status: 'CANCELLED', close_reason: 'no_fill', closed_at: new Date().toISOString(),
     }).eq('id', trade.id);


### PR DESCRIPTION
## Problem

When `placeOptionsOrder()` timed out (no fill within the window), both `options-scalp.ts` and `options-leap.ts` correctly marked the DB record as `CANCELLED` — but **never called `cancelOrder()` on IB**. The GTC order stayed alive in IB and could ghost-fill the next morning with no matching `paper_trade` record.

Reproduced today with **AMZN Jun05'26 255 Call** (Order ID 1419844248) — still showing as "PreSubmitted" in IB after-hours while DB already showed CANCELLED.

## Fix

Both files now call `cancelOrder(result.orderId)` in the `timedOut` path before updating the DB. If the cancel call fails (e.g. IB not connected), it logs a warning and still proceeds with the DB update.

## Files changed
- `auto-trader/src/lib/options-scalp.ts`
- `auto-trader/src/lib/options-leap.ts`

Made with [Cursor](https://cursor.com)