### PR TITLE
fix: show Options label for OPTIONS_SCALP and OPTIONS_LEAP in Today's Activity

### DIFF
--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -132,7 +132,7 @@ export function TodayActivityTab({ events, trades, todayTrades, todaySignalsForE
   };
   const todayISO = todayStart.toISOString();
 
-  const OPTIONS_MODES = new Set(['OPTIONS_PUT', 'OPTIONS_CALL', 'CALENDAR_SPREAD', 'CREDIT_SPREAD', 'EARNINGS_CALENDAR']);
+  const OPTIONS_MODES = new Set(['OPTIONS_PUT', 'OPTIONS_CALL', 'CALENDAR_SPREAD', 'CREDIT_SPREAD', 'EARNINGS_CALENDAR', 'OPTIONS_SCALP', 'OPTIONS_LEAP']);
 
   // Primary data source: todayTrades (from paper_trades, kept accurate by ib_fills trigger).
   // Include all modes — options trades visible via the "Options" filter chip.
@@ -478,8 +478,7 @@ export function TodayActivityTab({ events, trades, todayTrades, todaySignalsForE
                 : trade.mode === 'DAY_PENNY' ? 'Penny'
                 : trade.mode === 'SWING_TRADE' ? 'Swing'
                 : trade.mode === 'LONG_TERM' ? 'Long Term'
-                : (trade.mode === 'OPTIONS_PUT' || trade.mode === 'OPTIONS_CALL'
-                   || trade.mode === 'CALENDAR_SPREAD' || trade.mode === 'CREDIT_SPREAD') ? 'Options'
+                : OPTIONS_MODES.has(trade.mode ?? '') ? 'Options'
                 : '—';
 
               const entrySignal = trade.signal ?? 'BUY';


### PR DESCRIPTION
## Problem
`OPTIONS_SCALP` and `OPTIONS_LEAP` trades were showing `—` in the Type column and were excluded from the Options filter tab in Today's Activity.

## Fix
- Added `OPTIONS_SCALP` and `OPTIONS_LEAP` to the `OPTIONS_MODES` set so the Options filter tab includes them
- Simplified `modeLabel` to use `OPTIONS_MODES.has()` instead of a separate inline list (keeps both in sync automatically)

Made with [Cursor](https://cursor.com)