### PR TITLE
fix: show specific options type labels in Today's Activity

### DIFF
--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -478,7 +478,11 @@ export function TodayActivityTab({ events, trades, todayTrades, todaySignalsForE
                 : trade.mode === 'DAY_PENNY' ? 'Penny'
                 : trade.mode === 'SWING_TRADE' ? 'Swing'
                 : trade.mode === 'LONG_TERM' ? 'Long Term'
-                : OPTIONS_MODES.has(trade.mode ?? '') ? 'Options'
+                : trade.mode === 'OPTIONS_SCALP' ? 'Scalp'
+                : trade.mode === 'OPTIONS_LEAP' ? 'Leap'
+                : trade.mode === 'OPTIONS_PUT' ? 'Put'
+                : trade.mode === 'OPTIONS_CALL' ? 'Call'
+                : (trade.mode === 'CREDIT_SPREAD' || trade.mode === 'CALENDAR_SPREAD' || trade.mode === 'EARNINGS_CALENDAR') ? 'Spread'
                 : '—';
 
               const entrySignal = trade.signal ?? 'BUY';


### PR DESCRIPTION
## Change
Replace the generic 'Options' label with distinct per-mode labels so it's immediately clear what kind of options trade each row is:

| Mode | Before | After |
|------|--------|-------|
| OPTIONS_SCALP | Options | **Scalp** |
| OPTIONS_LEAP | Options | **Leap** |
| OPTIONS_PUT | Options | **Put** |
| OPTIONS_CALL | Options | **Call** |
| CREDIT_SPREAD | Options | **Spread** |
| CALENDAR_SPREAD | Options | **Spread** |

The Options filter tab still shows all of them (no change to `OPTIONS_MODES`).

Made with [Cursor](https://cursor.com)