### PR TITLE
fix(options): exclude PENDING/SUBMITTED positions from all P&L calculations

### DIFF
--- a/app/src/lib/optionsApi.ts
+++ b/app/src/lib/optionsApi.ts
@@ -4,7 +4,7 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
-import { ACTIVE_STATUSES, CLOSED_STATUSES } from '../../../shared/trade-status-sets.ts';
+import { CLOSED_STATUSES } from '../../../shared/trade-status-sets.ts';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
@@ -263,7 +263,7 @@ export async function getOpenOptionsPositions(): Promise<OpenOptionsPosition[]> 
     .from('paper_trades')
     .select('id, ticker, mode, option_strike, option_expiry, option_premium, option_contracts, option_capital_req, option_prob_profit, option_iv_rank, option_annual_yield, option_net_price, option_delta, option_assigned, status, close_reason, pnl, opened_at, closed_at, notes, scanner_reason, ib_order_id')
     .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
-    .in('status', [...ACTIVE_STATUSES])
+    .in('status', ['FILLED', 'PARTIAL'])
     .order('option_expiry', { ascending: true });
   if (error) throw error;
   return (data ?? []) as OpenOptionsPosition[];
@@ -311,7 +311,7 @@ export async function getOptionsMonthlyStats(): Promise<OptionsMonthlyStats> {
       .from('paper_trades')
       .select('id, option_premium, option_contracts')
       .in('mode', ['OPTIONS_PUT', 'OPTIONS_CALL'])
-      .in('status', [...ACTIVE_STATUSES]),
+      .in('status', ['FILLED', 'PARTIAL']),
     supabase
       .from('paper_trades')
       .select('pnl')
@@ -457,7 +457,7 @@ export async function getOpenCreditSpreads(): Promise<CreditSpreadPosition[]> {
     .from('paper_trades')
     .select('id, ticker, mode, status, spread_type, spread_short_strike, spread_long_strike, spread_width, spread_net_credit, spread_credit_pct, spread_max_loss, spread_max_gain, option_expiry, option_contracts, option_delta, pnl, opened_at, closed_at, close_reason, notes, scanner_reason')
     .eq('mode', 'CREDIT_SPREAD')
-    .in('status', [...ACTIVE_STATUSES])
+    .in('status', ['FILLED', 'PARTIAL'])
     .order('option_expiry', { ascending: true });
   if (error) throw error;
   return (data ?? []) as CreditSpreadPosition[];


### PR DESCRIPTION
## Summary
- `getOpenOptionsPositions()` now filters to `FILLED`/`PARTIAL` only (was `ACTIVE_STATUSES` which included `PENDING`/`SUBMITTED`)
- Same fix applied to `getOpenCreditSpreads()` and the "open" positions query inside `getOptionsMonthlyStats()`
- Removes unused `ACTIVE_STATUSES` import from `optionsApi.ts`

## Effect
Pending options (not yet filled by IB) no longer appear on the Options main page or contribute to:
- Unrealized P&L / "Cost to Close Now"
- Premium in Play / Monthly income progress bar
- Crash scenario calculations (30%/50% drawdown)
- Deployed capital figure
- Credit spread open positions list

## Test plan
- [ ] Open the Options page — only FILLED positions should appear in open puts and open spreads sections
- [ ] "Premium in Play" should not include pending options
- [ ] Monthly P&L stats unchanged (they only ever counted CLOSED statuses for realized P&L)

Made with [Cursor](https://cursor.com)