### PR TITLE
fix: auto-classify sub-$5 influencer signals as DAY_PENNY, lower floor to $5

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -1989,14 +1989,20 @@ async function autoQueueDailySignalsFromTrackedVideos(): Promise<void> {
     if (!sourceName) continue;
     const sourceUrl = inferSourceUrl(video);
     const heading = (video.videoHeading ?? video.videoId).trim();
-    // daily_penny videos are explicitly penny-stock plays; always use DAY_PENNY
-    // so they bypass the $20 influencer day-trade floor (which targets illiquid
-    // mid-caps, not intentional penny signals).
-    const mode = video.strategyType === 'daily_penny' ? 'DAY_PENNY' : (video.timeframe ?? 'DAY_TRADE');
+    // Video-level base mode from strategy type / timeframe.
+    const videoBaseMode = video.strategyType === 'daily_penny' ? 'DAY_PENNY' : (video.timeframe ?? 'DAY_TRADE');
 
     for (const setup of (video.extractedSignals ?? [])) {
       const ticker = String(setup.ticker ?? '').trim().toUpperCase();
       if (!ticker) continue;
+
+      // Per-signal: if the entry trigger is sub-$5 (SEC penny stock threshold), use DAY_PENNY
+      // regardless of channel. This handles channels like Kianstrades whose video-level
+      // strategy_type may be mis-classified, and any influencer who occasionally picks pennies.
+      const entryRef = setup.longTriggerAbove ?? setup.shortTriggerBelow ?? null;
+      const mode = videoBaseMode === 'DAY_TRADE' && entryRef !== null && entryRef < 5
+        ? 'DAY_PENNY'
+        : videoBaseMode;
 
       // Minimum stop distance: 0.3% of entry. Prevents zero-width brackets when the
       // influencer gives the same price for both long and short trigger (e.g. SPY 704.7
@@ -4856,12 +4862,14 @@ async function executeExternalStrategySignal(
     return 'failed';
   }
 
-  // Influencer penny stock floor: data shows 13 influencer sub-$20 day trades = -$3,469
-  // (GFAI at $0.82, EZRA at $0.31, etc.). Block true penny stocks while still allowing
-  // influencer calls in the $20-50 range.
-  if (isInfluencerSignal && signal.mode === 'DAY_TRADE' && referencePrice < 20) {
+  // Influencer penny stock floor: block sub-$5 stocks that somehow slip through as DAY_TRADE.
+  // Intentional penny plays should be classified DAY_PENNY at signal creation (entry price < $5);
+  // this is a safety net for edge cases where classification fails.
+  // Floor lowered from $20 → $5 to match the SEC/industry penny stock definition and avoid
+  // blocking $5-$20 influencer picks that are legitimate small-cap calls.
+  if (isInfluencerSignal && signal.mode === 'DAY_TRADE' && referencePrice < 5) {
     return skipExternalSignal(
-      `Price $${referencePrice.toFixed(2)} below $20 influencer day trade floor`,
+      `Price $${referencePrice.toFixed(2)} below $5 influencer day trade floor`,
       'influencer_price_floor',
     );
   }

--- a/supabase/functions/import-strategy-signals/index.ts
+++ b/supabase/functions/import-strategy-signals/index.ts
@@ -422,12 +422,14 @@ Deno.serve(async (req) => {
       const entryDesc = stockEntryCtx === 'above_todays_high'
         ? `Long above today's high (~${entryPrice})`
         : `Long above ${entryPrice}`;
+      // Sub-$5 entry price = penny stock (SEC threshold) → DAY_PENNY regardless of channel.
+      const signalMode = primaryMode === 'DAY_TRADE' && entryPrice < 5 ? 'DAY_PENNY' : primaryMode;
       toInsert.push({
         source_name: video.source_name,
         source_url: sourceUrl,
         ticker,
         signal: 'BUY',
-        mode: primaryMode,
+        mode: signalMode,
         confidence: 7,
         entry_price: entryPrice,
         stop_loss: stopLoss ?? (resolvedShortTrigger ?? null),
@@ -453,12 +455,14 @@ Deno.serve(async (req) => {
       const entryDesc = stockEntryCtx === 'below_todays_low'
         ? `Short below today's low (~${entryPrice})`
         : `Short below ${entryPrice}`;
+      // Sub-$5 entry price = penny stock (SEC threshold) → DAY_PENNY regardless of channel.
+      const signalMode = primaryMode === 'DAY_TRADE' && entryPrice < 5 ? 'DAY_PENNY' : primaryMode;
       toInsert.push({
         source_name: video.source_name,
         source_url: sourceUrl,
         ticker,
         signal: 'SELL',
-        mode: primaryMode,
+        mode: signalMode,
         confidence: 7,
         entry_price: entryPrice,
         stop_loss: stopLoss ?? (resolvedLongTrigger ?? null),


### PR DESCRIPTION
## Summary

- **Per-signal penny auto-classification**: at signal creation time (both `import-strategy-signals` and `autoQueueDailySignalsFromTrackedVideos`), if `entry_price < $5` the mode is set to `DAY_PENNY` regardless of which channel the video came from — stock price is the ground truth, not a hardcoded channel bucket
- **Floor lowered $20 → $5**: the influencer DAY_TRADE floor was blocking legitimate $5–$20 small-cap calls (XOS at $6.82, etc.); floor now only catches true pennies that slip through as DAY_TRADE
- **Root cause today**: Kianstrades video `DZGxhyqRYtZ` was classified `daily_signal` instead of `daily_penny` (classification bug), so YMAT/XOS/DEVS were all created as `DAY_TRADE` and blocked by the $20 floor despite being in the DB from a known penny channel. Fixed by patching the video record and re-importing signals.

## Test plan
- [ ] Upload a new Kianstrades video — signals for sub-$5 stocks should appear as DAY_PENNY
- [ ] Upload a Somesh video with a mix of $6 and $200 stocks — $6 stock gets DAY_PENNY, $200 gets DAY_TRADE
- [ ] Influencer signal for a $3 stock with mode=DAY_TRADE hits $5 floor (safety net still works)

Made with [Cursor](https://cursor.com)