### PR TITLE
fix: show correct 'External signal · Kianstrades' label when strategy_source is set

### DIFF
--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -463,7 +463,8 @@ export function TodayActivityTab({ events, trades, todayTrades, todaySignalsForE
               // Only show realized P&L for closed trades — active positions haven't locked in gains/losses yet
               const pnl = isActive ? null : (trade.pnl ?? null);
 
-              const isExternalSignal = trade.scanner_reason?.includes('External')
+              const isExternalSignal = !!trade.strategy_source
+                || trade.scanner_reason?.includes('External')
                 || trade.notes?.startsWith('External signal');
               const externalInfluencer = trade.strategy_source
                 ?? trade.scanner_reason?.match(/External strategy signal from (.+?)(?:\s*\||$)/)?.[1]


### PR DESCRIPTION
## Summary
- \`isExternalSignal\` in \`TodayActivityTab\` was only checking \`scanner_reason\` and \`notes\` patterns — missed the case where \`strategy_source\` is set directly (manual paper_trade inserts, externally-sourced trades)
- ABTS and HKIT from yesterday's Kianstrades video showed as "Trade signal" instead of "External signal · Kianstrades"
- Fix: \`!!trade.strategy_source\` is now the primary check; the scanner_reason/notes patterns remain as fallbacks

## Test plan
- [ ] ABTS and HKIT in Today's Activity show "External signal · Kianstrades"
- [ ] Normal scanner trades still show "Trade signal"

Made with [Cursor](https://cursor.com)