### PR TITLE
fix: DAY_PENNY bracket orders expire at close (DAY tif, not GTC)

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -5045,7 +5045,9 @@ async function executeExternalStrategySignal(
           entryPrice: effectiveEntryPrice!,
           stopLoss: effectiveStopLoss!,
           takeProfit: effectiveTargetPrice!,
-          tif: signal.mode === 'DAY_TRADE' ? 'DAY' : 'GTC',
+          // DAY_PENNY is same-day intraday — expire at close like DAY_TRADE.
+          // GTC would allow after-hours fills, creating overnight exposure.
+          tif: (signal.mode === 'DAY_TRADE' || signal.mode === 'DAY_PENNY') ? 'DAY' : 'GTC',
         });
         ibOrderId = String(result.parentOrderId);
         ibTpOrderId = String(result.takeProfitOrderId);


### PR DESCRIPTION
## Root Cause

On June 2, ABTS, HKIT, and TGHL (Kianstrades DAY_PENNY signals) had their bracket
BUY orders filled at **4:19 PM ET** — 19 minutes after market close. This happened
because `DAY_PENNY` external-signal brackets were placed with `tif: 'GTC'` instead of
`tif: 'DAY'`.

The EOD sweeps (3:55 PM and 4:05 PM) ran before the fills occurred, so they found no
IB positions to close. When IB filled the GTC limit orders post-close, the positions
entered overnight with live GTC stop-losses but no EOD protection. HKIT dropped 49%
overnight; its stop triggered for a -$2,448 loss.

## Fix

In `executeExternalStrategySignal`, change the `tif` logic to treat `DAY_PENNY` the
same as `DAY_TRADE`:

```typescript
// Before
tif: signal.mode === 'DAY_TRADE' ? 'DAY' : 'GTC',

// After
tif: (signal.mode === 'DAY_TRADE' || signal.mode === 'DAY_PENNY') ? 'DAY' : 'GTC',
```

`DAY_PENNY` signals are intraday momentum plays — if the entry trigger isn't hit by
market close, the order should expire, not carry overnight risk.

## Test Plan
- [ ] Auto-trader builds cleanly (`npm run build`)
- [ ] Future DAY_PENNY external signals will place `DAY` bracket orders that expire at 4 PM

Made with [Cursor](https://cursor.com)