### PR TITLE
fix: today's activity missing losses + penny stock IB routing

### DIFF
--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -228,17 +228,37 @@ export async function getTodayTrades(accountView: AccountView = 'paper'): Promis
   todayStart.setHours(0, 0, 0, 0);
   const todayISO = todayStart.toISOString();
 
+  // Look back 7 days to catch stale day trades the EOD sweep missed.
+  const lookbackStart = new Date(todayStart);
+  lookbackStart.setDate(lookbackStart.getDate() - 7);
+  const lookbackISO = lookbackStart.toISOString();
+
   async function fetchForTable(table: 'paper_trades' | 'live_trades', acct?: AccountType): Promise<PaperTradeWithAccount[]> {
+    // Fetch today's traded rows (opened or closed today) PLUS any still-open
+    // (FILLED/PARTIAL) day trades from the past 7 days. These are stale positions
+    // the EOD sweep missed — they belong in today's activity because the auto-trader
+    // is actively trying to close them today.
     const { data, error } = await supabase
       .from(table)
       .select('*')
-      .or(`opened_at.gte.${todayISO},closed_at.gte.${todayISO}`)
+      .or(
+        `opened_at.gte.${todayISO},` +
+        `closed_at.gte.${todayISO},` +
+        `and(status.in.(FILLED,PARTIAL),mode.in.(DAY_TRADE,DAY_PENNY),filled_at.gte.${lookbackISO})`
+      )
       .order('opened_at', { ascending: false });
 
     if (error) return [];
     const rows = (data ?? []) as PaperTrade[];
-    if (acct) return rows.map(t => ({ ...t, _accountType: acct }));
-    return rows;
+    // Deduplicate by id in case any row matches multiple OR conditions
+    const seen = new Set<string>();
+    const deduped = rows.filter(r => {
+      if (seen.has(r.id)) return false;
+      seen.add(r.id);
+      return true;
+    });
+    if (acct) return deduped.map(t => ({ ...t, _accountType: acct }));
+    return deduped;
   }
 
   if (accountView === 'live') return fetchForTable('live_trades', 'live');

--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -63,6 +63,10 @@ export interface MarketOrderParams {
   symbol: string;
   side: 'BUY' | 'SELL';
   quantity: number;
+  /** Use IB's Adaptive Algo instead of a plain MKT order.
+   *  Recommended for sub-$1 stocks to avoid IB error 2161
+   *  (regulatory price cap on plain market orders). */
+  useAdaptiveAlgo?: boolean;
 }
 
 export interface MarketOrderResult {
@@ -894,7 +898,7 @@ export class IBConnection {
       throw new Error(`${this.tag} Not connected to IB Gateway`);
     }
 
-    const { symbol, side, quantity } = params;
+    const { symbol, side, quantity, useAdaptiveAlgo } = params;
     const contract = await this.resolveContractForOrder(symbol);
 
     return new Promise((resolve, reject) => {
@@ -906,6 +910,14 @@ export class IBConnection {
         totalQuantity: quantity,
         tif: TimeInForce.DAY,
         transmit: true,
+        // IB Adaptive Algo: avoids error 2161 (regulatory price cap) on sub-$1 stocks.
+        // Set algoStrategy="Adaptive" + adaptivePriority="Urgent" so it fills quickly
+        // while still routing through IB's algo infrastructure (bypassing the plain
+        // MKT order price cap). Confirmed via IB TWS API docs: ibalgos.html
+        ...(useAdaptiveAlgo ? {
+          algoStrategy: 'Adaptive',
+          algoParams: [{ tag: 'adaptivePriority', value: 'Urgent' }],
+        } : {}),
       };
 
       const timer = setTimeout(() => {

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -1106,8 +1106,11 @@ async function checkStaleDayTrades(positions: EnrichedPosition[]): Promise<void>
     const closeSide = isLong ? 'SELL' : 'BUY';
     if (qty <= 0) continue;
 
+    // Sub-$1 stocks trigger IB error 2161 (regulatory price cap) with plain MKT orders.
+    // IB explicitly recommends using IBALGO (Adaptive) instead — use it for any stock ≤ $5.
+    const useAdaptiveAlgo = fillPrice <= 5;
     try {
-      const result = await placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });
+      const result = await placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty, useAdaptiveAlgo });
       await recordTradeClose({
         tradeId: trade.id,
         closePrice: result.avgFillPrice,
@@ -1116,9 +1119,34 @@ async function checkStaleDayTrades(positions: EnrichedPosition[]): Promise<void>
         orderId: result.orderId,
         accountType: 'paper',
       });
-      log(`  ${trade.ticker}: stale position closed via market order @ $${result.avgFillPrice.toFixed(2)}`);
+      log(`  ${trade.ticker}: stale position closed via ${useAdaptiveAlgo ? 'Adaptive Algo' : 'market order'} @ $${result.avgFillPrice.toFixed(2)}`);
     } catch (err) {
-      log(`  ${trade.ticker}: stale close failed — ${err instanceof Error ? err.message : 'unknown'}`);
+      const errMsg = err instanceof Error ? err.message : 'unknown';
+      log(`  ${trade.ticker}: stale close failed — ${errMsg}`);
+
+      // IB error code=200 means "No security definition found" — the symbol is no longer
+      // tradeable on IB (delisted, OTC removed, etc.). The position can never be closed
+      // via IB. Mark it as CLOSED with the last known quote price so it appears in today's
+      // activity with a loss and doesn't stay invisibly stuck as FILLED forever.
+      const isNoSecurityDef = errMsg.includes('code=200') || errMsg.includes('No security definition');
+      if (isNoSecurityDef) {
+        const fallbackPrice = await getQuotePrice(trade.ticker);
+        const estimatedClose = fallbackPrice ?? fillPrice;
+        await recordTradeClose({
+          tradeId: trade.id,
+          closePrice: estimatedClose,
+          closeReason: 'stale_eod_close',
+          status: 'CLOSED',
+          accountType: 'paper',
+          overridePnlSource: 'estimated',
+          extraUpdates: { notes: `IB error: security definition not found — position may still exist in IB; close price estimated` },
+        });
+        log(`  ${trade.ticker}: no IB security definition — marked CLOSED with estimated price $${estimatedClose.toFixed(2)} (manual IB review required)`);
+        await persistEvent(trade.ticker, 'warning',
+          `⚠️ Stale position: IB can no longer find ${trade.ticker} (no security definition) — marked closed at estimated price $${estimatedClose.toFixed(2)}. Manual IB review required.`,
+          { action: 'closed', source: 'system', mode: trade.mode as string },
+        );
+      }
     }
   }
 }
@@ -3650,7 +3678,7 @@ async function executeScannerTrade(
         log(`${ticker}: skipped — market direction against BUY: SPY ${spyPct.toFixed(2)}%`);
         persistEvent(ticker, 'skipped', `Market direction: SPY ${spyPct.toFixed(2)}% against BUY`, {
           action: 'skipped', source: 'scanner', mode, skip_reason: 'market_direction',
-          spy_change_pct: spyPct,
+          metadata: { spy_change_pct: spyPct },
         });
         return 'skipped:market_direction_bearish';
       }
@@ -3658,7 +3686,7 @@ async function executeScannerTrade(
         log(`${ticker}: skipped — market direction against SELL: SPY +${spyPct.toFixed(2)}%`);
         persistEvent(ticker, 'skipped', `Market direction: SPY +${spyPct.toFixed(2)}% against SELL`, {
           action: 'skipped', source: 'scanner', mode, skip_reason: 'market_direction',
-          spy_change_pct: spyPct,
+          metadata: { spy_change_pct: spyPct },
         });
         return 'skipped:market_direction_bullish';
       }


### PR DESCRIPTION
## Summary

- **spy_change_pct PERMANENT failure**: `persistEvent()` was passing `spy_change_pct` as a top-level field — `auto_trade_events` has no such column. Every market-direction skip event (SMH, NVDA, etc.) was failing with PERMANENT DB error and not appearing in the activity feed. Fixed by moving into `metadata`.

- **Stale FILLED positions invisible in today's tab**: `getTodayTrades()` only fetched rows where `opened_at >= today` or `closed_at >= today`. A stale HKIT/ABTS/TGHL opened yesterday and still FILLED would never appear. Fixed: also include `FILLED/PARTIAL` DAY_TRADE + DAY_PENNY trades from the last 7 days.

- **IB code=200 (No security definition) leaves position stuck forever**: When IB can't find a symbol (delisted/OTC removed), the stale close catch block just logged and moved on — paper_trade stayed FILLED indefinitely. Fixed: detect error code=200, mark the trade CLOSED with estimated price and create a warning event.

- **IB error 2161 (regulatory price cap) on sub-$5 market orders**: IB converts plain MKT orders on cheap stocks to capped limit orders that fill only 100 shares at a time. IB's own error message says to use IBALGO. Added `useAdaptiveAlgo` to `placeMarketOrder()`; stale close path now uses it automatically for stocks ≤ $5.

## Test plan
- [ ] Tomorrow's first stale check cycle: verify penny stock stale closes log "Adaptive Algo" instead of plain "market order"
- [ ] Verify `spy_change_pct` events no longer show PERMANENT failure in `/tmp/auto-trader-stdout.log`
- [ ] Confirm today's activity tab shows stale FILLED day trades from prior days

Made with [Cursor](https://cursor.com)