### PR TITLE
fix: sum all partial fills for P&L + treat IB 2161 as advisory + DAY_PENNY Adaptive Algo

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -432,14 +432,14 @@ export class IBConnection {
       if (reqId != null && this._pendingOrderCallbacks.has(reqId)) {
         const pending = this._pendingOrderCallbacks.get(reqId)!;
 
-        // Code 399 = "order repriced to avoid crossing a resting order" — this is a WARNING,
-        // not a rejection. IB reprices and fills the order anyway. If we reject and delete the
-        // callback here, the subsequent orderStatus:Filled event has nowhere to resolve, the
-        // placeMarketOrder promise rejects, the caller thinks the order failed and retries —
-        // creating duplicate sells. Confirmed: caused 3× IWM sells and a 20-share accidental short.
-        // Solution: swallow the warning, keep the callback alive, let the fill event resolve it.
-        if (code === 399) {
-          console.warn(`${this.tag} Order ${reqId} (${pending.symbol}) warning code=399: ${err.message} — order repriced by IB, still waiting for fill`);
+        // Code 399 = "order repriced to avoid crossing a resting order" — advisory WARNING.
+        // Code 2161 = IB regulatory price cap — IB converts MKT to a capped limit order but
+        //   the order stays ALIVE and fills when the market cooperates. Rejecting here causes
+        //   placeMarketOrder to throw before createPaperTrade runs, so the IB fill arrives but
+        //   no paper_trade record is ever created (confirmed: XOS on 2026-06-03, 869 shares).
+        // Solution for both: swallow the advisory, keep the callback alive, let fill resolve it.
+        if (code === 399 || code === 2161) {
+          console.warn(`${this.tag} Order ${reqId} (${pending.symbol}) advisory code=${code}: ${err.message} — order still live, waiting for fill`);
           return;
         }
 

--- a/auto-trader/src/lib/trade-closer.ts
+++ b/auto-trader/src/lib/trade-closer.ts
@@ -63,7 +63,9 @@ export async function recordTradeClose(params: CloseTradeParams): Promise<void> 
     pnlPct = overridePnlPct ?? (fillPrice * qty > 0 ? (overridePnl / (fillPrice * qty)) * 100 : null);
     pnlSource = overridePnlSource ?? 'ib_fill_calculated';
   } else {
-    // 2. Check ib_fills for realizedPnl from commissionReport
+    // 2. Check ib_fills for realizedPnl from commissionReport.
+    // Penny stocks fill in many 100-share chunks — SUM all fills for the order
+    // rather than taking the first row (LIMIT 1 would give a ~100-share slice P&L).
     let ibRealizedPnl: number | null = null;
     if (orderId != null) {
       const fillsTableName = fillsTable(accountType);
@@ -71,13 +73,12 @@ export async function recordTradeClose(params: CloseTradeParams): Promise<void> 
         .from(fillsTableName)
         .select('realized_pnl')
         .eq('order_id', orderId)
-        .not('realized_pnl', 'is', null)
-        .limit(1);
+        .not('realized_pnl', 'is', null);
 
-      if (fills && fills.length > 0 && fills[0].realized_pnl != null) {
-        const rpnl = fills[0].realized_pnl as number;
-        if (isFinite(rpnl) && Math.abs(rpnl) < 1e6) {
-          ibRealizedPnl = rpnl;
+      if (fills && fills.length > 0) {
+        const totalRpnl = fills.reduce((sum, f) => sum + (f.realized_pnl as number), 0);
+        if (isFinite(totalRpnl) && Math.abs(totalRpnl) < 1e6) {
+          ibRealizedPnl = totalRpnl;
         }
       }
     }

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -1155,9 +1155,11 @@ async function checkStaleDayTrades(positions: EnrichedPosition[]): Promise<void>
     const closeSide = isLong ? 'SELL' : 'BUY';
     if (qty <= 0) continue;
 
-    // Sub-$1 stocks trigger IB error 2161 (regulatory price cap) with plain MKT orders.
-    // IB explicitly recommends using IBALGO (Adaptive) instead — use it for any stock ≤ $5.
-    const useAdaptiveAlgo = fillPrice <= 5;
+    // DAY_PENNY trades can trigger IB error 2161 (regulatory price cap) with plain MKT
+    // orders regardless of price (confirmed: XOS at $6.55, TGHL at $0.86). Use Adaptive
+    // Algo for all penny-mode stale closes. Also keep the sub-$5 fallback for any mislabelled
+    // DAY_TRADE that slips through at a low price.
+    const useAdaptiveAlgo = trade.mode === 'DAY_PENNY' || fillPrice <= 5;
     try {
       const result = await placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty, useAdaptiveAlgo });
       await recordTradeClose({
@@ -5147,10 +5149,15 @@ async function executeExternalStrategySignal(
           upsertSwingMetrics({ date: getETDateString(), swing_orders_placed: 1 }).catch(() => {});
         }
       } else {
+        // DAY_PENNY stocks can trigger IB error 2161 (regulatory price cap) with plain
+        // MKT orders at any price. Use Adaptive Algo for all penny-mode entries so IB
+        // routes through its algo infrastructure and avoids the cap. For regular day
+        // trades the cap is not an issue (stocks priced well above $1).
         const result = await extConnection.placeMarketOrder({
           symbol: ticker,
           side,
           quantity: sizing.quantity,
+          useAdaptiveAlgo: signal.mode === 'DAY_PENNY',
         });
         ibOrderId = String(result.orderId);
       }


### PR DESCRIPTION
## Summary

- **`trade-closer.ts`**: Replace `LIMIT 1` with a `SUM` over all `ib_fills` rows for the order. Penny stocks fill in 100-share chunks — the first fill's `realized_pnl` was only ~$22 for a 1857-share ABTS position that actually lost $420.
- **`ib-connection.ts`**: IB error code 2161 is a regulatory price-cap _advisory_ (order stays alive and fills). Treating it as a rejection caused `createPaperTrade` to be skipped while IB filled the order anyway — confirmed orphaned XOS position (869 shares, no DB record).
- **`scheduler.ts`**: Use Adaptive Algo for all `DAY_PENNY` market orders (entry + stale close), not just sub-$5. XOS at $6.55 still triggered 2161; stale-close condition extended from `fillPrice <= 5` to `mode === 'DAY_PENNY' || fillPrice <= 5`.

## Root cause evidence
| Trade | Symptom | Root cause |
|-------|---------|------------|
| ABTS | pnl -$21.53 vs IB -$420 | LIMIT 1 grabbed first 100-share fill |
| XOS | no paper_trade created | 2161 rejected promise before createPaperTrade |
| TGHL stale close | 2161 fired on $0.86 stock → today fixed | sub-$5 check already in; DAY_PENNY mode check now covers $5-$20 range |

## Test plan
- [ ] Verify ABTS pnl is now -$420 in Today's Activity
- [ ] Next DAY_PENNY trade creates a paper_trade even if IB sends 2161
- [ ] Stale DAY_PENNY closes use Adaptive Algo at any price point

Made with [Cursor](https://cursor.com)