### PR TITLE
fix: restore options wheel log entries (OPTIONS_SCALP missing + silent scan days)

### DIFF
--- a/app/src/lib/optionsApi.ts
+++ b/app/src/lib/optionsApi.ts
@@ -418,7 +418,7 @@ export async function getOptionsActivityLog(limit = 50): Promise<OptionsActivity
   const { data, error } = await supabase
     .from('auto_trade_events')
     .select('id, ticker, event_type, message, metadata, created_at')
-    .or('mode.in.(OPTIONS_PUT,OPTIONS_CALL,CREDIT_SPREAD),and(mode.is.null,message.ilike.%option%)')
+    .or('mode.in.(OPTIONS_PUT,OPTIONS_CALL,CREDIT_SPREAD,OPTIONS_SCALP,CALENDAR_SPREAD,OPTIONS_LEAP),and(mode.is.null,message.ilike.%option%)')
     .order('created_at', { ascending: false })
     .limit(limit);
 

--- a/auto-trader/src/lib/credit-spread-scanner.ts
+++ b/auto-trader/src/lib/credit-spread-scanner.ts
@@ -297,7 +297,7 @@ export async function runCreditSpreadScan(
     }
   }
 
-  // Log top opportunities
+  // Log top opportunities (up to 5)
   for (const opp of opportunities.slice(0, 5)) {
     await createAutoTradeEvent({
       ticker: opp.ticker,
@@ -315,6 +315,18 @@ export async function runCreditSpreadScan(
         contracts: opp.contracts,
         pullbackPct: opp.pullbackPct,
       },
+    }).catch(() => {});
+  }
+
+  // Always log a scan summary so the Options Wheel log shows the scan ran,
+  // even on days with no qualifying setups.
+  if (opportunities.length === 0) {
+    await createAutoTradeEvent({
+      ticker: 'SYSTEM',
+      mode: 'CREDIT_SPREAD',
+      event_type: 'info',
+      message: `Credit spread scan: no qualifying setups today (${skipped.length} tickers scanned, none met criteria)`,
+      metadata: { scanned: skipped.length, scanDate },
     }).catch(() => {});
   }
 


### PR DESCRIPTION
## Problem
Options Wheel **Log tab** showed no new entries since June 2.

**Root cause 1 — wrong query filter:**
`getOptionsActivityLog` in `optionsApi.ts` only queried for `mode IN (OPTIONS_PUT, OPTIONS_CALL, CREDIT_SPREAD)`. The `OPTIONS_SCALP` mode was never included, so all scalp trades (which do run and fill) were completely invisible in the Log tab. June 3 had 5 scalp events and June 4 already had 4 — all silently dropped.

**Root cause 2 — silent scan on zero-opportunity days:**
When the credit spread scanner finds 0 qualifying setups, it skips the entire event-logging loop. No `auto_trade_events` record is created, so the log appears dead even though the scan ran normally.

## Fix
1. **`app/src/lib/optionsApi.ts`** — Add `OPTIONS_SCALP`, `CALENDAR_SPREAD`, `OPTIONS_LEAP` to the log query filter
2. **`auto-trader/src/lib/credit-spread-scanner.ts`** — Always persist a `CREDIT_SPREAD` summary event (`"no qualifying setups today"`) when 0 opportunities are found

## Test
- Options Wheel Log tab will now show today's scalp trades immediately after deploy
- On future zero-opportunity scan days, log will show `"Credit spread scan: no qualifying setups today (N tickers scanned, none met criteria)"`

Made with [Cursor](https://cursor.com)