### PR TITLE
feat: separate influencer and internal scanner daily loss gates

### DIFF
--- a/app/src/lib/autoTrader.ts
+++ b/app/src/lib/autoTrader.ts
@@ -211,6 +211,7 @@ export async function loadAutoTraderConfig(): Promise<AutoTraderConfig> {
         suggestedFindPositionSize: Number(data.suggested_find_position_size ?? DEFAULT_CONFIG.suggestedFindPositionSize),
         externalSignalPositionSize: Number(data.external_signal_position_size ?? DEFAULT_CONFIG.externalSignalPositionSize),
         dayTradeMaxDailyLoss: Number(data.day_trade_max_daily_loss ?? DEFAULT_CONFIG.dayTradeMaxDailyLoss),
+        influencerDailyLossMax: Number(data.influencer_daily_loss_max ?? DEFAULT_CONFIG.influencerDailyLossMax),
 
         // Module Toggles
         tradeSignalsEnabled: data.trade_signals_enabled ?? DEFAULT_CONFIG.tradeSignalsEnabled,

--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -124,6 +124,7 @@ export async function loadConfig(): Promise<AutoTraderConfig> {
     ltMaxHoldDays: Number(data.lt_max_hold_days ?? DEFAULT_CONFIG.ltMaxHoldDays),
     ltTrailingStopPct: Number(data.lt_trailing_stop_pct ?? DEFAULT_CONFIG.ltTrailingStopPct),
     dayTradeMaxDailyLoss: Number(data.day_trade_max_daily_loss ?? DEFAULT_CONFIG.dayTradeMaxDailyLoss),
+    influencerDailyLossMax: Number(data.influencer_daily_loss_max ?? DEFAULT_CONFIG.influencerDailyLossMax),
     tradeSignalsEnabled: data.trade_signals_enabled ?? DEFAULT_CONFIG.tradeSignalsEnabled,
     suggestedFindsEnabled: data.suggested_finds_enabled ?? DEFAULT_CONFIG.suggestedFindsEnabled,
     optionsWheelEnabled: data.options_wheel_enabled ?? DEFAULT_CONFIG.optionsWheelEnabled,

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -1701,27 +1701,36 @@ export async function reconcileIBLongs(): Promise<{ closed: string[]; errors: st
   return { closed, errors };
 }
 
-// ── Daily Max-Loss Gate ────────────────────────────────────────────────────────
+// ── Daily Max-Loss Gates ───────────────────────────────────────────────────────
 //
-// Returns true if new day-trade entries should be blocked for the rest of the session.
-// Compares today's realized P&L from closed day trades against dayTradeMaxDailyLoss.
-// 0 = gate disabled.
+// Two independent gates:
+//
+//   isDayTradeLossGateActive   — counts only INTERNAL scanner trades (strategy_source IS NULL).
+//                                Threshold: dayTradeMaxDailyLoss (default $1,000).
+//                                Blocks internal scanner entries when exceeded.
+//
+//   isInfluencerLossGateActive — counts only EXTERNAL/influencer trades (strategy_source IS NOT NULL).
+//                                Threshold: influencerDailyLossMax (default $500).
+//                                Blocks only new external signals; internal scanner is unaffected.
+//
+// This prevents influencer losses from silencing our own scanner.
 
-let _dayTradeGateActive  = false;
-let _dayTradeGateChecked = ''; // ET date of last check — reset daily
+let _dayTradeGateActive     = false;
+let _dayTradeGateChecked    = ''; // ET date of last check — reset daily
+let _influencerGateActive   = false;
+let _influencerGateChecked  = '';
 
 async function isDayTradeLossGateActive(config: AutoTraderConfig): Promise<boolean> {
   if (!config.dayTradeMaxDailyLoss || config.dayTradeMaxDailyLoss <= 0) return false;
 
   const todayEt = getETDateString();
 
-  // Reset flag on new day
   if (_dayTradeGateChecked !== todayEt) {
     _dayTradeGateActive  = false;
     _dayTradeGateChecked = todayEt;
   }
 
-  if (_dayTradeGateActive) return true; // already tripped today
+  if (_dayTradeGateActive) return true;
 
   const sb       = getSupabase();
   const { data } = await sb
@@ -1729,6 +1738,7 @@ async function isDayTradeLossGateActive(config: AutoTraderConfig): Promise<boole
     .select('pnl')
     .in('mode', ['DAY_TRADE', 'DAY_PENNY'])
     .eq('status', 'CLOSED')
+    .is('strategy_source', null)          // internal scanner only
     .gte('closed_at', `${todayEt}T00:00:00Z`);
 
   const sessionPnl = (data ?? []).reduce((s, t) => s + (t.pnl ?? 0), 0);
@@ -1736,8 +1746,43 @@ async function isDayTradeLossGateActive(config: AutoTraderConfig): Promise<boole
   if (sessionPnl < -config.dayTradeMaxDailyLoss) {
     _dayTradeGateActive = true;
     log(
-      `🛑 [DailyLossGate] Session P&L $${sessionPnl.toFixed(0)} < -$${config.dayTradeMaxDailyLoss} ` +
-      `— no new day-trade entries for the rest of today`,
+      `🛑 [DailyLossGate] Internal scanner P&L $${sessionPnl.toFixed(0)} < -$${config.dayTradeMaxDailyLoss} ` +
+      `— no new internal day-trade entries for the rest of today`,
+    );
+    return true;
+  }
+
+  return false;
+}
+
+async function isInfluencerLossGateActive(config: AutoTraderConfig): Promise<boolean> {
+  if (!config.influencerDailyLossMax || config.influencerDailyLossMax <= 0) return false;
+
+  const todayEt = getETDateString();
+
+  if (_influencerGateChecked !== todayEt) {
+    _influencerGateActive  = false;
+    _influencerGateChecked = todayEt;
+  }
+
+  if (_influencerGateActive) return true;
+
+  const sb       = getSupabase();
+  const { data } = await sb
+    .from('paper_trades')
+    .select('pnl')
+    .in('mode', ['DAY_TRADE', 'DAY_PENNY'])
+    .eq('status', 'CLOSED')
+    .not('strategy_source', 'is', null)   // influencer/external signals only
+    .gte('closed_at', `${todayEt}T00:00:00Z`);
+
+  const influencerPnl = (data ?? []).reduce((s, t) => s + (t.pnl ?? 0), 0);
+
+  if (influencerPnl < -config.influencerDailyLossMax) {
+    _influencerGateActive = true;
+    log(
+      `🛑 [InfluencerLossGate] Influencer P&L $${influencerPnl.toFixed(0)} < -$${config.influencerDailyLossMax} ` +
+      `— blocking new external signals for the rest of today (internal scanner unaffected)`,
     );
     return true;
   }
@@ -4719,8 +4764,8 @@ async function executeExternalStrategySignal(
   }
   const extAccountType = extConnections[0].accountType;
 
-  if (signal.mode === 'DAY_TRADE' && await isDayTradeLossGateActive(config)) {
-    log(`${ticker}: external signal skipped — daily loss gate active`);
+  if (signal.mode === 'DAY_TRADE' && await isInfluencerLossGateActive(config)) {
+    log(`${ticker}: external signal skipped — influencer daily loss gate active`);
     return 'skipped';
   }
 

--- a/shared/config-defaults.ts
+++ b/shared/config-defaults.ts
@@ -56,6 +56,12 @@ export interface AutoTraderConfig {
   ltMaxHoldDays: number;
   ltTrailingStopPct: number;
   dayTradeMaxDailyLoss: number;
+  /**
+   * Max total loss from influencer/external signals in a single day.
+   * When exceeded, new external signals are blocked but the internal scanner
+   * can still trade (subject to dayTradeMaxDailyLoss). 0 = disabled.
+   */
+  influencerDailyLossMax: number;
   tradeSignalsEnabled: boolean;
   suggestedFindsEnabled: boolean;
   optionsWheelEnabled: boolean;
@@ -121,7 +127,8 @@ export const DEFAULT_CONFIG: AutoTraderConfig = {
   ltProfitTakePct: 15,
   ltMaxHoldDays: 0,
   ltTrailingStopPct: 10,
-  dayTradeMaxDailyLoss: 500,
+  dayTradeMaxDailyLoss: 1000,
+  influencerDailyLossMax: 500,
   tradeSignalsEnabled: true,
   suggestedFindsEnabled: true,
   optionsWheelEnabled: true,


### PR DESCRIPTION
## Problem
A single \`dayTradeMaxDailyLoss = $500\` gate counted ALL day trades — internal scanner + influencer signals combined. When Kianstrades/Somesh lost -$3,900 this week, the gate tripped and blocked the internal scanner from taking any trades for the rest of each day, even though the internal system was finding valid setups.

## Fix
Two independent gates:

| Gate | Trades counted | Threshold | Blocks |
|------|---------------|-----------|--------|
| Internal scanner | `strategy_source IS NULL` | **$1,000** | Internal scanner only |
| Influencer gate | `strategy_source IS NOT NULL` | **$500** | External signals only |

- Influencer losses no longer shut off the internal scanner
- Internal scanner gets a higher threshold ($1,000) since it has better filters
- Both are configurable via `AutoTraderConfig.dayTradeMaxDailyLoss` / `influencerDailyLossMax`

## Scale-in (follow-up)
Scaling into winners is tracked separately.

Made with [Cursor](https://cursor.com)