### PR TITLE
fix: use actual IB position qty in stale close (prevent repeated sell loop)

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -1134,7 +1134,6 @@ async function checkStaleDayTrades(positions: EnrichedPosition[]): Promise<void>
 
     const fillPrice = trade.fill_price ?? trade.entry_price ?? 0;
     const isLong = trade.signal === 'BUY';
-    const qty = trade.quantity ?? 0;
 
     // If IB position no longer exists, just mark closed in DB (position already gone)
     if (!ibPos || Math.abs(ibPos.position) === 0) {
@@ -1151,6 +1150,15 @@ async function checkStaleDayTrades(positions: EnrichedPosition[]): Promise<void>
       log(`  ${trade.ticker}: no IB position found — marked CLOSED (reconciled)`);
       continue;
     }
+
+    // Use the actual IB position size, not the stale paper_trade quantity.
+    // If IB held multiple accumulated lots (e.g. 3× 31 shares = 93) but the DB
+    // only tracks 31, selling only 31 would leave 62 in IB, trigger a reopen,
+    // and repeat — creating accidental shorts and orphaned fills. Confirmed: XOM
+    // on 2026-06-04 had 93 IB shares, paper_trade tracked 31, sold 31 three times,
+    // ended up short 27 shares (required a costly cover order to clean up).
+    const ibQty = Math.abs(ibPos.position);
+    const qty = ibQty > 0 ? ibQty : (trade.quantity ?? 0);
 
     const closeSide = isLong ? 'SELL' : 'BUY';
     if (qty <= 0) continue;


### PR DESCRIPTION
## Summary
- **Root cause of today's XOM cascade**: `checkStaleDayTrades` was using `trade.quantity` (DB paper_trade qty) to decide how many shares to sell when closing a stale position. If IB held more shares than the DB tracked (e.g. 93 XOM across 3 lots vs 31 in paper_trade), it would only sell 31, leave 62 in IB, and the reconciler would reopen the paper_trade and sell 31 again — looping until it oversold and created an accidental short.
- **Fix**: Sell `Math.abs(ibPos.position)` — the actual IB quantity — so the entire position is cleared in one order, regardless of what the DB thinks.
- **Confirmed on 2026-06-04**: XOM had 93 IB shares tracked as 31 in DB → sold 4x → ended short 27 shares → required a cover order at a loss.

## Test plan
- [x] Build passes (`npm run build`)
- [x] Auto-trader restarted cleanly
- [x] DB patched: inserted 3 missing XOM paper_trade records for today's orphaned fills
- [ ] Monitor tomorrow morning that stale positions (if any) close in a single order

Made with [Cursor](https://cursor.com)