### PR TITLE
Improve day trade entry quality: remove loss cooldown + lunch exclusion

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -3715,11 +3715,12 @@ async function executeScannerTrade(
     }
   }
 
-  // ── Recent-loss cooldown gate ─────────────────────────────────────────
-  // Block re-entry on any ticker that lost money in the last N days.
-  // Both swing and day trades use 5 days — swing setups change weekly,
-  // a 14-day cooldown was too aggressive and blocked valid re-entries.
-  {
+  // ── Recent-loss cooldown gate (SWING_TRADE only) ──────────────────────
+  // Swing setups change weekly — if the thesis was wrong once, wait 5 days
+  // before re-entering. Day trades are intentionally excluded: a loss on
+  // Monday tells you nothing about Tuesday's setup on the same ticker.
+  // The same-day re-entry block above already covers the intraday case.
+  if (mode === 'SWING_TRADE') {
     const lookbackDays = 5;
     if (await hasRecentLoss(ticker, lookbackDays, { excludeOptions: true })) {
       log(`${ticker}: skipped — recent loss within ${lookbackDays}d cooldown`);
@@ -3805,6 +3806,21 @@ async function executeScannerTrade(
   // Gate expires after 12 PM ET — the opening range is stale by afternoon.
   // Skip for vwap_confluence — the strategy IS a chop-exit play.
   const etMinutes = getETMinutes();
+
+  // ── Lunch-hour exclusion gate ─────────────────────────────────────────
+  // Block new day-trade entries from 12:00–13:00 ET. This is the "death
+  // zone": institutional desks step away, volume craters, moves are random
+  // and often mean-reverting. Even technically valid setups fail at elevated
+  // rates during this window. Existing positions continue to be managed
+  // normally — this only gates new entries.
+  if (mode === 'DAY_TRADE' && etMinutes >= 12 * 60 && etMinutes < 13 * 60) {
+    log(`${ticker}: skipped — lunch-hour exclusion (12:00–13:00 ET, low-quality entry window)`);
+    persistEvent(ticker, 'skipped', 'Lunch-hour exclusion: no new day-trade entries 12:00–13:00 ET', {
+      action: 'skipped', source: 'scanner', mode, skip_reason: 'lunch_hour',
+    });
+    return 'skipped:lunch_hour';
+  }
+
   const skipOrbGate = idea.tags?.includes('vwap_confluence');
   if (mode === 'DAY_TRADE' && etMinutes < 12 * 60 && !skipOrbGate) {
     const choppy = await isInsideOrb(ticker, signal as 'BUY' | 'SELL');


### PR DESCRIPTION
## Changes

### 1. Loss cooldown — SWING_TRADE only
The 5-day recent-loss cooldown was applied to both day and swing trades, but it only makes sense for swing trades. A swing thesis being wrong means waiting for the setup to reset (5 days is reasonable). A day trade loss on AAPL Monday has zero predictive value for AAPL's setup on Tuesday — market conditions, sector news, and index direction all change daily.

The same-day re-entry block already handles the intraday case (don't re-enter a ticker that already resolved a trade today).

### 2. Lunch-hour exclusion: 12:00–13:00 ET
Block new day-trade entries during the "death zone." Institutional desks step away from noon to ~1 PM ET: volume craters, spreads widen, and moves are random/mean-reverting. Even technically valid setups (Fib retracement, EMA pullback) have a much lower hit rate in this window. Existing position management (stops, trailing stops, dip buys) is completely unaffected — this only gates *new* entries.

## Test plan
- [ ] Verify tickers that had a loss this week (XOM, IWM, DIA) now appear in the day-trade scan if a valid setup forms tomorrow
- [ ] Verify no new day-trade `executed` events between 12:00–13:00 ET in logs tomorrow
- [ ] Swing trades with recent losses should still be blocked by the cooldown

Made with [Cursor](https://cursor.com)