### PR TITLE
Flip ORB gate: trade the boundary, block the middle

### DIFF
--- a/auto-trader/src/lib/orb.ts
+++ b/auto-trader/src/lib/orb.ts
@@ -4,13 +4,15 @@
  * Somesh's rule: the first 15 minutes of the session (three 5-min candles at
  * 9:30, 9:35, 9:40 AM ET) define the "opening range."
  *
- *   - Price ABOVE  ORB high → trending up  → OK to trade LONG
- *   - Price BELOW  ORB low  → trending down → OK to trade SHORT
- *   - Price INSIDE the ORB  → choppy        → SKIP the trade
+ *   - Price ABOVE  ORB high → trending up    → OK to trade LONG
+ *   - Price BELOW  ORB low  → trending down  → OK to trade SHORT
+ *   - Price INSIDE the ORB, near the HIGH    → pre-breakout BUY setup → OK
+ *   - Price INSIDE the ORB, near the LOW     → pre-breakdown SELL setup → OK
+ *   - Price INSIDE the ORB, in the middle    → genuinely choppy → SKIP
  *
- * Usage:
- *   const orb = await fetchOrb('SPY');
- *   if (orb?.status === 'inside') return 'skipped:inside_orb';
+ * "Near the boundary" = within the outer 25% of the ORB range in the trade
+ * direction. E.g. if ORB is $745–$750 (range $5), a BUY signal is allowed
+ * when price ≥ $748.75 (top 25%). A price of $746 with a BUY is choppy.
  *
  * The result is cached per ticker for 5 minutes so repeated calls within the
  * same scheduler cycle don't multiply Yahoo Finance requests.
@@ -21,7 +23,7 @@
 export type OrbStatus =
   | 'above'      // current price is above ORB high → uptrend confirmed
   | 'below'      // current price is below ORB low  → downtrend confirmed
-  | 'inside'     // current price between ORB low and high → choppy, skip
+  | 'inside'     // current price between ORB low and high
   | 'not_ready'; // fewer than 3 bars printed yet (before ~9:45 AM ET)
 
 export interface OrbResult {
@@ -29,7 +31,9 @@ export interface OrbResult {
   low: number;
   status: OrbStatus;
   currentPrice: number;
-  barsUsed: number; // how many 5-min bars formed the ORB (should be 3)
+  barsUsed: number;           // how many 5-min bars formed the ORB (should be 3)
+  positionInRange: number;    // 0 = at ORB low, 1 = at ORB high (only meaningful when inside)
+  nearBoundary: boolean;      // inside ORB but in the outer 25% near a boundary
 }
 
 // ── Cache ─────────────────────────────────────────────────────────────────
@@ -106,7 +110,17 @@ export async function fetchOrb(symbol: string): Promise<OrbResult | null> {
       status = 'inside';
     }
 
-    const orbResult: OrbResult = { high: orbHigh, low: orbLow, status, currentPrice, barsUsed: orbBars };
+    const orbRange = orbHigh - orbLow;
+    const positionInRange = orbRange > 0
+      ? Math.max(0, Math.min(1, (currentPrice - orbLow) / orbRange))
+      : 0.5;
+    // "Near boundary" = within the outer 25% of the ORB range on either side
+    const nearBoundary = status === 'inside' && (positionInRange >= 0.75 || positionInRange <= 0.25);
+
+    const orbResult: OrbResult = {
+      high: orbHigh, low: orbLow, status, currentPrice, barsUsed: orbBars,
+      positionInRange, nearBoundary,
+    };
     _cache.set(cacheKey, { result: orbResult, fetchedAt: Date.now() });
     return orbResult;
   } catch (err) {
@@ -116,21 +130,33 @@ export async function fetchOrb(symbol: string): Promise<OrbResult | null> {
 }
 
 /**
- * Quick helper: returns true when a ticker is inside its ORB and a trade
- * in `direction` should be suppressed.
+ * Returns true when a ticker's ORB position should suppress a new entry.
  *
- * - direction = 'BUY'  → suppress if inside OR below ORB (no bullish momentum)
- * - direction = 'SELL' → suppress if inside OR above ORB (no bearish momentum)
+ * Updated logic (Somesh's actual approach):
+ *   - Inside ORB, near the boundary in the trade direction → ALLOW (boundary play)
+ *     "Near" = within the outer 25% of the ORB range on the correct side.
+ *     A BUY signal with price in the top 25% of the ORB = pre-breakout entry.
+ *     A SELL signal with price in the bottom 25% of the ORB = pre-breakdown entry.
+ *   - Inside ORB, in the middle 50% → SUPPRESS (genuinely choppy, no edge)
+ *   - Below ORB + BUY, Above ORB + SELL → SUPPRESS (direction mismatch)
+ *   - Above ORB + BUY, Below ORB + SELL → ALLOW (momentum confirmed, unchanged)
  *
- * Returns false (don't suppress) when ORB data is unavailable, so the gate
- * is never a hard blocker on data failure.
+ * Returns false (don't suppress) when ORB data is unavailable.
  */
 export async function isInsideOrb(symbol: string, direction: 'BUY' | 'SELL'): Promise<boolean> {
   const orb = await fetchOrb(symbol);
   if (!orb || orb.status === 'not_ready') return false; // data missing → don't block
 
-  if (orb.status === 'inside') return true;
-  // Also block directional mismatches: don't BUY when below ORB, don't SELL when above ORB
+  if (orb.status === 'inside') {
+    // Near the ORB high with a BUY = pre-breakout setup → allow
+    if (direction === 'BUY'  && orb.positionInRange >= 0.75) return false;
+    // Near the ORB low with a SELL = pre-breakdown setup → allow
+    if (direction === 'SELL' && orb.positionInRange <= 0.25) return false;
+    // Middle of the range = genuine chop → suppress
+    return true;
+  }
+
+  // Direction mismatch: don't BUY when below ORB, don't SELL when above ORB
   if (direction === 'BUY'  && orb.status === 'below') return true;
   if (direction === 'SELL' && orb.status === 'above') return true;
   return false;

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -101,7 +101,7 @@ import { checkSpxLevelSetups } from './lib/spx-level-scanner.js';
 import { checkVwapConfluenceSetups, type ConfluenceResult } from './lib/vwap-confluence-scanner.js';
 import { checkFibRetraceSetups, type FibRetraceResult } from './lib/fib-retrace-scanner.js';
 import { checkEmaPullbackSetups, type EmaPullbackResult } from './lib/ema-pullback-scanner.js';
-import { isInsideOrb } from './lib/orb.js';
+import { isInsideOrb, fetchOrb } from './lib/orb.js';
 import { evaluateVwapAlignment, detectVwapReclaim } from './lib/vwap.js';
 import { checkTrendFilter } from './lib/trend-filter.js';
 import { getStreakMultiplier } from './lib/streak-tracker.js';
@@ -3823,18 +3823,27 @@ async function executeScannerTrade(
 
   const skipOrbGate = idea.tags?.includes('vwap_confluence');
   if (mode === 'DAY_TRADE' && etMinutes < 12 * 60 && !skipOrbGate) {
+    const orb = await fetchOrb(ticker);
     const choppy = await isInsideOrb(ticker, signal as 'BUY' | 'SELL');
-    if (choppy) {
+    if (orb && orb.status === 'inside' && !choppy) {
+      // Near the ORB boundary in the trade direction — this is the setup, not chop.
+      const pct = (orb.positionInRange * 100).toFixed(0);
+      log(`${ticker}: inside ORB but near ${signal === 'BUY' ? 'high' : 'low'} boundary (${pct}% of range) — pre-breakout ${signal} setup, proceeding`);
+      persistEvent(ticker, 'info', `ORB boundary play: price at ${pct}% of range — pre-${signal === 'BUY' ? 'breakout' : 'breakdown'} entry`, {
+        action: 'proceeding', source: 'scanner', mode,
+        orb_high: orb.high, orb_low: orb.low, current_price: orb.currentPrice,
+      });
+    } else if (choppy) {
       const reclaim = await detectVwapReclaim(ticker, signal as 'BUY' | 'SELL');
       if (reclaim.reclaimed) {
-        log(`${ticker}: inside ORB but VWAP ${signal === 'BUY' ? 'reclaimed' : 'broke down'} — proceeding (${reclaim.log})`);
+        log(`${ticker}: inside ORB (choppy) but VWAP ${signal === 'BUY' ? 'reclaimed' : 'broke down'} — proceeding (${reclaim.log})`);
         persistEvent(ticker, 'info', `ORB chop overridden by VWAP reclaim: ${reclaim.log}`, {
           action: 'proceeding', source: 'scanner', mode,
           vwap: reclaim.vwap, current_price: reclaim.currentPrice,
         });
       } else {
-        log(`${ticker}: inside ORB (choppy), no VWAP reclaim — skipping ${signal} day trade (${reclaim.log})`);
-        persistEvent(ticker, 'skipped', `Inside ORB — choppy conditions, no VWAP reclaim`, {
+        log(`${ticker}: inside ORB (choppy middle), no VWAP reclaim — skipping ${signal} day trade (${reclaim.log})`);
+        persistEvent(ticker, 'skipped', `Inside ORB — choppy middle, no VWAP reclaim`, {
           action: 'skipped', source: 'scanner', mode, skip_reason: 'inside_orb',
         });
         return 'skipped:inside_orb';


### PR DESCRIPTION
## Problem

The previous ORB gate treated all "inside ORB" situations identically as choppy and skipped them. This blocked ~10 setups this week including the best ones.

## What Somesh actually does

Being near the ORB boundary IS the setup — it's a pre-breakout entry. The ORB boundary becomes support/resistance:
- Price pressing up against ORB high with a BUY signal → enter for the breakout
- Price pressing down against ORB low with a SELL signal → enter for the breakdown  
- Choppy = aimlessly in the **middle** of the range with no directional push

## New logic

| Situation | Old | New |
|-----------|-----|-----|
| Inside ORB, price in **top 25%** of range + BUY | Block | **Allow** (pre-breakout) |
| Inside ORB, price in **bottom 25%** of range + SELL | Block | **Allow** (pre-breakdown) |
| Inside ORB, price in **middle 50%** | Block | Block → VWAP reclaim override still applies |
| Above ORB + BUY | Allow | Allow (unchanged) |
| Direction mismatch | Block | Block (unchanged) |

"Top 25%" means: `(currentPrice - orbLow) / (orbHigh - orbLow) >= 0.75`

## Changes

- `orb.ts`: Added `positionInRange` (0–1 where 1 = at ORB high) and `nearBoundary` to `OrbResult`. Updated `isInsideOrb()` to return `false` (allow) when at the boundary in the trade direction.
- `scheduler.ts`: Imports `fetchOrb` for context logging. Logs "ORB boundary play: price at X% of range" when allowed through at boundary. Keeps the VWAP reclaim fallback for the middle-of-range choppy case.

## Test plan
- [ ] Tomorrow morning: verify setups pressing against ORB high produce "ORB boundary play" log lines instead of `skipped:inside_orb`
- [ ] Verify genuine middle-of-range chop still hits `skipped:inside_orb`
- [ ] Verify VWAP reclaim still works as override for the choppy case

Made with [Cursor](https://cursor.com)