### PR TITLE
fix(options): correct expiry timezone display and add submitted date to scalp card

### DIFF
--- a/app/src/components/PaperTrading/tabs/OptionsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/OptionsTab.tsx
@@ -37,8 +37,14 @@ function daysUntil(dateStr: string): number {
 
 function formatExpiry(dateStr: string): string {
   if (!dateStr) return '—';
-  const d = new Date(dateStr);
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  // Parse YYYY-MM-DD as a local date (not UTC) to avoid the midnight UTC
+  // timezone shift that shows "Jun 5" as "Jun 4" in UTC-4 browsers.
+  const parts = dateStr.split('-').map(Number);
+  if (parts.length === 3) {
+    const d = new Date(parts[0], parts[1] - 1, parts[2]);
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  }
+  return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
 function dteBadgeColor(dte: number): string {
@@ -1328,6 +1334,11 @@ function ScalpCard({ scalp, closed }: { scalp: ScalpTrade; closed?: boolean }) {
 
       {scalp.scanner_reason && (
         <p className="mt-2 text-[10px] text-[hsl(var(--muted-foreground))] leading-snug">{scalp.scanner_reason}</p>
+      )}
+      {scalp.opened_at && (
+        <p className="mt-1 text-[10px] text-[hsl(var(--muted-foreground))]">
+          Submitted {new Date(scalp.opened_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} · {new Date(scalp.opened_at).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
+        </p>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- **Expiry date bug**: `new Date('2026-06-05')` parses as UTC midnight, which is 8 PM ET the day before → all expiry dates showed one day early (Jun 5 → "Jun 4"). Fixed by parsing `YYYY-MM-DD` strings as local date components instead of UTC.
- **Submitted date**: Added "Submitted Jun 4 · 10:02 AM" line to each scalp card so it's visible when the position was entered.

## What the data actually shows
All 6 open scalps (IWM, MSFT, SPY, NVDL, APP, AMZN) have `option_expiry = 2026-06-05` in the DB — which is correct (Jun 5 = today). The UI was just displaying it wrong due to the UTC parsing issue.

Made with [Cursor](https://cursor.com)