### PR TITLE
fix(loss-cut): stop cascade loop on partial swing/long-term loss cuts

### DIFF
--- a/auto-trader/src/lib/supabase.ts
+++ b/auto-trader/src/lib/supabase.ts
@@ -753,12 +753,18 @@ export async function getPastLossCutEvents(
   ticker: string
 ): Promise<{ metadata: Record<string, unknown> }[]> {
   const sb = getSupabase();
+  // Loss cut events are persisted with action='closed' (from persistEvent in scheduler).
+  // Previously queried for 'executed' which never matched → dedup was silently broken.
+  // Scope to today only so positions can be re-managed on a new day if needed.
+  const todayEt = new Date().toLocaleDateString('en-US', { timeZone: 'America/New_York' });
+  const todayStart = new Date(`${todayEt} 00:00:00 EST`).toISOString();
   const { data } = await sb
     .from('auto_trade_events')
     .select('metadata')
     .eq('ticker', ticker)
     .eq('source', 'loss_cut')
-    .eq('action', 'executed');
+    .in('action', ['closed', 'executed'])   // handle both spellings
+    .gte('created_at', todayStart);
   return (data ?? []) as { metadata: Record<string, unknown> }[];
 }
 

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -7090,7 +7090,8 @@ async function checkLossCutOpportunities(
     const activeTrades = await getActiveTrades(acctType);
     const eligible = activeTrades.filter(t =>
       (t.mode === 'LONG_TERM' || t.mode === 'SWING_TRADE') &&
-      (t.status === 'FILLED' || t.status === 'PARTIAL')
+      (t.status === 'FILLED' || t.status === 'PARTIAL') &&
+      t.signal !== 'SELL'  // partial loss cut creates SELL records — never apply loss cuts to them
     );
     if (eligible.length === 0) continue;
 
@@ -7140,27 +7141,28 @@ async function checkLossCutOpportunities(
         const side = ibPos.position > 0 ? 'SELL' : 'BUY';
         const result = await conn.placeMarketOrder({ symbol: trade.ticker, side: side as 'BUY' | 'SELL', quantity: sellQty });
 
-        // If this is a full exit (Tier 3), close the original trade
-        if (triggered.sellPct >= 100) {
+        // Determine remaining IB quantity after this sell
+        const remainingQty = Math.max(0, Math.round(ibPos.position) - sellQty);
+
+        if (triggered.sellPct >= 100 || remainingQty === 0) {
+          // Full exit — close the original trade record
           await recordTradeClose({
             tradeId: trade.id,
             closePrice: result.avgFillPrice,
-            closeReason: `loss_cut_${triggered.label.toLowerCase().replace(/\s+/g, '_')}`,
+            closeReason: 'loss_cut',
             status: 'STOPPED',
             orderId: result.orderId,
             accountType: acctType,
           });
         } else {
-          // Partial loss cut — create a SELL record (can't close the original since position remains)
-          await createPaperTrade({
-            ticker: trade.ticker, mode: trade.mode as 'LONG_TERM' | 'SWING_TRADE',
-            signal: 'SELL', entry_price: ibPos.mktPrice,
-            quantity: sellQty,
-            position_size: sellQty * ibPos.mktPrice,
-            status: 'SUBMITTED',
-            notes: `Loss cut ${triggered.label} at -${lossPct.toFixed(1)}%`,
-            entry_trigger_type: 'loss_cut',
-          }, acctType);
+          // Partial loss cut — update the original record's quantity to what remains in IB.
+          // Previously this spawned a new SELL paper_trade record which the next cycle's
+          // eligible filter would pick up as a new position and loss-cut again → cascade loop.
+          const sb = getSupabase();
+          await sb.from('paper_trades').update({
+            quantity: remainingQty,
+            notes: `Loss cut ${triggered.label} at -${lossPct.toFixed(1)}% (${sellQty} of ${Math.round(ibPos.position)} sold, ${remainingQty} remain)`,
+          }).eq('id', trade.id);
         }
 
         actedTickers.add(trade.ticker.toUpperCase());


### PR DESCRIPTION
## Root cause
Three silent bugs combined to create an infinite loss-cut loop on ASTS (Jason Luongo Jun 2 swing trade, 86 shares):

### Bug 1 — dedup was broken (silent)
`persistEvent` saved loss cut events with `action='closed'`, but `getPastLossCutEvents` queried for `action='executed'`. They never matched → the "already fired this tier" guard was always bypassed → same tier fired every 15 min cycle.

### Bug 2 — SELL records treated as new positions  
Partial loss cuts spawned a new `SWING_TRADE SELL SUBMITTED` paper_trade. The `eligible` filter didn't exclude SELL-signal records, so the next cycle treated that SELL record as a fresh swing trade and triggered another loss cut on it.

### Bug 3 — orphan records accumulate  
Each partial loss cut wrote a new DB record instead of updating the original, fragmenting the position into many phantom records.

## Fixes
1. `getPastLossCutEvents` now queries `action IN ('closed','executed')` scoped to today
2. `eligible` filter adds `t.signal !== 'SELL'`
3. Partial loss cut now **updates the original record's quantity** to remaining IB shares instead of spawning a new SELL record. Full exit calls `recordTradeClose` on the original.

## DB cleanup
- Deleted 11 phantom ASTS records created by today's cascade
- Updated Jun 2 Jason Luongo ASTS record: qty=12 (remaining 12 shares still in IB)

Made with [Cursor](https://cursor.com)