### PR TITLE
fix(options-manager): correct P&L sign for long scalps expiring worthless

### DIFF
--- a/auto-trader/src/lib/options-manager.ts
+++ b/auto-trader/src/lib/options-manager.ts
@@ -47,6 +47,7 @@ interface PositionRow {
   id: string;
   ticker: string;
   mode: string;
+  signal?: string;
   option_strike: number;
   option_expiry: string;
   option_premium: number;
@@ -438,7 +439,7 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
 
   const { data, error } = await sb
     .from('paper_trades')
-    .select('id, ticker, mode, option_strike, option_expiry, option_premium, option_capital_req, option_assigned, fill_price, status, ib_order_id, roll_count, rolled_from_id')
+    .select('id, ticker, mode, signal, option_strike, option_expiry, option_premium, option_capital_req, option_assigned, fill_price, status, ib_order_id, roll_count, rolled_from_id')
     .in('mode', [...OPTIONS_MODES])
     .in('status', ['FILLED', 'PARTIAL']);
 
@@ -452,15 +453,24 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
 
     // ── Check 1: Expired (past expiry date) ──
     if (dte <= 0) {
-      // Option expired — close as profit (premium kept) if not assigned
+      // Short options (SELL signal = CSP/covered call/short scalp): expiring at $0 means
+      // we keep the full premium collected → profit.
+      // Long options (BUY signal = long scalp/leap): expiring at $0 means we lose the
+      // full premium paid → loss. Use negative P&L.
+      const isLong = pos.signal === 'BUY';
+      const expiredPnl = isLong ? -(premiumCollected * 100) : premiumCollected * 100;
+      const expiredPct = isLong
+        ? -(premiumCollected / pos.option_strike) * 100
+        : (premiumCollected / pos.option_strike) * 100;
+
       await recordTradeClose({
         tradeId: pos.id,
         closePrice: 0,
         closeReason: 'expired_worthless',
         status: 'CLOSED',
         accountType: 'paper',
-        overridePnl: premiumCollected * 100,
-        overridePnlPct: (premiumCollected / pos.option_strike) * 100,
+        overridePnl: expiredPnl,
+        overridePnlPct: expiredPct,
         overridePnlSource: 'ib_fill_calculated',
         extraUpdates: { option_close_pct: 100 },
       });


### PR DESCRIPTION
## Root Cause

`options-manager.ts` computed `overridePnl = premiumCollected * 100` (positive) for **all** options modes including `OPTIONS_SCALP` when a position expired at \$0. This formula is correct for **short** options (CSPs, covered calls) — you collected premium and the option expired worthless, so you keep the full credit.

But for **long** scalps (BUY signal = debit paid), expiring at \$0 is a **total loss**. The sign was inverted, showing e.g. APP +\$990 when the correct P&L is -\$990.

## Fix

Added `signal` to `PositionRow` interface and the Supabase `.select()` call. When computing the expiry P&L:
- `signal === 'SELL'` (short option): `+premiumCollected * 100` ✓
- `signal === 'BUY'` (long option): `-premiumCollected * 100` ✓

## DB Correction (Jun 5)

Four long scalps that expired worthless today had their `pnl` corrected manually:
| Ticker | Was | Now |
|--------|-----|-----|
| APP    | +\$990 | -\$990 |
| MSFT   | +\$785 | -\$785 |
| AMZN   | +\$129 | -\$129 |
| SPY    | +\$235 | -\$235 |

SELL scalps (NVDL, IWM) were already correct (+\$210 each).

## Test plan
- [ ] Open a long scalp tomorrow; let it expire worthless → P&L should show negative
- [ ] SELL scalp expiring worthless → P&L should still show positive (unchanged)

Made with [Cursor](https://cursor.com)