### PR TITLE
fix(loss-cut): prevent duplicate sells when multiple records exist for same ticker

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -7128,6 +7128,11 @@ async function checkLossCutOpportunities(
       const triggered = tiers.find(t => lossPct >= t.pct);
       if (!triggered) continue;
 
+      // In-memory guard: if we already acted on this ticker during THIS loop (e.g. two LONG_TERM
+      // records for the same ticker), skip — persistEvent is fire-and-forget so the DB dedup
+      // check below won't see the first iteration's event before the second iteration runs.
+      if (actedTickers.has(trade.ticker.toUpperCase())) continue;
+
       const pastEvents = await getPastLossCutEvents(trade.ticker);
       if (pastEvents.some(e => e.metadata?.tier === triggered.label)) continue;
 
@@ -7140,6 +7145,11 @@ async function checkLossCutOpportunities(
       try {
         const side = ibPos.position > 0 ? 'SELL' : 'BUY';
         const result = await conn.placeMarketOrder({ symbol: trade.ticker, side: side as 'BUY' | 'SELL', quantity: sellQty });
+
+        // Claim the ticker immediately so any subsequent records for the same ticker in this
+        // loop iteration are blocked by the in-memory guard above (persistEvent is fire-and-forget
+        // so the DB dedup check can't protect against within-loop duplicates).
+        actedTickers.add(trade.ticker.toUpperCase());
 
         // Determine remaining IB quantity after this sell
         const remainingQty = Math.max(0, Math.round(ibPos.position) - sellQty);
@@ -7165,7 +7175,6 @@ async function checkLossCutOpportunities(
           }).eq('id', trade.id);
         }
 
-        actedTickers.add(trade.ticker.toUpperCase());
         const realizedLoss = ibPos.position > 0
           ? sellQty * (ibPos.avgCost - ibPos.mktPrice)
           : sellQty * (ibPos.mktPrice - ibPos.avgCost);


### PR DESCRIPTION
## Root Cause

When the same ticker has **two LONG_TERM FILLED records** (e.g. original buy + dip buy), `checkLossCutOpportunities` iterates both records and both pass the dedup check. The dedup check uses `getPastLossCutEvents()` (a DB query), but `persistEvent()` is **fire-and-forget** — the first iteration's event isn't committed to the DB before the second iteration's check runs.

Result: two sell orders are placed against the same IB position. Observed with GATX on Jun 5: sold 4+4=8 shares instead of 4.

## Fix

1. Added **in-memory guard** at the top of the per-trade loop: if `actedTickers` already contains this ticker (set synchronously after the first sell succeeds), skip immediately.
2. Moved `actedTickers.add()` to **immediately after the market order succeeds** — before any DB writes — so the guard is claimed as early as possible.

## DB Cleanup (Jun 5)

- Deleted 2 phantom `DAY_TRADE CLOSED -$67.94` records auto-created from duplicate IB fills
- Updated both GATX `LONG_TERM FILLED` records to `qty:3` each (6 total = actual IB position after 8 shares sold)

Made with [Cursor](https://cursor.com)