### PR TITLE
fix(options-manager): don't close OPTIONS_SCALP on expiry day until after market close

### DIFF
--- a/auto-trader/src/lib/options-manager.ts
+++ b/auto-trader/src/lib/options-manager.ts
@@ -19,6 +19,12 @@ import { isConnected, placeOptionsOrder, getDefaultAccount } from '../ib-connect
 
 import type { AutoTradeEventType } from '../../../shared/auto-trade-events.js';
 
+/** Returns true only after 4:15 PM ET — when equity options have truly expired. */
+function isPastOptionsExpiryET(): boolean {
+  const et = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
+  return et.getHours() * 60 + et.getMinutes() >= 16 * 60 + 15;
+}
+
 function persistEvent(ticker: string, eventType: AutoTradeEventType, message: string, extra?: Record<string, unknown>): void {
   createAutoTradeEvent({ ticker, event_type: eventType, message, ...extra })
     .catch(err => console.warn(`[Options persistEvent] ${ticker}/${eventType} failed:`, err instanceof Error ? err.message : err));
@@ -453,6 +459,12 @@ export async function runOptionsManageCycle(): Promise<ManageCycleResult> {
 
     // ── Check 1: Expired (past expiry date) ──
     if (dte <= 0) {
+      // OPTIONS_SCALP positions on expiry day must NOT be closed here during market hours.
+      // manageScalpPositions() tracks their live P&L and closeAllScalpPositionsEod() at 3:45 PM
+      // handles the actual close — potentially at a profit if the option is ITM at expiry.
+      // Closing here at 9:30 AM would forfeit any intraday gain on ITM long scalps.
+      if (pos.mode === 'OPTIONS_SCALP' && !isPastOptionsExpiryET()) continue;
+
       // Short options (SELL signal = CSP/covered call/short scalp): expiring at $0 means
       // we keep the full premium collected → profit.
       // Long options (BUY signal = long scalp/leap): expiring at $0 means we lose the


### PR DESCRIPTION
## Problem

`options-manager.ts` ran at market open, saw `dte = 0` for Jun 5 expiry options, and immediately closed all `OPTIONS_SCALP` positions as `expired_worthless` at \$0 — without checking the actual option premium. Long scalp BUY positions were locked in as losses at 9:30 AM even though the market doesn't close until 4 PM and there was still time for the stock to move ITM.

## Fix

Added a guard in the `dte <= 0` block: if the position is `OPTIONS_SCALP` and it's still before 4:15 PM ET, skip and let the existing handlers do their job:
- `manageScalpPositions()` tracks live P&L every 15 min
- `closeAllScalpPositionsEod()` at 3:45 PM actually checks premium and sells to close if the option has value

`OPTIONS_PUT`, `OPTIONS_CALL`, `OPTIONS_LEAP` are unaffected — for CSPs and covered calls, expiring OTM on expiry day is expected.

## DB Fix (Jun 5)

4 BUY scalps (AMZN, SPY, APP, MSFT) were reopened to `FILLED` so the 3:45 PM sweep handles them properly.

## Today's status (11 AM ET)

All 4 are currently OTM so losses are real, but at least the system won't prematurely lock them in for future trades where the stock could rally ITM before close.

Made with [Cursor](https://cursor.com)