### PR TITLE
fix: update paths after folder rename to star-automation-regular

### DIFF
--- a/auto-trader/com.portfolio-assistant.auto-trader.plist
+++ b/auto-trader/com.portfolio-assistant.auto-trader.plist
@@ -22,7 +22,7 @@
     <array>
         <string>/bin/bash</string>
         <string>-c</string>
-        <string>cd ~/Git-RV/portfolio-assistant/auto-trader &amp;&amp; ./start.sh</string>
+        <string>cd ~/Git-RV/star-automation-regular/auto-trader &amp;&amp; ./start.sh</string>
     </array>
 
     <!-- Ensure Homebrew and system tools are on PATH — LaunchAgents inherit a minimal env -->

--- a/auto-trader/start.sh
+++ b/auto-trader/start.sh
@@ -58,7 +58,7 @@ if [ -n "$listener_pids" ]; then
   while IFS= read -r pid; do
     [ -z "$pid" ] && continue
     cmd="$(ps -p "$pid" -o command= 2>/dev/null || true)"
-    if echo "$cmd" | grep -Eq "portfolio-assistant/auto-trader.*dist/(auto-trader/src/)?index\\.js|node( .*)?dist/(auto-trader/src/)?index\\.js"; then
+    if echo "$cmd" | grep -Eq "star-automation-regular/auto-trader.*dist/(auto-trader/src/)?index\\.js|node( .*)?dist/(auto-trader/src/)?index\\.js"; then
       running_our_service="yes"
       break
     fi


### PR DESCRIPTION
## Summary
- Update `auto-trader/com.portfolio-assistant.auto-trader.plist` launch path from `~/Git-RV/portfolio-assistant/auto-trader` → `~/Git-RV/star-automation-regular/auto-trader`
- Update `auto-trader/start.sh` already-running detection grep pattern to match the new folder name

## Test plan
- [ ] `git status` in the main repo returns no errors
- [ ] Auto-trader restarts cleanly via launchctl (port-reuse detection correctly identifies the running process)

Made with [Cursor](https://cursor.com)