### PR TITLE
feat(scalp): trail runner stop on stock structure

### DIFF
--- a/auto-trader/src/lib/options-scalp.ts
+++ b/auto-trader/src/lib/options-scalp.ts
@@ -21,7 +21,7 @@
 import { getSupabase, createAutoTradeEvent } from './supabase.js';
 import { isConnected, placeOptionsOrder, cancelOrder, getDefaultAccount } from '../ib-connection.js';
 import { findAtmStrike, getOptionGreeksForContract } from './options-chain.js';
-import { fetchQuote } from './yahoo-finance.js';
+import { fetchQuote, fetchIntradayBars, type IntradayBar } from './yahoo-finance.js';
 import { detectVwapReclaim, VWAP_RELIABLE_HOUR_ET } from './vwap.js';
 
 // ── Constants ────────────────────────────────────────────
@@ -439,6 +439,51 @@ async function executeScalp(p: ScalpParams): Promise<boolean> {
   return true;
 }
 
+// ── Runner Stop Trailing ──────────────────────────────────
+
+/**
+ * Trail the runner stop based on stock structure (higher lows for calls,
+ * lower highs for puts) — Kay Capitals: "base your stop on the stock price,
+ * not the option price. Every time a new higher low forms, bring your stop up."
+ *
+ * Uses the last N completed 5-min bars (excludes the current incomplete bar).
+ * Returns the new stop price if a better level is found, or null if not.
+ *
+ * Minimum improvement required ($MIN_TRAIL_MOVE) prevents stop from creeping
+ * on noise — the new level must be meaningfully better than the current stop.
+ */
+const MIN_TRAIL_MOVE = 0.15; // stock must move at least $0.15 to trail stop
+
+function trailRunnerStop(
+  bars: IntradayBar[],
+  currentStop: number,
+  right: 'C' | 'P',
+): number | null {
+  // Exclude last bar — it may still be forming (incomplete candle)
+  const completed = bars.slice(0, -1);
+  if (completed.length < 3) return null;
+
+  // Scan backwards to find the most recent confirmed structure point
+  for (let i = completed.length - 1; i >= 1; i--) {
+    if (right === 'C') {
+      // For calls: trail stop up to higher lows
+      const thisLow = completed[i].low;
+      const prevLow = completed[i - 1].low;
+      if (thisLow > prevLow && thisLow > currentStop + MIN_TRAIL_MOVE) {
+        return thisLow;
+      }
+    } else {
+      // For puts: trail stop down to lower highs
+      const thisHigh = completed[i].high;
+      const prevHigh = completed[i - 1].high;
+      if (thisHigh < prevHigh && thisHigh < currentStop - MIN_TRAIL_MOVE) {
+        return thisHigh;
+      }
+    }
+  }
+  return null;
+}
+
 // ── Position Management ───────────────────────────────────
 
 /**
@@ -505,6 +550,62 @@ export async function manageScalpPositions(): Promise<void> {
 
     const profitPct = ((currentPremium - premiumPaid) / premiumPaid) * 100;
 
+    // ── Runner trailing stop (stock-price based, PARTIAL positions only) ──
+    // Kay Capitals: "trail your stop based on higher highs and higher lows,
+    // not the option premium."
+    if (isPartiallyExited) {
+      const runnerStop = (meta.runner_stop_price as number | undefined);
+
+      if (runnerStop == null) {
+        // First cycle after partial: initialize runner stop to current stock price
+        // (with a tiny buffer so it doesn't exit immediately on noise)
+        const initialStop = right === 'C'
+          ? q.price * 0.998   // 0.2% below current for calls
+          : q.price * 1.002;  // 0.2% above current for puts
+        await getSupabase().from('paper_trades').update({
+          metadata: { ...meta, runner_stop_price: initialStop },
+        }).eq('id', pos.id);
+        console.log(`[Options Scalp] ${pos.ticker} — runner stop initialized @ $${initialStop.toFixed(2)} (stock $${q.price.toFixed(2)})`);
+
+      } else {
+        // Try to trail the stop based on recent 5-min higher lows / lower highs
+        const intradayBars = await fetchIntradayBars(pos.ticker, '5m', '1d');
+        if (intradayBars && intradayBars.length >= 4) {
+          const newStop = trailRunnerStop(intradayBars, runnerStop, right);
+          if (newStop !== null) {
+            await getSupabase().from('paper_trades').update({
+              metadata: { ...meta, runner_stop_price: newStop },
+            }).eq('id', pos.id);
+            console.log(`[Options Scalp] ${pos.ticker} — runner stop trailed: $${runnerStop.toFixed(2)} → $${newStop.toFixed(2)}`);
+            meta.runner_stop_price = newStop; // use updated value for exit check below
+          }
+        }
+
+        // Check if stock price has crossed the runner stop
+        const activeStop = (meta.runner_stop_price as number | undefined) ?? runnerStop;
+        const stopHit = right === 'C'
+          ? q.price <= activeStop
+          : q.price >= activeStop;
+
+        if (stopHit) {
+          console.log(`[Options Scalp] ${pos.ticker} — runner stock stop hit (stock $${q.price.toFixed(2)} ${right === 'C' ? '<=' : '>='} stop $${activeStop.toFixed(2)})`);
+          await closeScalpPosition(pos.id, pos.ticker, right, pos.option_strike, pos.option_expiry,
+            currentPremium, premiumPaid, 'runner_stop',
+            { contractsToSell: contractsRemaining, existingMeta: meta });
+          continue;
+        }
+
+        // Fallback: break-even option premium stop (in case stock stop isn't yet set or is stale)
+        if (currentPremium <= breakEvenPremium) {
+          console.log(`[Options Scalp] ${pos.ticker} — runner break-even stop @ $${currentPremium.toFixed(2)} (entry $${breakEvenPremium.toFixed(2)})`);
+          await closeScalpPosition(pos.id, pos.ticker, right, pos.option_strike, pos.option_expiry,
+            currentPremium, premiumPaid, 'break_even_stop',
+            { contractsToSell: contractsRemaining, existingMeta: meta });
+          continue;
+        }
+      }
+    }
+
     if (!isPartiallyExited && currentPremium >= premiumPaid * PARTIAL_TARGET_MULT) {
       // First target (+50%): sell 1 contract, set break-even stop on runner
       console.log(`[Options Scalp] ${pos.ticker} — partial target hit (+${profitPct.toFixed(0)}%) @ $${currentPremium.toFixed(2)} — selling 1, runner to break-even`);
@@ -517,13 +618,6 @@ export async function manageScalpPositions(): Promise<void> {
       console.log(`[Options Scalp] ${pos.ticker} — profit target hit (+${profitPct.toFixed(0)}%) @ $${currentPremium.toFixed(2)}`);
       await closeScalpPosition(pos.id, pos.ticker, right, pos.option_strike, pos.option_expiry,
         currentPremium, premiumPaid, 'profit_target',
-        { contractsToSell: contractsRemaining, existingMeta: meta });
-
-    } else if (isPartiallyExited && currentPremium <= breakEvenPremium) {
-      // Runner hit break-even stop — exit at entry price, no loss on runner
-      console.log(`[Options Scalp] ${pos.ticker} — runner break-even stop @ $${currentPremium.toFixed(2)} (entry $${breakEvenPremium.toFixed(2)})`);
-      await closeScalpPosition(pos.id, pos.ticker, right, pos.option_strike, pos.option_expiry,
-        currentPremium, premiumPaid, 'break_even_stop',
         { contractsToSell: contractsRemaining, existingMeta: meta });
 
     } else if (!isPartiallyExited && currentPremium <= premiumPaid * STOP_LOSS_MULT) {

--- a/auto-trader/src/lib/yahoo-finance.ts
+++ b/auto-trader/src/lib/yahoo-finance.ts
@@ -98,6 +98,65 @@ export async function fetchOHLCV(symbol: string, days: number): Promise<DailyBar
   return bars.slice(-days);
 }
 
+// ── Intraday candles ─────────────────────────────────────────────────────────
+
+export interface IntradayBar {
+  timestamp: number;  // Unix seconds
+  open:  number;
+  high:  number;
+  low:   number;
+  close: number;
+  volume: number;
+}
+
+/**
+ * Fetch intraday OHLCV bars from Yahoo Finance v8 chart API.
+ * Returns oldest-first (chronological). Never throws — returns null on failure.
+ *
+ * @param symbol    Ticker symbol (e.g. "SPY")
+ * @param interval  Bar size: "1m" | "2m" | "5m" | "15m"
+ * @param range     Lookback: "1d" (today only) | "2d" (two sessions)
+ */
+export async function fetchIntradayBars(
+  symbol: string,
+  interval: '1m' | '2m' | '5m' | '15m' = '5m',
+  range: '1d' | '2d' = '1d',
+): Promise<IntradayBar[] | null> {
+  try {
+    const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?range=${range}&interval=${interval}&includePrePost=false`;
+    const res = await fetch(url, {
+      headers: YAHOO_HEADERS,
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+
+    const data = await res.json() as Record<string, unknown>;
+    const result = (data?.chart as Record<string, unknown>)?.result as Record<string, unknown>[] | undefined;
+    if (!result?.[0]) return null;
+
+    const r = result[0];
+    const timestamps = r.timestamp as number[] | undefined;
+    if (!timestamps?.length) return null;
+
+    const q = ((r.indicators as Record<string, unknown>)?.quote as Record<string, unknown>[])?.[0] ?? {};
+    const opens   = (q.open   as (number | null)[]) ?? [];
+    const highs   = (q.high   as (number | null)[]) ?? [];
+    const lows    = (q.low    as (number | null)[]) ?? [];
+    const closes  = (q.close  as (number | null)[]) ?? [];
+    const volumes = (q.volume as (number | null)[]) ?? [];
+
+    const bars: IntradayBar[] = [];
+    for (let i = 0; i < timestamps.length; i++) {
+      const o = opens[i], h = highs[i], l = lows[i], c = closes[i];
+      if (o == null || h == null || l == null || c == null) continue;
+      bars.push({ timestamp: timestamps[i], open: o, high: h, low: l, close: c, volume: volumes[i] ?? 0 });
+    }
+    return bars; // oldest-first
+  } catch {
+    return null;
+  }
+}
+
 // ── SMA helper ───────────────────────────────────────────────────────────────
 
 /** Compute the N-period simple moving average of the last N values. */

--- a/docs/cursor/2026-06-05-kaycapitals-scalp-exit-strategy.md
+++ b/docs/cursor/2026-06-05-kaycapitals-scalp-exit-strategy.md
@@ -183,13 +183,37 @@ Add entry-quality filters after exits are fixed (bad exits ruin good entries fir
 
 **For puts — mirror of the above.**
 
-### Phase 4 — P3: Runner Logic
+### Phase 4 — P3: Runner Logic (trailing stop on stock structure)
 
-Once partials are working:
-- Target next hourly level
-- Trailing stop under/over structure
-- VWAP / 8 EMA runner hold logic
-- Time-based runner exit
+**Source:** Kay Capitals video on holding runners (Jun 7, 2026)
+
+> "Base your stop loss on the stock price, not on the option price. Every time a new higher low forms, bring your stop loss up based on actual market structure."
+
+Currently the break-even stop is static — once set at entry price, it never moves. The real system trails it upward as the stock makes higher lows (for calls) or lower highs (for puts).
+
+**How it works:**
+```
+Call example — stock in uptrend:
+  Entry stock price: $300, break-even stop set at $300
+  Stock makes higher low at $305 → trail stop up to $305
+  Stock makes higher low at $310 → trail stop up to $310
+  Stock breaks below most recent higher low → exit runner
+```
+
+This is how he catches $5–$20 stock moves instead of exiting at a fixed +100% premium target. The option stop follows stock structure, not option premium math.
+
+**Implementation requirements:**
+- Every management cycle (every 15 min), for PARTIAL positions (runner active):
+  1. Fetch recent 5-min candles for the stock
+  2. Detect most recent higher low (calls) or lower high (puts)
+  3. If new higher low > previous stop level → update `metadata.runner_stop_price`
+  4. If stock price drops below `runner_stop_price` → close runner
+- Store `runner_stop_price` in metadata (stock price level, not option premium)
+- Current break-even stop stays as the floor — runner stop can only move in profit direction
+
+**Also from this video:**
+- Hide option bid/ask from view entirely — trade off stock price chart, not option price
+- This is psychology, not code — but it confirms the runner stop should be stock-price-based, not premium-based
 
 ---
 


### PR DESCRIPTION
## Summary

Implements Kay Capitals Phase 3 runner logic: trail the runner stop based on stock price structure (higher lows for calls, lower highs for puts), not on option premium percentage.

- **`fetchIntradayBars()`** added to `yahoo-finance.ts` — fetches 5-min bars via Yahoo Finance v8 API (verified working, returns ~79 bars per session)
- **`trailRunnerStop()`** helper — scans last N completed 5-min bars, finds most recent confirmed higher low (calls) or lower high (puts), requires ≥$0.15 improvement to filter noise
- **Runner stop lifecycle in `manageScalpPositions`:**
  - After partial exit: `runner_stop_price` initialized to current stock price ±0.2% (stored in `metadata`)
  - Each 15-min cycle: fetch 5-min bars, trail stop upward if new structure point found
  - Exit runner if stock price crosses the trailing stop
  - Break-even premium stop kept as fallback if bars unavailable
  - Full profit target (+100%) still closes runner regardless

## Test plan
- [ ] Monday: after first partial exit fires, confirm `metadata.runner_stop_price` is set in DB
- [ ] Subsequent cycles: confirm log shows `runner stop trailed: $X → $Y` on uptrending stocks
- [ ] Runner exits on stock stop: log shows `runner stock stop hit (stock $X <= stop $Y)`
- [ ] If Yahoo bars unavailable: falls back to break-even premium stop, no crash

Made with [Cursor](https://cursor.com)