### PR TITLE
fix: handle options scalp expiration and auto-exercise correctly

### DIFF
--- a/app/src/components/PaperTrading/tabs/OptionsTab.tsx
+++ b/app/src/components/PaperTrading/tabs/OptionsTab.tsx
@@ -1267,10 +1267,18 @@ function ScalpCard({ scalp, closed }: { scalp: ScalpTrade; closed?: boolean }) {
 
   const closeLabel = (() => {
     switch (scalp.close_reason) {
-      case 'eod_close':    return '🌙 EOD close';
-      case 'stop_loss':    return '🛑 Stop loss';
-      case '50pct_profit': return '💰 50% profit';
-      case 'no_fill':      return '❌ No fill';
+      case 'eod_close':          return '🌙 EOD close';
+      case 'stop_loss':          return '🛑 Stop loss';
+      case 'break_even_stop':    return '🛑 Break-even stop';
+      case 'runner_stop':        return '🛑 Runner stop';
+      case 'partial_profit':     return '💰 Partial profit';
+      case 'profit_target':      return '✅ Profit target';
+      case '50pct_profit':       return '💰 50% profit';
+      case 'no_fill':            return '❌ No fill';
+      case 'expired_worthless':  return '📭 Expired worthless';
+      case 'auto_exercised':     return '⚙️ Auto-exercised';
+      case 'ib_reconciliation_cover': return '🔄 Exercise cover';
+      case 'manual':             return '✋ Manual';
       default: return scalp.close_reason?.replace(/_/g, ' ') ?? null;
     }
   })();

--- a/app/src/lib/optionsApi.ts
+++ b/app/src/lib/optionsApi.ts
@@ -441,6 +441,10 @@ export async function getClosedScalpTrades(limit = 40): Promise<ScalpTrade[]> {
     .select(SCALP_SELECT)
     .eq('mode', 'OPTIONS_SCALP')
     .in('status', [...CLOSED_STATUSES])
+    // Exclude exercise-cover mechanics records (pnl=0 cover buys from reconcileIBShorts).
+    // These are audit-trail entries only — the P&L is attributed to the originating
+    // options trade (auto_exercised). Including them would add noise to the scalp history.
+    .neq('close_reason', 'ib_reconciliation_cover')
     .order('closed_at', { ascending: false })
     .limit(limit);
   if (error) throw error;

--- a/auto-trader/src/lib/options-scalp.ts
+++ b/auto-trader/src/lib/options-scalp.ts
@@ -173,6 +173,19 @@ function get5mSmaDirection(bars: IntradayBar[], currentPrice: number): 'C' | 'P'
   return currentPrice > sma200 ? 'C' : 'P';
 }
 
+/**
+ * Parse an option expiry string (YYYYMMDD or YYYY-MM-DD) to a local Date at midnight.
+ * Returns null if the format is unrecognised.
+ */
+function parseExpiryDate(expiry: string): Date | null {
+  const cleaned = expiry.replace(/-/g, '');
+  if (!/^\d{8}$/.test(cleaned)) return null;
+  const y = parseInt(cleaned.slice(0, 4), 10);
+  const m = parseInt(cleaned.slice(4, 6), 10) - 1;
+  const d = parseInt(cleaned.slice(6, 8), 10);
+  return new Date(y, m, d);
+}
+
 /** Return nearest weekly Friday expiry that is at least 1 day away, as YYYYMMDD. */
 function getNearestWeeklyExpiry(): string {
   const now = new Date();
@@ -686,6 +699,9 @@ export async function manageScalpPositions(): Promise<void> {
 
   if (!positions?.length) return;
 
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
   for (const pos of (positions as Array<{
     id: string; ticker: string; signal: string; status: string;
     option_strike: number; option_expiry: string;
@@ -693,6 +709,26 @@ export async function manageScalpPositions(): Promise<void> {
     ib_order_id: number | null; metadata: Record<string, unknown> | null;
     filled_at: string | null;
   }>)) {
+    // Skip options that have already passed their expiry date — the contract no longer
+    // exists in IB so Greeks calls will always fail. closeAllScalpPositionsEod handles
+    // these on expiry day; they should not reappear in management on subsequent days.
+    const expiryDate = parseExpiryDate(pos.option_expiry ?? '');
+    if (expiryDate && expiryDate < today) {
+      console.log(`[Options Scalp] ${pos.ticker} — option_expiry ${pos.option_expiry} is in the past, closing as expired_worthless (missed by EOD close)`);
+      const right2 = pos.signal === 'BUY' ? 'C' : 'P';
+      const meta2 = ((pos.metadata ?? {}) as Record<string, unknown>);
+      const isPartial2 = pos.status === 'PARTIAL';
+      const remaining2 = isPartial2 ? ((meta2.contracts_remaining as number | undefined) ?? 1) : (pos.option_contracts ?? MAX_CONTRACTS);
+      // Fetch stock price to determine if expired ITM (auto-exercised) or OTM (worthless)
+      const q2 = await fetchQuote(pos.ticker);
+      const stockPx2 = q2?.price ?? null;
+      const isItm2 = stockPx2 != null && (right2 === 'C' ? stockPx2 > pos.option_strike : stockPx2 < pos.option_strike);
+      await closeScalpPosition(pos.id, pos.ticker, right2, pos.option_strike, pos.option_expiry,
+        0, pos.option_premium, isItm2 ? 'auto_exercised' : 'expired_worthless',
+        { contractsToSell: remaining2, existingMeta: meta2 });
+      continue;
+    }
+
     const premiumPaid = pos.option_premium ?? 0;
     if (premiumPaid <= 0) continue;
 
@@ -866,9 +902,47 @@ export async function closeAllScalpPositionsEod(): Promise<void> {
     // CRITICAL: getOptionGreeksForContract returns null when IB is disconnected.
     // null !== $0 (worthless) — if Greeks are unavailable, leave the position open
     // rather than incorrectly marking it CLOSED at $0. The next cycle will retry.
+    //
+    // Exception: if the option is ON its expiry date, IB drops the contract from
+    // its chain after exercise/expiry — Greeks will always be null. In this case
+    // we use the live stock price to determine ITM vs OTM and close accordingly.
     const greeks = await getOptionGreeksForContract(pos.ticker, pos.option_strike, pos.option_expiry, right, stockPrice);
     if (!greeks) {
-      console.warn(`[Options Scalp] ${pos.ticker} — IB Greeks unavailable (disconnected?), leaving open — DO NOT mark as $0`);
+      const expiryDate = parseExpiryDate(pos.option_expiry ?? '');
+      const todayEod = new Date();
+      todayEod.setHours(0, 0, 0, 0);
+
+      if (expiryDate && expiryDate <= todayEod) {
+        // Option has reached or passed its expiry — contract no longer exists in IB.
+        // Use stock price to determine whether it expired ITM (auto-exercised) or OTM (worthless).
+        const isItm = right === 'C'
+          ? stockPrice > pos.option_strike
+          : stockPrice < pos.option_strike;
+
+        if (isItm) {
+          // ITM at expiry → OCC auto-exercised. A short stock position (for puts) or long
+          // stock position (for calls) was created in IB. reconcileIBShorts/Longs will
+          // detect and handle the resulting stock position. Mark the option record closed.
+          console.log(`[Options Scalp] ${pos.ticker} — expired ITM on ${pos.option_expiry} (${right === 'C' ? 'CALL' : 'PUT'} $${pos.option_strike}, stock $${stockPrice.toFixed(2)}) — auto-exercised, P&L tracked when stock cover happens`);
+          await closeScalpPosition(
+            pos.id, pos.ticker, right,
+            pos.option_strike, pos.option_expiry,
+            0, pos.option_premium, 'auto_exercised',
+            { contractsToSell: contractsRemaining, existingMeta: meta },
+          );
+        } else {
+          // OTM at expiry → expired worthless. Full premium is the loss.
+          console.log(`[Options Scalp] ${pos.ticker} — expired OTM worthless on ${pos.option_expiry} (${right === 'C' ? 'CALL' : 'PUT'} $${pos.option_strike}, stock $${stockPrice.toFixed(2)})`);
+          await closeScalpPosition(
+            pos.id, pos.ticker, right,
+            pos.option_strike, pos.option_expiry,
+            0, pos.option_premium, 'expired_worthless',
+            { contractsToSell: contractsRemaining, existingMeta: meta },
+          );
+        }
+      } else {
+        console.warn(`[Options Scalp] ${pos.ticker} — IB Greeks unavailable (disconnected?), leaving open — DO NOT mark as $0`);
+      }
       continue;
     }
 
@@ -996,7 +1070,11 @@ async function closeScalpPosition(
   } else {
     // Full close (or final contract of a partial)
     const prevRealized = (existingMeta.partial_realized_pnl as number | undefined) ?? 0;
-    const totalPnl = prevRealized + contractPnl;
+
+    // auto_exercised: option was ITM at expiry and exercised by OCC, creating a stock
+    // position in IB. The stock P&L is unknown until reconcileIBShorts/Longs covers it.
+    // Store pnl=null here; reconcileIBShorts will update it with the full round-trip P&L.
+    const totalPnl = reason === 'auto_exercised' ? null : prevRealized + contractPnl;
 
     await sb.from('paper_trades').update({
       status:       'CLOSED',
@@ -1006,16 +1084,21 @@ async function closeScalpPosition(
       pnl:          totalPnl,
     }).eq('id', tradeId);
 
-    const pnlStr = totalPnl >= 0 ? `+$${totalPnl.toFixed(0)}` : `-$${Math.abs(totalPnl).toFixed(0)}`;
+    // totalPnl is null for auto_exercised (P&L tracked by reconcileIBShorts on cover)
+    const pnlStr = totalPnl == null
+      ? 'pending exercise cover'
+      : totalPnl >= 0 ? `+$${totalPnl.toFixed(0)}` : `-$${Math.abs(totalPnl).toFixed(0)}`;
     console.log(`[Options Scalp] ${ticker} closed [${reason}] @ $${closePremium.toFixed(2)} | total P&L ${pnlStr}`);
 
     createAutoTradeEvent({
       ticker,
-      event_type: totalPnl >= 0 ? 'success' : 'warning',
+      event_type: totalPnl == null ? 'info' : totalPnl >= 0 ? 'success' : 'warning',
       action:     'closed',
       source:     'scanner',
       mode:       'OPTIONS_SCALP',
-      message:    `${totalPnl >= 0 ? '✅' : '🛑'} Scalp ${right === 'C' ? 'CALL' : 'PUT'} $${strike} closed [${reason}] @ $${closePremium.toFixed(2)} | P&L ${pnlStr}`,
+      message:    totalPnl == null
+        ? `📋 Scalp ${right === 'C' ? 'CALL' : 'PUT'} $${strike} auto-exercised ITM [${reason}] — P&L pending stock cover by reconcileIBShorts`
+        : `${totalPnl >= 0 ? '✅' : '🛑'} Scalp ${right === 'C' ? 'CALL' : 'PUT'} $${strike} closed [${reason}] @ $${closePremium.toFixed(2)} | P&L ${pnlStr}`,
       metadata:   { reason, totalPnl, closePremium, premiumPaid, contractsToSell },
     }).catch(() => {});
   }

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -1471,28 +1471,83 @@ export async function reconcileIBShorts(): Promise<{ closed: string[]; errors: s
         }).eq('id', orphan.id);
         log(`[IBReconcile] Linked cover orderId=${coverOrderId} to paper_trade ${orphan.id} for ${pos.symbol} (pnl $${finalPnl.toFixed(2)}, source=${pnlSource})`);
       } else {
-        // No orphaned SELL paper_trade found — insert a new one so this cover appears
-        // in Today's Activity with the correct IB P&L. The Postgres trigger will upgrade
-        // pnl_source to 'ib_realized' if the realized_pnl arrives later via execDetails.
-        const nowIso = new Date().toISOString();
-        await sb.from('paper_trades').insert({
-          ticker: pos.symbol,
-          signal: 'BUY',
-          mode: 'DAY_TRADE',
-          quantity: qty,
-          fill_price: avgFillPrice,
-          close_price: avgFillPrice,
-          pnl: finalPnl,
-          pnl_source: pnlSource,
-          status: 'CLOSED',
-          ib_order_id: String(coverOrderId),
-          close_reason: 'ib_reconciliation_cover',
-          opened_at: nowIso,
-          filled_at: nowIso,
-          closed_at: nowIso,
-          notes: `Short cover orderId=${coverOrderId} filled @ $${avgFillPrice.toFixed(2)} by reconcileIBShorts (avg cost $${pos.avgCost.toFixed(2)})`,
-        });
-        log(`[IBReconcile] Inserted cover paper_trade for ${pos.symbol} (pnl $${finalPnl.toFixed(2)}, source=${pnlSource})`);
+        // No orphaned SELL paper_trade found.
+        // Before inserting a generic DAY_TRADE cover record, check if there's an
+        // OPTIONS_SCALP PUT trade for this ticker that expired recently and is awaiting
+        // its exercise P&L (pnl=null, close_reason='auto_exercised'). If found, update
+        // the options record directly — this keeps P&L in the Options Scalp history where
+        // the user expects it, avoids a spurious DAY_TRADE row in Today's Activity, and
+        // prevents double-counting between the options record and a cover trade.
+        const twoWeeksAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+        const { data: exercisedScalpTrade } = await sb
+          .from('paper_trades')
+          .select('id')
+          .eq('ticker', pos.symbol)
+          .eq('mode', 'OPTIONS_SCALP')
+          .eq('signal', 'SELL')   // SELL = bought a put
+          .eq('status', 'CLOSED')
+          .eq('close_reason', 'auto_exercised')
+          .is('pnl', null)
+          .gte('closed_at', twoWeeksAgo)
+          .order('closed_at', { ascending: false })
+          .limit(1);
+
+        const exercisedScalp = (exercisedScalpTrade ?? [])[0] as { id: string } | undefined;
+
+        if (exercisedScalp) {
+          // Found the originating options trade — write the full round-trip P&L back to it.
+          // IB's avgCost for the short already includes the put premium (it's deducted from
+          // the cost basis), so finalPnl here is the true net P&L of the whole options trade.
+          await sb.from('paper_trades').update({
+            pnl:        finalPnl,
+            pnl_source: pnlSource,
+            notes: `Auto-exercised ITM put covered by reconcileIBShorts: BUY ${qty} @ $${avgFillPrice.toFixed(2)} (IB avg cost $${pos.avgCost.toFixed(2)}, orderId=${coverOrderId})`,
+          }).eq('id', exercisedScalp.id);
+          log(`[IBReconcile] Updated OPTIONS_SCALP ${exercisedScalp.id} with exercise P&L $${finalPnl.toFixed(2)} for ${pos.symbol}`);
+
+          // Insert a minimal cover record for audit trail, with pnl=0 to avoid double-counting.
+          const nowIso = new Date().toISOString();
+          await sb.from('paper_trades').insert({
+            ticker: pos.symbol,
+            signal: 'BUY',
+            mode: 'OPTIONS_SCALP',
+            quantity: qty,
+            fill_price: avgFillPrice,
+            close_price: avgFillPrice,
+            pnl: 0,
+            pnl_source: 'options_exercise_cover',
+            status: 'CLOSED',
+            ib_order_id: String(coverOrderId),
+            close_reason: 'ib_reconciliation_cover',
+            opened_at: nowIso,
+            filled_at: nowIso,
+            closed_at: nowIso,
+            notes: `Short cover orderId=${coverOrderId} filled @ $${avgFillPrice.toFixed(2)} by reconcileIBShorts (avg cost $${pos.avgCost.toFixed(2)}) — P&L attributed to OPTIONS_SCALP trade ${exercisedScalp.id}`,
+          });
+          log(`[IBReconcile] Inserted OPTIONS_SCALP cover record for ${pos.symbol} (pnl=0, P&L in scalp trade ${exercisedScalp.id})`);
+        } else {
+          // No matching options trade — insert a standard DAY_TRADE cover record so this
+          // cover appears in Today's Activity with the correct IB P&L.
+          const nowIso = new Date().toISOString();
+          await sb.from('paper_trades').insert({
+            ticker: pos.symbol,
+            signal: 'BUY',
+            mode: 'DAY_TRADE',
+            quantity: qty,
+            fill_price: avgFillPrice,
+            close_price: avgFillPrice,
+            pnl: finalPnl,
+            pnl_source: pnlSource,
+            status: 'CLOSED',
+            ib_order_id: String(coverOrderId),
+            close_reason: 'ib_reconciliation_cover',
+            opened_at: nowIso,
+            filled_at: nowIso,
+            closed_at: nowIso,
+            notes: `Short cover orderId=${coverOrderId} filled @ $${avgFillPrice.toFixed(2)} by reconcileIBShorts (avg cost $${pos.avgCost.toFixed(2)})`,
+          });
+          log(`[IBReconcile] Inserted cover paper_trade for ${pos.symbol} (pnl $${finalPnl.toFixed(2)}, source=${pnlSource})`);
+        }
       }
 
       await createAutoTradeEvent({


### PR DESCRIPTION
## Summary

- **Root cause**: `closeAllScalpPositionsEod()` couldn't price expired/exercised option contracts (IB drops them after expiry), leaving June 5 scalps stuck as FILLED forever. `reconcileIBShorts` then covered the resulting short positions as generic DAY_TRADE records, causing NVDL/SOFI/IWM to appear in Today's Activity on June 8.
- **Code fix**: EOD close now detects expired contracts (IB Greeks unavailable + expiry date reached), checks ITM vs OTM using stock price, and closes as `auto_exercised` or `expired_worthless` appropriately.
- **Code fix**: `reconcileIBShorts` now detects when a short came from a put auto-exercise, writes the full round-trip P&L back to the originating OPTIONS_SCALP trade, and inserts a zero-P&L `OPTIONS_SCALP` cover record instead of a `DAY_TRADE` one.
- **Data fix**: Corrected 7 June 5 trades (4 stale open + 3 with wrong positive P&L from a bad manual close).

## Changes

| File | Change |
|------|--------|
| `options-scalp.ts` | `closeAllScalpPositionsEod`: handle expired contracts; `manageScalpPositions`: skip past-expiry positions; `closeScalpPosition`: pnl=null for auto_exercised |
| `scheduler.ts` | `reconcileIBShorts`: link exercise-cover P&L to originating OPTIONS_SCALP trade |
| `optionsApi.ts` | `getClosedScalpTrades`: exclude ib_reconciliation_cover records |
| `OptionsTab.tsx` | `ScalpCard`: add labels for expired_worthless, auto_exercised, exercise cover |

## Data fixes applied (June 5)
- SPY $753 Call → `expired_worthless` pnl=-$235
- NVDL $103 Put → `auto_exercised` pnl=+$4
- SOFI $18 Put → `auto_exercised` pnl=+$122.18
- IWM $290 Put → `auto_exercised` pnl=+$199.34
- APP/AMZN/MSFT calls → fixed wrong positive P&L to correct negative values
- NVDL/SOFI/IWM reconcile cover trades → mode=OPTIONS_SCALP, pnl=0

Made with [Cursor](https://cursor.com)