### PR TITLE
fix: clean up Today's Activity display (Jun 8)

### DIFF
--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -542,8 +542,18 @@ export function TodayActivityTab({ events, trades, todayTrades, orphanedFills = 
 
               const acctType = (trade as PaperTrade & { _accountType?: 'paper' | 'live' })._accountType;
 
+              // Stale trades: opened on a prior day but closed today by stale_eod_close.
+              // Show their original open date so the user knows this isn't a fresh trade.
+              const todayMidnight = new Date(); todayMidnight.setHours(0, 0, 0, 0);
+              const isStaleClose = trade.close_reason === 'stale_eod_close'
+                && trade.opened_at != null
+                && new Date(trade.opened_at) < todayMidnight;
+              const staleOpenDate = isStaleClose
+                ? new Date(trade.opened_at!).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+                : null;
+
               return (
-                <tr key={trade.id} className="hover:bg-[hsl(var(--secondary))]/50">
+                <tr key={trade.id} className={cn('hover:bg-[hsl(var(--secondary))]/50', isStaleClose && 'bg-amber-50/20')}>
                   <td className="px-4 py-3 font-bold">
                     <span className="inline-flex items-center gap-1.5">
                       {acctType === 'live' && <AccountDot type="live" />}
@@ -567,6 +577,11 @@ export function TodayActivityTab({ events, trades, todayTrades, orphanedFills = 
                     )}
                     {closePrice != null && (
                       <span className="ml-1 text-[10px]">→ ${closePrice.toFixed(2)}</span>
+                    )}
+                    {isStaleClose && staleOpenDate && (
+                      <span className="ml-1.5 px-1 py-0.5 rounded text-[9px] font-medium bg-amber-100 text-amber-700" title="Trade opened on a prior day — cleaned up today by stale EOD close">
+                        opened {staleOpenDate}
+                      </span>
                     )}
                     {trade.strategy_video_heading && (
                       <p className="text-[10px] text-[hsl(var(--muted-foreground))] truncate max-w-[180px] mt-0.5" title={trade.strategy_video_heading}>

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -246,6 +246,9 @@ export async function getTodayTrades(accountView: AccountView = 'paper'): Promis
         `closed_at.gte.${todayISO},` +
         `and(status.in.(FILLED,PARTIAL),mode.in.(DAY_TRADE,DAY_PENNY),filled_at.gte.${lookbackISO})`
       )
+      // Exclude exercise-cover mechanics (pnl=0 cover buys from reconcileIBShorts).
+      // P&L for these is already attributed to the originating OPTIONS_SCALP trade.
+      .neq('close_reason', 'ib_reconciliation_cover')
       .order('opened_at', { ascending: false });
 
     if (error) return [];


### PR DESCRIPTION
## Summary
- Filters `ib_reconciliation_cover` records from Today's Activity — the NVDL/SOFI/IWM exercise cover mechanics ($0 pnl buys) no longer clutter the list
- Adds an **"opened May 26"** badge for stale trades closed today by `stale_eod_close` so it's clear they're not new trades
- Data fix: NEM pnl corrected to -$31.74, ASTS to -$55.49 (ghost `ib_fill_auto_created` records had pnl=0 due to null fill_price)

## What was wrong
| Row | Problem | Fix |
|---|---|---|
| NVDL/SOFI/IWM (Scalp $0) | ib_reconciliation_cover records showing in today's feed | Filtered at API level |
| NEM -$31.74 | pnl=0 on ghost record | DB update from IB actual |
| ASTS -$55.49 | pnl=0 on ghost record | DB update from IB actual |
| Somesh SPY | 12-day-old stale trade (May 26) closed today | Now shows "opened May 26" badge |

Made with [Cursor](https://cursor.com)