### PR TITLE
fix: today activity drops open trades; swap calc/IB P&L colors

### DIFF
--- a/app/src/components/PaperTrading/shared/StreakBoard.tsx
+++ b/app/src/components/PaperTrading/shared/StreakBoard.tsx
@@ -92,7 +92,8 @@ export function StreakBoard() {
         // pnl values. Excluding them hides all ghost closes (ASTS swing losses, AOS,
         // GATX, NEM long-term closes) making those rows look far better than reality.
         // pnl IS NOT NULL is already sufficient to exclude unfilled/cancelled trades.
-        .neq('close_reason', 'ib_reconciliation_cover')
+        // Must use OR IS NULL — plain .neq() drops NULL close_reason rows too (SQL NULL != x is UNKNOWN).
+        .or('close_reason.neq.ib_reconciliation_cover,close_reason.is.null')
         .in('mode', ['DAY_TRADE', 'DAY_PENNY', 'SWING_TRADE', 'LONG_TERM', 'OPTIONS_SCALP'])
         .gte('closed_at', since + 'T00:00:00')
         .order('closed_at', { ascending: true });

--- a/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
+++ b/app/src/components/PaperTrading/tabs/TodayActivityTab.tsx
@@ -346,9 +346,7 @@ export function TodayActivityTab({ events, trades, todayTrades, orphanedFills = 
   const ibSyncing = ibConnected && ibRealizedPnl === null;
   const ibOffline = !isTradingDay() || ibRealizedPnl === undefined;
 
-  // When IB is connected, IB realized P&L is the source of truth (workspace rule).
-  // Paper_trades sum is shown as a small secondary reference only.
-  const displayPnl = effectiveIbPnl != null ? effectiveIbPnl : filteredPnl;
+  // Our calc P&L is always the primary green display; IB P&L is shown in amber as a secondary check.
 
   return (
     <div className="space-y-3">
@@ -357,14 +355,16 @@ export function TodayActivityTab({ events, trades, todayTrades, orphanedFills = 
         <div className="flex items-center justify-between rounded-lg bg-[hsl(var(--secondary))] px-4 py-2.5">
           <span className="text-sm font-medium text-[hsl(var(--muted-foreground))]">{pnlLabel}</span>
           <div className="flex items-center gap-3">
-            <span className={cn('text-sm font-bold tabular-nums', displayPnl > 0 ? 'text-emerald-600' : displayPnl < 0 ? 'text-red-600' : '')}>
-              {fmtUsd(displayPnl, 2, true)}
+            {/* Our calc P&L — always primary in green/red */}
+            <span className={cn('text-sm font-bold tabular-nums', filteredPnl > 0 ? 'text-emerald-600' : filteredPnl < 0 ? 'text-red-600' : '')}>
+              {fmtUsd(filteredPnl, 2, true)}
             </span>
+            {/* IB P&L — amber secondary reference */}
             {effectiveIbPnl != null && (() => {
               const mismatch = Math.abs(filteredPnl - effectiveIbPnl) > 5;
               return mismatch ? (
                 <span className="text-[11px] tabular-nums text-amber-500">
-                  calc {fmtUsd(filteredPnl, 2, true)} ⚠️
+                  IB {fmtUsd(effectiveIbPnl, 2, true)} ⚠️
                 </span>
               ) : null;
             })()}

--- a/app/src/lib/optionsApi.ts
+++ b/app/src/lib/optionsApi.ts
@@ -442,9 +442,8 @@ export async function getClosedScalpTrades(limit = 40): Promise<ScalpTrade[]> {
     .eq('mode', 'OPTIONS_SCALP')
     .in('status', [...CLOSED_STATUSES])
     // Exclude exercise-cover mechanics records (pnl=0 cover buys from reconcileIBShorts).
-    // These are audit-trail entries only — the P&L is attributed to the originating
-    // options trade (auto_exercised). Including them would add noise to the scalp history.
-    .neq('close_reason', 'ib_reconciliation_cover')
+    // Must use OR IS NULL — plain .neq() drops NULL close_reason rows too (SQL NULL != x is UNKNOWN).
+    .or('close_reason.neq.ib_reconciliation_cover,close_reason.is.null')
     .order('closed_at', { ascending: false })
     .limit(limit);
   if (error) throw error;

--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -247,8 +247,8 @@ export async function getTodayTrades(accountView: AccountView = 'paper'): Promis
         `and(status.in.(FILLED,PARTIAL),mode.in.(DAY_TRADE,DAY_PENNY),filled_at.gte.${lookbackISO})`
       )
       // Exclude exercise-cover mechanics (pnl=0 cover buys from reconcileIBShorts).
-      // P&L for these is already attributed to the originating OPTIONS_SCALP trade.
-      .neq('close_reason', 'ib_reconciliation_cover')
+      // Must use OR IS NULL — plain .neq() drops NULL close_reason rows too (SQL NULL != x is UNKNOWN).
+      .or('close_reason.neq.ib_reconciliation_cover,close_reason.is.null')
       .order('opened_at', { ascending: false });
 
     if (error) return [];


### PR DESCRIPTION
## Summary
- Fixed NULL filter bug: `.neq('close_reason', 'ib_reconciliation_cover')` was silently dropping all rows where `close_reason IS NULL` (SQL `!=` returns UNKNOWN for NULLs). AAPL, QQQ, SMH and any other open day trades with no close_reason were being excluded from Today's Activity. Fixed with `.or('close_reason.neq...,close_reason.is.null')` in `paperTradesApi.ts`, `optionsApi.ts`, and `StreakBoard.tsx`.
- Swapped P&L colors in Today's Activity header: our calc P&L is now the primary green/red number; IB realized P&L is the amber secondary reference (shown only on >$5 mismatch).

## Test plan
- [ ] Today's Activity shows AAPL, QQQ, SMH (open day trades)
- [ ] Header shows calc P&L in green/red and IB P&L in amber when they differ

Made with [Cursor](https://cursor.com)