### PR TITLE
fix: exclude ib_reconciliation_cover from scalp daily cap count

### DIFF
--- a/auto-trader/src/lib/options-scalp.ts
+++ b/auto-trader/src/lib/options-scalp.ts
@@ -235,13 +235,16 @@ export async function runOptionScalpScan(): Promise<void> {
     return;
   }
 
-  // Daily cap check
+  // Daily cap check — exclude ib_reconciliation_cover records (cover buys created by
+  // reconcileIBShorts for auto-exercised puts). They are OPTIONS_SCALP mode but are not
+  // real scalp trades and must not consume a daily slot.
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
   const { data: todayTrades } = await sb
     .from('paper_trades')
     .select('id')
     .eq('mode', 'OPTIONS_SCALP')
+    .neq('close_reason', 'ib_reconciliation_cover')
     .gte('opened_at', todayStart.toISOString());
   const usedToday = (todayTrades ?? []).length;
   if (usedToday >= MAX_SCALP_TRADES_PER_DAY) {
@@ -409,11 +412,13 @@ export async function runVwapRetestScalpScan(): Promise<void> {
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
 
-  // Combined daily cap — VWAP retests count toward the same 2-trade limit
+  // Combined daily cap — VWAP retests count toward the same 2-trade limit.
+  // Exclude ib_reconciliation_cover records — cover buys are not real scalp trades.
   const { data: todayTrades } = await sb
     .from('paper_trades')
     .select('id')
     .eq('mode', 'OPTIONS_SCALP')
+    .neq('close_reason', 'ib_reconciliation_cover')
     .gte('opened_at', todayStart.toISOString());
   const usedToday = (todayTrades ?? []).length;
   if (usedToday >= MAX_SCALP_TRADES_PER_DAY) {


### PR DESCRIPTION
## Summary
The scalp daily cap query counted `ib_reconciliation_cover` trades (OPTIONS_SCALP cover buys placed by `reconcileIBShorts`) as real scalp slots. Today's 3 cover trades (NVDL/SOFI/IWM) pushed the counter to 3/2, blocking the scanner for the entire day.

Fixed by adding `.neq('close_reason', 'ib_reconciliation_cover')` to the daily cap count query in both `manageScalpPositions` and `scanVwapRetestScalps`.

## Test plan
- [ ] Auto-trader log no longer shows "Daily cap reached" due to cover trades
- [ ] Scalp scanner can place up to 2 real scalps per day regardless of how many reconcile covers exist

Made with [Cursor](https://cursor.com)