### PR TITLE
fix: pre-stamp ib_close_order_id to prevent ghost records on auto-trader closes

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -63,6 +63,10 @@ export interface MarketOrderParams {
   symbol: string;
   side: 'BUY' | 'SELL';
   quantity: number;
+  /** Pre-allocate the IB order ID before calling placeMarketOrder, so callers can stamp
+   *  ib_close_order_id on the paper_trade BEFORE placing the order. This prevents the
+   *  DB trigger from creating ghost records when the fill arrives before recordTradeClose runs. */
+  preAllocatedOrderId?: number;
   /** Use IB's Adaptive Algo instead of a plain MKT order.
    *  Recommended for sub-$1 stocks to avoid IB error 2161
    *  (regulatory price cap on plain market orders). */
@@ -898,11 +902,11 @@ export class IBConnection {
       throw new Error(`${this.tag} Not connected to IB Gateway`);
     }
 
-    const { symbol, side, quantity, useAdaptiveAlgo } = params;
+    const { symbol, side, quantity, useAdaptiveAlgo, preAllocatedOrderId } = params;
     const contract = await this.resolveContractForOrder(symbol);
 
     return new Promise((resolve, reject) => {
-      const orderId = this.getNextOrderId();
+      const orderId = preAllocatedOrderId ?? this.getNextOrderId();
 
       const order: Order = {
         action: side === 'BUY' ? OrderAction.BUY : OrderAction.SELL,

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -983,9 +983,9 @@ async function closeAllDayTrades(config: AutoTraderConfig): Promise<void> {
           catch (e) { log(`${trade.ticker}: EOD — cancel SL #${trade.ib_sl_order_id} failed: ${e instanceof Error ? e.message : 'unknown'}`); }
         }
 
-        let fillResult: { avgFillPrice: number } | null = null;
+        let fillResult: import('./ib-connection.js').MarketOrderResult | null = null;
         try {
-          fillResult = await conn.placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });
+          fillResult = await stampAndPlaceClose(conn, trade.id, { symbol: trade.ticker, side: closeSide, quantity: qty }, acctType);
           log(`${trade.ticker}: EOD close filled [${acctType}] (${qty} shares ${closeSide}) @ $${fillResult.avgFillPrice.toFixed(2)}`);
         } catch (orderErr) {
           log(`EOD sweep: ${trade.ticker} — IB order failed (${orderErr instanceof Error ? orderErr.message : 'unknown'}) — will retry on next sweep`);
@@ -998,7 +998,7 @@ async function closeAllDayTrades(config: AutoTraderConfig): Promise<void> {
           closePrice: fillResult.avgFillPrice,
           closeReason: 'eod_close',
           status: 'CLOSED',
-          orderId: (fillResult as { orderId?: number }).orderId,
+          orderId: fillResult.orderId,
           accountType: acctType,
         });
         log(`${trade.ticker}: EOD closed [${acctType}] (${qty} shares ${closeSide}) @ $${fillResult.avgFillPrice.toFixed(2)}`);
@@ -1073,9 +1073,9 @@ async function softCloseDayTrades(positions: EnrichedPosition[]): Promise<void> 
       }
 
       try {
-        let fillResult: { avgFillPrice: number } | null = null;
+        let fillResult: import('./ib-connection.js').MarketOrderResult | null = null;
         try {
-          fillResult = await conn.placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });
+          fillResult = await stampAndPlaceClose(conn, trade.id, { symbol: trade.ticker, side: closeSide, quantity: qty }, acctType);
           log(`${trade.ticker}: [SoftClose:${acctType}] close filled @ $${fillResult.avgFillPrice.toFixed(2)} — ${reason}`);
         } catch (orderErr) {
           log(`${trade.ticker}: [SoftClose] IB order failed (${orderErr instanceof Error ? orderErr.message : 'unknown'}) — will retry at 3:55 PM hard close`);
@@ -1088,7 +1088,7 @@ async function softCloseDayTrades(positions: EnrichedPosition[]): Promise<void> 
           closePrice: fillResult.avgFillPrice,
           closeReason: 'soft_eod_close',
           status: 'CLOSED',
-          orderId: (fillResult as { orderId?: number }).orderId,
+          orderId: fillResult.orderId,
           accountType: acctType,
         });
         log(`${trade.ticker}: [SoftClose:${acctType}] DB marked closed — ${reason} — fill $${fillResult.avgFillPrice.toFixed(2)}`);
@@ -1168,7 +1168,11 @@ async function checkStaleDayTrades(positions: EnrichedPosition[]): Promise<void>
     // DAY_TRADE that slips through at a low price.
     const useAdaptiveAlgo = trade.mode === 'DAY_PENNY' || fillPrice <= 5;
     try {
-      const result = await placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty, useAdaptiveAlgo });
+      const result = await stampAndPlaceClose(
+        getConnectionForAccount('paper'), trade.id,
+        { symbol: trade.ticker, side: closeSide, quantity: qty, useAdaptiveAlgo },
+        'paper',
+      );
       await recordTradeClose({
         tradeId: trade.id,
         closePrice: result.avgFillPrice,
@@ -1963,6 +1967,31 @@ export async function forceExecuteSignal(signalId: string): Promise<{
 
 function log(msg: string): void {
   console.log(`[Scheduler] ${msg}`);
+}
+
+/**
+ * Pre-stamp ib_close_order_id on a paper_trade, then place a market close order.
+ *
+ * By writing ib_close_order_id BEFORE the IB order is submitted, the DB trigger
+ * (sync_ib_fill_to_paper_trades) can match the incoming fill to this trade and close it
+ * properly instead of creating a ghost record. Without this, the fill arrives during the
+ * await, the trigger fires before recordTradeClose runs, and a ghost is created.
+ *
+ * Use this helper for every close-initiating placeMarketOrder call that has a known tradeId.
+ */
+async function stampAndPlaceClose(
+  conn: IBConnection,
+  tradeId: string,
+  params: Omit<import('./ib-connection.js').MarketOrderParams, 'preAllocatedOrderId'>,
+  accountType: AccountType = 'paper',
+): Promise<import('./ib-connection.js').MarketOrderResult> {
+  const sb = getSupabase();
+  const preId = conn.getNextOrderId();
+  await sb
+    .from(tradesTable(accountType))
+    .update({ ib_close_order_id: String(preId) })
+    .eq('id', tradeId);
+  return conn.placeMarketOrder({ ...params, preAllocatedOrderId: preId });
 }
 
 /** Log and append to lastCycleSummary (kept for status API, max 30 lines) */
@@ -6603,7 +6632,7 @@ async function checkSwingHoldExpiry(
 
     for (const { connection: swingConn, accountType: swAcct } of swingConnections) {
       try {
-        const result = await swingConn.placeMarketOrder({ symbol: trade.ticker, side, quantity: qty });
+        const result = await stampAndPlaceClose(swingConn, trade.id, { symbol: trade.ticker, side, quantity: qty }, swAcct);
         await recordTradeClose({
           tradeId: trade.id,
           closePrice: result.avgFillPrice,
@@ -6845,7 +6874,7 @@ async function checkLongTermAutoSell(
 
     for (const { connection: ltConn, accountType: ltAcctType } of ltConnections) {
       try {
-        const result = await ltConn.placeMarketOrder({ symbol: trade.ticker, side, quantity: qty });
+        const result = await stampAndPlaceClose(ltConn, trade.id, { symbol: trade.ticker, side, quantity: qty }, ltAcctType);
         const avgFillPrice = result.avgFillPrice;
         const fillPnlPct = ibPos.avgCost > 0
           ? ((avgFillPrice - ibPos.avgCost) / ibPos.avgCost) * 100
@@ -6921,7 +6950,11 @@ async function makeRoomForTrade(
     const side: 'BUY' | 'SELL' = candidate.ibPos.position > 0 ? 'SELL' : 'BUY';
 
     try {
-      const result = await placeMarketOrder({ symbol: candidate.trade.ticker, side, quantity: qty });
+      const result = await stampAndPlaceClose(
+        getConnectionForAccount('paper'), candidate.trade.id,
+        { symbol: candidate.trade.ticker, side, quantity: qty },
+        'paper',
+      );
       await recordTradeClose({
         tradeId: candidate.trade.id,
         closePrice: result.avgFillPrice,
@@ -7126,7 +7159,7 @@ async function checkDayTradeTrailingStops(
       }
 
       try {
-        const result = await conn.placeMarketOrder({ symbol: trade.ticker, side: closeSide, quantity: qty });
+        const result = await stampAndPlaceClose(conn, trade.id, { symbol: trade.ticker, side: closeSide, quantity: qty }, acctType);
         await recordTradeClose({
           tradeId: trade.id,
           closePrice: result.avgFillPrice,
@@ -7224,7 +7257,13 @@ async function checkLossCutOpportunities(
 
       try {
         const side = ibPos.position > 0 ? 'SELL' : 'BUY';
-        const result = await conn.placeMarketOrder({ symbol: trade.ticker, side: side as 'BUY' | 'SELL', quantity: sellQty });
+        // Pre-stamp ib_close_order_id before placing so the DB trigger can match the
+        // incoming fill to this paper_trade instead of creating a ghost record.
+        const result = await stampAndPlaceClose(
+          conn, trade.id,
+          { symbol: trade.ticker, side: side as 'BUY' | 'SELL', quantity: sellQty },
+          acctType,
+        );
 
         // Claim the ticker immediately so any subsequent records for the same ticker in this
         // loop iteration are blocked by the in-memory guard above (persistEvent is fire-and-forget


### PR DESCRIPTION
## Root cause

Every close path in the auto-trader (loss cut, swing expiry, long-term exit, EOD sweep, soft close, stale EOD, trailing stop, capital pressure) followed this pattern:

```
const result = await conn.placeMarketOrder(...)   // IB fill arrives HERE
await recordTradeClose(...)                       // sets ib_close_order_id — TOO LATE
```

The IB fill event arrives **during** the `placeMarketOrder` await. The DB trigger (`sync_ib_fill_to_paper_trades`) fires, finds no `ib_close_order_id` on the paper_trade, and creates a ghost record. The real paper_trade stays `FILLED`. `recordTradeClose` eventually runs but now there's a ghost AND a real trade — P&L is doubled, Today's Activity shows duplicate/misleading rows.

This is why NEM and ASTS loss-cuts showed as BUY with $0.00 in Today's Activity — the ghosts were created with the original position's signal (BUY) and pnl=0 (commission report hadn't arrived yet).

## Fix

New `stampAndPlaceClose()` helper:
1. Calls `conn.getNextOrderId()` to pre-allocate the order ID
2. Writes `ib_close_order_id = preId` to the paper_trade **before** submitting to IB
3. Passes `preAllocatedOrderId` to `placeMarketOrder` so IB uses the same ID

The trigger now finds the matching paper_trade by `ib_close_order_id` and closes it inline. No ghost is created. `recordTradeClose` then corrects the close price and P&L as before.

Applied to: loss cut, swing expiry, long-term exit, EOD sweep, soft close, stale EOD close, trailing stop, capital pressure.

`placeMarketOrder` gains an optional `preAllocatedOrderId` param for callers that need it.

## Why this is stable

The fix is at the right level — it doesn't patch filter logic that reacts to symptoms, it prevents the ghost from being created in the first place. The trigger already had the logic to match fills to `ib_close_order_id`; we just weren't setting it in time.

Made with [Cursor](https://cursor.com)