### PR TITLE
fix: LONG_TERM loss cuts opened before today no longer show as orphaned fills

### DIFF
--- a/app/src/lib/paperTradesApi.ts
+++ b/app/src/lib/paperTradesApi.ts
@@ -318,6 +318,26 @@ export async function getTodaysOrphanedFills(
     groups.get(key)!.push(fill);
   }
 
+  // knownOrderIds is built from todayTradesResult (trades opened/closed today).
+  // But LONG_TERM/SWING positions opened before today can be partially closed today —
+  // their ib_close_order_id won't be in todayTradesResult. Do a targeted DB lookup
+  // for any fill order_id that matches an ib_close_order_id on any paper_trade.
+  const uncoveredIds = [...groups.keys()]
+    .map(k => String(groups.get(k)![0].order_id))
+    .filter(id => !knownOrderIds.has(id));
+
+  if (uncoveredIds.length > 0) {
+    const tradesTable = accountView === 'live' ? 'live_trades' : 'paper_trades';
+    const { data: closeMatches } = await supabase
+      .from(tradesTable)
+      .select('ib_close_order_id')
+      .in('ib_close_order_id', uncoveredIds)
+      .not('ib_close_order_id', 'is', null);
+    (closeMatches ?? []).forEach(t => {
+      if (t.ib_close_order_id) knownOrderIds.add(t.ib_close_order_id);
+    });
+  }
+
   const orphans: OrphanedFill[] = [];
   for (const [, fillGroup] of groups) {
     const first = fillGroup[0];


### PR DESCRIPTION
## Summary
- ADBE (and any LONG_TERM/SWING position opened before today) was showing as **System · IB execution** in Today's Activity when its loss cut fired today
- Root cause: \`knownOrderIds\` was built only from trades opened/closed today — old positions' \`ib_close_order_id\` was never included
- Fix: \`getTodaysOrphanedFills\` now does a targeted DB lookup for \`ib_close_order_id\` matches on any fill not already covered, so ADBE correctly shows as **Suggested find · Loss Cut**

## DB fix
- ADBE (ba881467) \`pnl\` corrected from -308.03 → -106.56 (actual IB realized P&L for the 4-share partial close)
- \`close_reason\` set to \`loss_cut\`, \`close_price\` set to 235.72

Made with [Cursor](https://cursor.com)