### PR TITLE
fix: partial loss cuts now appear in Today's Activity

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -7280,9 +7280,14 @@ async function checkLossCutOpportunities(
           // Partial loss cut — update the original record's quantity to what remains in IB.
           // Previously this spawned a new SELL paper_trade record which the next cycle's
           // eligible filter would pick up as a new position and loss-cut again → cascade loop.
+          // Set close_price, close_reason, and closed_at so Today's Activity picks up this
+          // trade via the closed_at.gte.today condition even though it isn't fully closed.
           const sb = getSupabase();
           await sb.from('paper_trades').update({
             quantity: remainingQty,
+            close_price: result.avgFillPrice,
+            close_reason: 'loss_cut',
+            closed_at: new Date().toISOString(),
             notes: `Loss cut ${triggered.label} at -${lossPct.toFixed(1)}% (${sellQty} of ${Math.round(ibPos.position)} sold, ${remainingQty} remain)`,
           }).eq('id', trade.id);
         }


### PR DESCRIPTION
## Root Cause
Partial loss cuts (e.g. sell 4 of 15 ADBE shares) updated \`quantity\` and \`notes\` but never set \`closed_at\`. The \`getTodayTrades\` query includes trades via \`closed_at >= today\` — without \`closed_at\` set, the trade was invisible in Today's Activity.

## Fix
Set \`close_price\`, \`close_reason = loss_cut\`, and \`closed_at = now()\` on partial loss cuts so they surface in Today's Activity with the correct **Suggested find · Loss Cut** label.

## DB fix applied
ADBE (ba881467) \`closed_at\` manually set to today's partial close time (16:30:04 UTC).

Made with [Cursor](https://cursor.com)