### PR TITLE
fix: skip CREDIT_SPREAD in syncPositions to prevent stock-price fallback closure

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -5863,8 +5863,8 @@ async function _syncPositionsForAccount(
   const activeTrades = await getActiveTrades(syncAcct);
 
   for (const trade of activeTrades) {
-    // Options positions are managed exclusively by options-manager — never touch them here.
-    if (trade.mode === 'OPTIONS_PUT' || trade.mode === 'OPTIONS_CALL') continue;
+    // Options and spread positions are managed by their own dedicated managers — never touch them here.
+    if (trade.mode === 'OPTIONS_PUT' || trade.mode === 'OPTIONS_CALL' || trade.mode === 'CREDIT_SPREAD' || trade.mode === 'CALENDAR_SPREAD') continue;
 
     const ibPos = positions.find(
       p => p.symbol.toUpperCase() === trade.ticker.toUpperCase() && p.secType === 'STK'


### PR DESCRIPTION
Second-order effect of the secType===STK fix: credit spreads are OPT positions in IB, so they never match the STK filter and trigger the position-missing fallback with wrong stock-based P&L. Adding CREDIT_SPREAD and CALENDAR_SPREAD to the skip list (same as OPTIONS_PUT/CALL).

Made with [Cursor](https://cursor.com)