### PR TITLE
fix: partial loss cut creates child record instead of mutating original

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -7279,19 +7279,65 @@ async function checkLossCutOpportunities(
             accountType: acctType,
           });
         } else {
-          // Partial loss cut — update the original record's quantity to what remains in IB.
-          // Previously this spawned a new SELL paper_trade record which the next cycle's
-          // eligible filter would pick up as a new position and loss-cut again → cascade loop.
-          // Set close_price, close_reason, and closed_at so Today's Activity picks up this
-          // trade via the closed_at.gte.today condition even though it isn't fully closed.
+          // Partial loss cut — create a child CLOSED record for the sold portion only.
+          // The original record stays FILLED with reduced quantity (the remaining IB position).
+          //
+          // Why a child record (not mutating the original):
+          //   - The Supabase trigger (section 4) uses `paper_trades.quantity` to compute fallback
+          //     P&L. Mutating the original sets quantity=remainingQty, so the trigger computes
+          //     P&L on the wrong qty. Child record has quantity=sellQty → trigger is always right.
+          //   - The original represents the OPEN position. Setting close fields on it makes
+          //     `Today's Activity` and `syncPositions` see a conflicted state (open yet closed).
+          //   - Cascade-loop risk: the eligible filter blocks t.signal !== 'SELL', but a STOPPED
+          //     child record also can't loop (status != FILLED/PARTIAL → not in eligible).
           const sb = getSupabase();
-          await sb.from('paper_trades').update({
-            quantity: remainingQty,
-            close_price: result.avgFillPrice,
-            close_reason: 'loss_cut',
-            closed_at: new Date().toISOString(),
-            notes: `Loss cut ${triggered.label} at -${lossPct.toFixed(1)}% (${sellQty} of ${Math.round(ibPos.position)} sold, ${remainingQty} remain)`,
-          }).eq('id', trade.id);
+
+          // 1. Insert a child record for the sold shares. Starts as FILLED so recordTradeClose
+          //    can mark it STOPPED and the trigger's section-4 can target it via ib_close_order_id.
+          const { data: child } = await sb
+            .from(tradesTable(acctType))
+            .insert({
+              ticker: trade.ticker,
+              signal: trade.signal,
+              mode: trade.mode,
+              status: 'FILLED',
+              quantity: sellQty,
+              entry_price: trade.entry_price,
+              fill_price: trade.fill_price,
+              ib_close_order_id: String(result.orderId),
+              entry_trigger_type: trade.entry_trigger_type,
+              strategy_source: trade.strategy_source,
+              opened_at: trade.opened_at,
+              notes: `Partial loss cut ${triggered.label}: sold ${sellQty} of ${Math.round(ibPos.position)} shares at -${lossPct.toFixed(1)}%`,
+            })
+            .select('id')
+            .single();
+
+          // 2. Close the child — recordTradeClose looks up ib_fills for realized P&L (correct
+          //    sellQty), and falls back to formula with sellQty if commission report hasn't landed.
+          if (child?.id) {
+            await recordTradeClose({
+              tradeId: child.id,
+              closePrice: result.avgFillPrice,
+              closeReason: 'loss_cut',
+              status: 'STOPPED',
+              orderId: result.orderId,
+              accountType: acctType,
+            });
+          } else {
+            log(`${trade.ticker}: Partial loss cut child record insert failed — ib_close_order_id ${result.orderId} orphaned`);
+          }
+
+          // 3. Reduce original quantity and clear ib_close_order_id (now owned by child).
+          //    No close fields — the original is still an open FILLED position.
+          await sb
+            .from(tradesTable(acctType))
+            .update({
+              quantity: remainingQty,
+              ib_close_order_id: null,
+              notes: `Partial loss cut ${triggered.label}: sold ${sellQty}, ${remainingQty} remain in IB`,
+            })
+            .eq('id', trade.id);
         }
 
         const realizedLoss = ibPos.position > 0


### PR DESCRIPTION
## Summary

- **Root cause of daily ADBE/NEM P&L discrepancies:** The partial loss cut path in `scheduler.ts` was mutating the original `paper_trade` record — setting `close_price`, `close_reason`, `closed_at`, and reducing `quantity` to `remainingQty`. The Supabase trigger then fired and computed P&L using `paper_trades.quantity` (now `remainingQty`, not `soldQty`) → wrong P&L every time.
- **Also broke state:** Setting close fields on a FILLED record made `syncPositions` and Today's Activity see a conflicted record (open but with a close date).
- **Fix:** Create a **child CLOSED record** for the sold portion (`quantity=soldQty`), call `recordTradeClose` on it (gets `realized_pnl` from `ib_fills`), then update the original with `quantity=remainingQty` + clear `ib_close_order_id`. The original stays a clean FILLED open position. The trigger always targets the correctly-sized child.

## Changes

- `auto-trader/src/scheduler.ts`: replace partial loss cut `else` block (~line 7282) with child-record pattern

## DB repairs done (Jun 10, 2026)
- ADBE `ba881467`: cleared stale close fields, set qty=4 (4 shares remain in IB)
- Created ADBE child for order 39548: 3 shares, pnl=-$84.50 (today)
- Created ADBE child for order 37825: 4 shares, pnl=-$106.56 (Jun 9)
- Created NEM record for order 43825: 2 shares, pnl=-$34.20 (today 1:45 PM)
- RKLB `ff945d9a`: reopened (was falsely closed with stock price 107.6 as close_price)

## Test plan
- [ ] Trigger a partial loss cut tomorrow and verify: original qty decreases, new child record appears in Today's Activity with correct P&L, `pnl_source=ib_realized`
- [ ] Run Amelia's audit query: `SELECT ... WHERE ABS(pt.pnl - SUM(ib_fills.realized_pnl)) > 0.10` should return 0 rows for today's closes
- [ ] IB realized P&L should match app total within $1

Made with [Cursor](https://cursor.com)