### PR TITLE
fix: prevent spurious credit spread closes (ghost records + reconcileGhostCloses)

### DIFF
--- a/auto-trader/src/lib/credit-spread-scanner.ts
+++ b/auto-trader/src/lib/credit-spread-scanner.ts
@@ -525,6 +525,12 @@ export async function manageCreditSpreadPositions(): Promise<void> {
             });
             ibCloseOrderId = closeResult.orderId;
             console.log(`[Credit Spread Manager] IB buy-to-close dispatched for ${pos.ticker} (order #${ibCloseOrderId})`);
+            // Pre-stamp ib_close_order_id immediately so the trigger can match incoming
+            // fill events even if recordTradeClose() hasn't written to the DB yet.
+            // Without this, fills arriving before the recordTradeClose write create ghost records.
+            await getSupabase().from('paper_trades').update({
+              ib_close_order_id: String(ibCloseOrderId),
+            }).eq('id', pos.id);
           } catch (ibErr) {
             console.warn(`[Credit Spread Manager] IB buy-to-close FAILED for ${pos.ticker}: ${ibErr instanceof Error ? ibErr.message : ibErr}`);
           }

--- a/auto-trader/src/lib/reconcile-executions.ts
+++ b/auto-trader/src/lib/reconcile-executions.ts
@@ -6,7 +6,7 @@
  */
 
 import { EventName } from '@stoqey/ib';
-import { getIBApi, isConnected, getNextOrderId, getDefaultAccount, type IBConnection, getConnectionForAccount } from '../ib-connection.js';
+import { getIBApi, isConnected, getNextOrderId, getDefaultAccount, type IBConnection, getConnectionForAccount, requestPositions } from '../ib-connection.js';
 import { getSupabase, createAutoTradeEvent, tradesTable, type PaperTrade } from './supabase.js';
 import { recalculatePerformance } from './feedback.js';
 import type { AccountType } from '../../../shared/trade-types.js';
@@ -450,6 +450,30 @@ export async function reconcileGhostCloses(
 
     const latestClosePrice = latestGhost.close_price;
     const closeOrderIds = ghostGroup.map(g => g.ib_close_order_id).filter(Boolean).join(',');
+
+    // Safety check: verify IB no longer holds this position before closing the DB record.
+    // Without this, a ghost created by a partial fill would cause premature closure of
+    // the real trade while IB still holds the remaining shares (NEM bug, Jun 10 2026).
+    if (isConnected()) {
+      try {
+        const ibPositions = await requestPositions();
+        const ibHolding = ibPositions.find(p => p.symbol === ticker && p.position !== 0);
+        if (ibHolding) {
+          log(
+            `[GhostClose] ${ticker} (${mode}): SKIPPING close — IB still holds ${ibHolding.position} ` +
+            `shares/contracts. Ghost was from a partial fill; real trade ${realTrade.id} remains open.`,
+          );
+          await createAutoTradeEvent({
+            ticker, event_type: 'warning', action: 'skipped', source: 'system',
+            message: `[GhostClose] ${ticker}: skipped close — IB still holds position (${ibHolding.position} units). Partial fill ghost, not a full close.`,
+            metadata: { realTradeId: realTrade.id, ghostIds: ghostGroup.map(g => g.id), ibPosition: ibHolding.position },
+          }, accountType);
+          continue;
+        }
+      } catch (posErr) {
+        log(`[GhostClose] ${ticker}: reqPositions failed (${posErr instanceof Error ? posErr.message : posErr}) — proceeding with close anyway`);
+      }
+    }
 
     log(
       `[GhostClose] ${ticker} (${mode}): linking ${ghostGroup.length} ghost(s) → real trade ${realTrade.id} ` +


### PR DESCRIPTION
## Summary

Two real bugs confirmed via Party Mode evidence gathering (code reads + DB queries, no assumptions):

**1. `credit-spread-scanner.ts` — ghost record race condition**
When `placeVerticalSpreadOrder` placed a buy-to-close order, IB fills could arrive before `recordTradeClose` wrote `ib_close_order_id` to the DB (~100ms window). The trigger found no match and created a ghost record. Fix: immediately stamp `ib_close_order_id` on the paper_trade right after getting the order ID, before calling `recordTradeClose`.

**2. `reconcile-executions.ts` — premature closure from partial fills**
`reconcileGhostCloses` closed a real paper_trade when it found a ghost for the same ticker+mode, without checking if IB still held shares. A partial sell creating a ghost caused the full position to be marked CLOSED (NEM bug, Jun 10). Fix: call `requestPositions()` before closing — if IB still holds the position, skip with a warning log.

## DB repair (not in code)
- NBIS `6ab19f67`: reopened from CLOSED → FILLED. Was spuriously closed with `close_reason='manual'` and `pnl=0`. Source traced: scheduler's SUBMITTED fill-detection code computed `pnl = (fill_price - fill_price) × qty = 0` after the trigger had already set `fill_price=9.80` on the entry record (IB's inverted leg reporting for BAG SELL fills). This is a separate investigation item.

## Test plan
- [ ] Credit spread close tomorrow: verify no ghost records created for the close fills
- [ ] Verify `reconcileGhostCloses` skips NBIS/RKLB positions (IB still holds them)
- [ ] Check auto-trader logs after restart for any new spurious closes

Made with [Cursor](https://cursor.com)