### PR TITLE
fix(options-scalp): fix ORB scanner silently placing 0 trades

### DIFF
--- a/auto-trader/src/lib/options-scalp.ts
+++ b/auto-trader/src/lib/options-scalp.ts
@@ -38,7 +38,7 @@ const LAST_ENTRY_MIN_ET  = 0;
 const ORB_END_HOUR_ET    = 9;            // ORB forms during 9:30–9:45; no entries before 9:45
 const ORB_END_MIN_ET     = 45;
 const ORB_RETEST_BUFFER  = 0.15;        // price must be within $0.15 of ORB level to count as retest
-const ORB_SMA200_PERIOD  = 200;          // 200-period SMA on 5-min bars for direction filter
+const ORB_SMA50_PERIOD   = 50;           // 50-period SMA on 5-min bars ≈ 4h trend filter (fits in 1d range)
 
 // ── NTZ / ORB helpers ────────────────────────────────────
 
@@ -160,17 +160,17 @@ function detectOrbSetup(
 }
 
 /**
- * Compute 200-period SMA from 5-min bars.
+ * Compute 50-period SMA from 5-min bars (~4h trend filter).
  * Returns 'C' if price above SMA (calls), 'P' if below (puts), null if chopping around it.
  */
 function get5mSmaDirection(bars: IntradayBar[], currentPrice: number): 'C' | 'P' | null {
-  if (bars.length < ORB_SMA200_PERIOD) return null;
+  if (bars.length < ORB_SMA50_PERIOD) return null;
   const closes = bars.map(b => b.close);
-  const sum = closes.slice(-ORB_SMA200_PERIOD).reduce((a, b) => a + b, 0);
-  const sma200 = sum / ORB_SMA200_PERIOD;
-  const distPct = Math.abs(currentPrice - sma200) / sma200 * 100;
+  const sum = closes.slice(-ORB_SMA50_PERIOD).reduce((a, b) => a + b, 0);
+  const sma50 = sum / ORB_SMA50_PERIOD;
+  const distPct = Math.abs(currentPrice - sma50) / sma50 * 100;
   if (distPct < 0.3) return null; // within 0.3% = chopping, no edge
-  return currentPrice > sma200 ? 'C' : 'P';
+  return currentPrice > sma50 ? 'C' : 'P';
 }
 
 /**
@@ -282,15 +282,18 @@ export async function runOptionScalpScan(): Promise<void> {
     // ── Get quote + 5-min bars ───────────────────────────────────────────────
     const [q, bars5m] = await Promise.all([
       fetchQuote(ticker),
-      fetchIntradayBars(ticker, '5m', '2d'),  // 2d = enough history for 200 SMA (200 × 5min ≈ 2.5 sessions)
+      fetchIntradayBars(ticker, '5m', '1d'),  // 1d = ~78 bars; 50-period SMA needs at least 50 bars
     ]);
-    if (!q?.price || !bars5m?.length) continue;
+    if (!q?.price || !bars5m?.length) {
+      console.log(`[Options Scalp] ${ticker}: data unavailable (quote=${q?.price ?? 'null'}, bars=${bars5m?.length ?? 'null'})`);
+      continue;
+    }
     const price = q.price;
 
-    // ── 200 SMA direction filter ─────────────────────────────────────────────
+    // ── 50 SMA direction filter (~4h trend) ─────────────────────────────────
     const smaDirection = get5mSmaDirection(bars5m, price);
     if (smaDirection === null) {
-      console.log(`[Options Scalp] ${ticker}: price chopping around 200 SMA — no edge, skipping`);
+      console.log(`[Options Scalp] ${ticker}: price chopping around 50 SMA — no edge, skipping`);
       continue;
     }
 

--- a/docs/cursor/discrepancy-fixes-log.md
+++ b/docs/cursor/discrepancy-fixes-log.md
@@ -30,6 +30,7 @@ Before making any fix:
 | Jun 10 | NBIS `6ab19f67` spuriously closed with `close_reason=manual`, `pnl=0` | **Root cause still unresolved.** Attribution: scheduler SUBMITTED detection path suspected, but CREDIT_SPREAD is `continue`d before that block. Reopened manually. | DB patch: reopened `6ab19f67` | none | Needs investigation — if root cause not found, will recur |
 | Jun 10 | Credit spread P&L wrong in Today's Activity (estimated Greeks, not actual fills) | `manageCreditSpreadPositions` called `recordTradeClose` immediately after placing close order with estimated P&L. Trigger couldn't correct it — combo fills have `realized_pnl=null`, trigger section 4 requires `realized_pnl IS NOT NULL` | `credit-spread-scanner.ts`, new trigger section (4b) | #436 | None known |
 | Jun 11 | ADBE/NEM loss cut child records showing "BUY" signal instead of "SELL" | PR #434 child record insert used `signal: trade.signal` — inherited `'BUY'` from original LONG_TERM position. Loss cut is a sell action, should be `'SELL'` | `scheduler.ts` line 7301 | #437 | None |
+| Jun 11 | OPTIONS_SCALP ORB scanner placed 0 trades silently for 2+ days | `fetchIntradayBars(ticker, '5m', '2d')` returns `null` from Yahoo Finance — `range=2d` unsupported. All 20 HIGH_VOL tickers silently skipped at `!bars5m?.length` (no log). Also `ORB_SMA200_PERIOD=200` unreachable — max ~78 bars/day. | `options-scalp.ts`: `'2d'`→`'1d'`, period 200→50, added data-unavailable log | #438 | SMA50 on 5-min = ~4h trend filter; equivalent direction signal |
 
 ---
 


### PR DESCRIPTION
## Summary
- `fetchIntradayBars(ticker, '5m', '2d')` returns `null` from Yahoo Finance — `range=2d` is not reliably supported for 5m interval. All 20 HIGH_VOL tickers silently skipped at `!bars5m?.length` with no log message (scanner appeared to run but placed 0 trades)
- `ORB_SMA200_PERIOD=200` was impossible to reach — `'1d'` range only yields ~78 bars, so `get5mSmaDirection()` would always return `null` even if bars were fetched
- Root cause found via log analysis: between `Scanning 20 HIGH_VOL tickers` and `Scan done — placed 0 trade(s)` there were zero per-ticker log lines

## Changes
- `'2d'` → `'1d'` for bars fetch (matches `fetchOrb`/`fetchNtz` which use `'1d'` and work correctly)
- `ORB_SMA200_PERIOD=200` → `ORB_SMA50_PERIOD=50` (50 × 5min ≈ 4h intraday trend filter, fits in 1d)
- Added explicit log when quote or bars are unavailable: `[Options Scalp] TSLA: data unavailable (quote=..., bars=...)`

## Test plan
- [ ] Tomorrow 9:45–11 AM ET: confirm `[Options Scalp] TSLA: data unavailable` no longer appears
- [ ] Confirm per-ticker skip reasons appear (ORB not yet formed, NTZ, SMA direction, etc.)
- [ ] Confirm the scanner places trades when valid ORB retest setups occur

Made with [Cursor](https://cursor.com)