### PR TITLE
fix: exclude ib_reconciliation_cover from TRADED badge on Trade Signals

### DIFF
--- a/app/src/components/TradeIdeas.tsx
+++ b/app/src/components/TradeIdeas.tsx
@@ -152,6 +152,8 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
   //   2. CANCELLED/REJECTED/EXPIRED excluded — phantom orders don't light up the badge
   //   3. Influencer/external trades excluded (strategy_video_id or strategy_source set) —
   //      influencer trades are independent and must NEVER affect auto-trader signal status
+  //   4. ib_reconciliation_cover excluded — these are orphaned-short cover buys by the
+  //      reconciler, not real signal executions; showing TRADED for them is misleading
   useEffect(() => {
     const todayET = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
     Promise.all([getActiveTrades(), getAllTrades(50)])
@@ -165,7 +167,8 @@ export function TradeIdeas({ onSelectTicker }: TradeIdeasProps) {
             (t.opened_at ?? '').startsWith(todayET) &&
             nonTerminal.has(t.status ?? '') &&
             !t.strategy_video_id &&   // influencer trades are independent — never affect trade signals
-            !t.strategy_source        // influencer trades are independent — never affect trade signals
+            !t.strategy_source &&     // influencer trades are independent — never affect trade signals
+            t.close_reason !== 'ib_reconciliation_cover'  // reconciler covers are not signal executions
           )
           .forEach(t => {
             tickers.add(`${t.ticker.toUpperCase()}_${(t.signal ?? '').toUpperCase()}`);

--- a/shared/trade-types.ts
+++ b/shared/trade-types.ts
@@ -55,7 +55,8 @@ export type CloseReason =
   | 'stopped'
   | 'expired_worthless'
   | 'expired_itm'
-  | 'ib_fill_auto_created';
+  | 'ib_fill_auto_created'
+  | 'ib_reconciliation_cover';
 
 /**
  * Full paper_trades row — superset of all columns used by any consumer.


### PR DESCRIPTION
## Summary

- Orphaned-short cover buys (`close_reason=ib_reconciliation_cover`) placed by the reconciler were incorrectly lighting up the **TRADED** badge on the matching trade signal
- Example: ASTS BUY signal showed TRADED today because the reconciler covered an accidental short from yesterday's duplicate sell — not because the signal was actually executed
- Fix: adds `t.close_reason !== 'ib_reconciliation_cover'` to the `tradedTickers` filter in `TradeIdeas.tsx`
- Also adds `'ib_reconciliation_cover'` to the `CloseReason` union in `shared/trade-types.ts` (was missing, causing TS2367 build error)

## Pattern consistency
Same `ib_reconciliation_cover` exclusion already exists in:
- `paperTradesApi.ts` (Today's Activity P&L query)
- `StreakBoard.tsx` (win/loss streak calc)
- `optionsApi.ts` (scalp trade history)

This PR makes Trade Signals consistent with those.

## Test plan
- [ ] Verify ASTS (or any reconciliation cover) no longer shows TRADED badge on Trade Signals
- [ ] Verify real day trade executions still show TRADED correctly

Made with [Cursor](https://cursor.com)