### PR TITLE
fix: stop long-term holdings from permanently blocking day/swing entries

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -3597,12 +3597,12 @@ function assessDrawdownMultiplier(positions: EnrichedPosition[]): {
   level: string;
   pnlPct: number;
 } {
-  // Only evaluate positions we are actively tracking (have an active paper_trade).
-  // Orphaned IB positions — stale portfolio holdings, failed-close leftovers, OTC
-  // shorts we can't cover — must not skew the drawdown and block new entries.
-  const tracked = _trackedIbTickers.size > 0
-    ? positions.filter(p => _trackedIbTickers.has(p.symbol.toUpperCase()))
-    : positions;
+  // Only evaluate short-term positions (DAY_TRADE, SWING_TRADE) we are actively tracking.
+  // Long-term holds being underwater must not block new intraday/swing entries —
+  // they are a different portfolio bucket with a different time horizon.
+  // When no short-term positions are active, there is no intraday risk to protect against.
+  if (_trackedIbTickers.size === 0) return { multiplier: 1.0, level: 'normal', pnlPct: 0 };
+  const tracked = positions.filter(p => _trackedIbTickers.has(p.symbol.toUpperCase()));
 
   if (tracked.length === 0) return { multiplier: 1.0, level: 'normal', pnlPct: 0 };
 


### PR DESCRIPTION
## Summary
- `assessDrawdownMultiplier` fell back to ALL IB positions when `_trackedIbTickers` was empty (no active DAY_TRADE/SWING_TRADE positions)
- Underwater long-term holds (AOS -25%, ALLY -12%, etc.) were pegging the intraday drawdown at -28.6%, triggering the critical gate (multiplier=0) on every cycle
- Every day trade and swing trade was silently blocked — MSFT, META, IWM, and others all hit the gate without a visible error to the user
- Fix: when `_trackedIbTickers.size === 0`, return `normal` immediately — long-term P&L is a different portfolio bucket and should never gate intraday entries

## Test plan
- [ ] Day trades and swing trades fire normally when no short-term positions are active
- [ ] Drawdown still blocks when active DAY_TRADE/SWING_TRADE positions are down > 5%

Made with [Cursor](https://cursor.com)