### PR TITLE
fix: restore 0DTE same-day expiry for scalps

### DIFF
--- a/auto-trader/src/lib/options-scalp.ts
+++ b/auto-trader/src/lib/options-scalp.ts
@@ -240,7 +240,15 @@ function getNearestFridayExpiry(): string {
 }
 
 function getTodayExpiry(): string {
-  return getNearestFridayExpiry();
+  // Always use TODAY's date for true 0DTE. Tickers without a same-day chain
+  // (most individual stocks on Mon–Thu) will get IB code-200 and be skipped.
+  // ETFs (SPY, QQQ, IWM) and mega-caps have daily chains every session.
+  // NEVER fall back to next Friday — that produces multi-day options, not scalps.
+  const nowET = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
+  const y  = nowET.getFullYear();
+  const mo = String(nowET.getMonth() + 1).padStart(2, '0');
+  const d  = String(nowET.getDate()).padStart(2, '0');
+  return `${y}${mo}${d}`;
 }
 
 // ── Scan ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- PR #463 broke the core scalp premise by switching to next-Friday expiry on all days
- Mon–Thu scalps were buying 1–4 DTE options (PLTR, HOOD, GOOGL bought Jun 26 chains on Wednesday Jun 24)
- These carry overnight risk, have expensive premium, and require a much larger move to profit
- Fix: restore `getTodayExpiry()` to return today's actual date — tickers without 0DTE chains get code-200 from IB and are skipped gracefully; ETFs (SPY, QQQ, IWM) have daily chains every day

## Test plan
- [ ] On a non-Friday, verify scalp orders only fire on tickers with same-day chains (SPY, QQQ, IWM, large caps)
- [ ] Verify individual stocks (PLTR, HOOD, CRDO) are skipped Mon–Thu with code-200 (not substituted with weekly)

Made with [Cursor](https://cursor.com)