### PR TITLE
fix(options-scalp): ETF-only VWAP universe on Mon–Thu to stop ib_error flood

### DIFF
--- a/auto-trader/src/lib/options-scalp.ts
+++ b/auto-trader/src/lib/options-scalp.ts
@@ -439,6 +439,12 @@ const VWAP_RETEST_UNIVERSE = [
   'MSTR', 'SOFI', 'SOXL', 'TQQQ',
 ];
 
+// ETF-only subset for Mon–Thu: these have daily (Mon–Fri) options chains in IB.
+// Individual stocks and even mega-caps only have weekly Friday expirations — they
+// generate ib_error (code-200) on every 0DTE attempt Mon–Thu, flooding the DB
+// with useless CANCELLED records. On Friday all tickers are valid (weekly = 0DTE).
+const VWAP_ETF_ONLY_UNIVERSE = ['QQQ', 'SPY', 'IWM', 'SMH', 'SOXL', 'TQQQ'];
+
 /**
  * VWAP retest scalp scanner — runs every 15 min 10 AM–3 PM ET.
  * Detects VWAP reclaim/breakdown + retest pattern and buys ATM call/put.
@@ -483,9 +489,14 @@ export async function runVwapRetestScalpScan(): Promise<void> {
   const slotsLeft = MAX_SCALP_TRADES_PER_DAY - usedToday;
   let placed = 0;
 
-  console.log(`[VWAP Scalp] Scanning ${VWAP_RETEST_UNIVERSE.length} tickers | expiry ${expiry} | slots ${slotsLeft}`);
+  // Mon–Thu: restrict to ETFs that have daily options chains in IB.
+  // On Fridays, weekly expiry = 0DTE for all tickers, so the full universe runs.
+  const isFriday = nowET.getDay() === 5;
+  const universe = isFriday ? VWAP_RETEST_UNIVERSE : VWAP_ETF_ONLY_UNIVERSE;
 
-  for (const ticker of VWAP_RETEST_UNIVERSE) {
+  console.log(`[VWAP Scalp] Scanning ${universe.length} tickers (${isFriday ? 'full universe' : 'ETF-only — Mon–Thu'}) | expiry ${expiry} | slots ${slotsLeft}`);
+
+  for (const ticker of universe) {
     if (placed >= slotsLeft) break;
 
     // Skip if already in an open scalp for this ticker today

--- a/docs/cursor/discrepancy-fixes-log.md
+++ b/docs/cursor/discrepancy-fixes-log.md
@@ -68,6 +68,8 @@ Before making any fix:
 
 | Jun 24 | OPTIONS_SCALP buying 2-day (next-Friday) options instead of 0DTE on a Wednesday | PR #463 changed `getTodayExpiry()` to always return `getNearestFridayExpiry()`. Mon–Thu scalps bought 1–4 DTE options (PLTR, HOOD, GOOGL bought Jun 26 chains on Jun 24). Multi-day options carry overnight risk, have expensive premium, need a larger move to double — violates Kay Capitals 0DTE strategy entirely. | `auto-trader/src/lib/options-scalp.ts`: restored `getTodayExpiry()` to return today's actual date. Tickers without a same-day chain get IB code-200 and are skipped. | #472 | **Do NOT revert to `getNearestFridayExpiry()`** — that's the regression. ETFs (SPY, QQQ, IWM) have daily chains every day. Individual stocks on Mon–Thu will be skipped via code-200 — that is correct behavior. |
 
+| Jun 25 | VWAP scanner flooding DB with ib_error CANCELLED records on Mon–Thu (11 today alone) | `VWAP_RETEST_UNIVERSE` includes individual stocks and mega-caps that only have Friday weekly chains. On Mon–Thu, every 0DTE order for these tickers hits IB code-200 → CANCELLED with `ib_error`. These don't consume cap slots, but create DB noise and log spam every 15 min. | `auto-trader/src/lib/options-scalp.ts`: added `VWAP_ETF_ONLY_UNIVERSE = ['QQQ','SPY','IWM','SMH','SOXL','TQQQ']`. `runVwapRetestScalpScan()` uses ETF-only on Mon–Thu, full universe on Fridays. | (pending PR) | On Fridays, full universe (22 tickers) still runs — individual stocks have weekly = 0DTE on Fridays. ETF-only Mon–Thu means fewer signals but zero wasted ib_error records. |
+
 ---
 
 ## Recurring Patterns — Red Flags


### PR DESCRIPTION
## Summary
- On Mon–Thu, the VWAP retest scanner was trying 0DTE orders on individual stocks and mega-caps that only have Friday weekly chains in IB, generating `ib_error` CANCELLED records for every attempt (11 today alone)
- Added `VWAP_ETF_ONLY_UNIVERSE = ['QQQ','SPY','IWM','SMH','SOXL','TQQQ']` — tickers confirmed to have daily options chains
- `runVwapRetestScalpScan()` now uses ETF-only Mon–Thu, full 22-ticker universe on Fridays (where weekly = 0DTE for all tickers)
- Keeps `getTodayExpiry()` (true 0DTE) — **do not revert to `getNearestFridayExpiry()`**

## Test plan
- [ ] Mon–Thu: VWAP scan log shows `ETF-only — Mon–Thu` label, only 6 tickers scanned, zero `ib_error` CANCELLED records
- [ ] Friday: VWAP scan log shows `full universe`, 22 tickers scanned, individual stocks get 0DTE (weekly expiry = today)

Made with [Cursor](https://cursor.com)