### PR TITLE
feat(scalp): add NVDL and TSLL to Mon–Thu ETF-only universe

### DIFF
--- a/auto-trader/src/lib/options-scalp.ts
+++ b/auto-trader/src/lib/options-scalp.ts
@@ -450,13 +450,16 @@ const VWAP_RETEST_UNIVERSE = [
   'AMD', 'PLTR', 'CRDO', 'HOOD', 'COIN', 'RKLB', 'APP', 'ALAB',
   // Momentum names often in play
   'MSTR', 'SOFI', 'SOXL', 'TQQQ',
+  // Leveraged single-asset ETFs — daily chains, high vol
+  'NVDL', 'TSLL',
 ];
 
 // ETF-only subset for Mon–Thu: these have daily (Mon–Fri) options chains in IB.
 // Individual stocks and even mega-caps only have weekly Friday expirations — they
 // generate ib_error (code-200) on every 0DTE attempt Mon–Thu, flooding the DB
 // with useless CANCELLED records. On Friday all tickers are valid (weekly = 0DTE).
-const VWAP_ETF_ONLY_UNIVERSE = ['QQQ', 'SPY', 'IWM', 'SMH', 'SOXL', 'TQQQ'];
+// NVDL/TSLL included: leveraged single-asset ETFs with daily chains like SOXL/TQQQ.
+const VWAP_ETF_ONLY_UNIVERSE = ['QQQ', 'SPY', 'IWM', 'SMH', 'SOXL', 'TQQQ', 'NVDL', 'TSLL'];
 
 /**
  * VWAP retest scalp scanner — runs every 15 min 10 AM–3 PM ET.


### PR DESCRIPTION
## Summary
- NVDL (2x NVDA) and TSLL (2x TSLA) have daily option chains like SOXL/TQQQ, but were missing from the ETF-only Mon–Thu list
- NVDL had a profitable `auto_exercised` +\$4 close on Jun 4 — excluded by the ETF-only filter in PR #477
- Both added to `VWAP_ETF_ONLY_UNIVERSE` (eligible Mon–Thu for ORB + VWAP) and `VWAP_RETEST_UNIVERSE` (eligible Fri VWAP full scan)

## Mon–Thu ETF-only universe is now
`SPY / QQQ / IWM / SMH / SOXL / TQQQ / NVDL / TSLL`

Made with [Cursor](https://cursor.com)