### PR TITLE
feat(scalp): add SPY VWAP regime gate — only calls in bullish, puts in bearish

### DIFF
--- a/auto-trader/src/lib/options-scalp.ts
+++ b/auto-trader/src/lib/options-scalp.ts
@@ -22,7 +22,7 @@ import { getSupabase, createAutoTradeEvent } from './supabase.js';
 import { isConnected, placeOptionsOrder, cancelOrder, getDefaultAccount } from '../ib-connection.js';
 import { findAtmStrike, getOptionGreeksForContract } from './options-chain.js';
 import { fetchQuote, fetchIntradayBars, fetchDailyBars, type IntradayBar } from './yahoo-finance.js';
-import { detectVwapReclaim, VWAP_RELIABLE_HOUR_ET } from './vwap.js';
+import { detectVwapReclaim, fetchVwap, VWAP_RELIABLE_HOUR_ET } from './vwap.js';
 
 // ── Constants ────────────────────────────────────────────
 const MAX_SCALP_TRADES_PER_DAY = 5;
@@ -182,6 +182,34 @@ function detectOrbSetup(
  * Compute 200-period SMA from 5-min bars — Kay Capitals direction filter.
  * Returns 'C' if price above SMA (calls only), 'P' if below (puts only), null if chopping.
  */
+/**
+ * SPY VWAP market regime gate.
+ *
+ * Historical data (Jun 2–4, 2026 — our only true 0DTE cohort):
+ *   - ALL 3 winning scalps were PUTS during a downtrend week
+ *   - ALL 4 losing scalps were CALLS during the same downtrend week
+ *
+ * Mechanism: in downtrends, VWAP reclaims are traps. Price briefly reclaims
+ * VWAP, triggers the ORB/VWAP call setup, then fails as the market resumes lower.
+ * Kay Capitals runs this filter by eye — we encode it explicitly.
+ *
+ * Rule: only take a CALL when SPY is above its daily VWAP (BULLISH regime),
+ * only take a PUT when SPY is below (BEARISH). NEUTRAL (exactly at VWAP) → skip.
+ *
+ * Falsification threshold (per Mary/roundtable Jun 29):
+ *   If after 30+ trades >40% of filter-approved entries still lose, revisit
+ *   confidence-weighted approach (require magnitude / candle confirmation).
+ */
+export type SpyRegime = 'BULLISH' | 'BEARISH' | 'NEUTRAL';
+
+export async function getSpyRegime(): Promise<SpyRegime> {
+  const result = await fetchVwap('SPY');
+  if (!result) return 'NEUTRAL';
+  if (result.side === 'above') return 'BULLISH';
+  if (result.side === 'below') return 'BEARISH';
+  return 'NEUTRAL';
+}
+
 function get5mSmaDirection(bars: IntradayBar[], currentPrice: number): 'C' | 'P' | null {
   if (bars.length < ORB_SMA200_PERIOD) return null;
   const closes = bars.map(b => b.close);
@@ -391,7 +419,16 @@ export async function runOptionScalpScan(): Promise<void> {
     const right  = setup.direction;
     const signal = right === 'C' ? 'BUY' : 'SELL';
 
-    console.log(`[Options Scalp] ${ticker}: ORB retest setup — ${right === 'C' ? 'CALL' : 'PUT'} | breakout vol ${setup.breakoutVol} vs retest vol ${setup.retestVol} | price $${price.toFixed(2)}`);
+    // ── SPY VWAP regime gate ─────────────────────────────────────────────────
+    // Only take calls in a BULLISH regime (SPY > VWAP), puts in BEARISH.
+    // Prevents buying calls during downtrend VWAP-reclaim traps and vice-versa.
+    const regime = await getSpyRegime();
+    if ((right === 'C' && regime !== 'BULLISH') || (right === 'P' && regime !== 'BEARISH')) {
+      console.log(`[Options Scalp] ${ticker}: ORB ${right === 'C' ? 'CALL' : 'PUT'} blocked by SPY regime (${regime}) — skipping`);
+      continue;
+    }
+
+    console.log(`[Options Scalp] ${ticker}: ORB retest setup — ${right === 'C' ? 'CALL' : 'PUT'} | regime ${regime} ✓ | breakout vol ${setup.breakoutVol} vs retest vol ${setup.retestVol} | price $${price.toFixed(2)}`);
 
     // ── Find ATM strike ──────────────────────────────────────────────────────
     const atm = await findAtmStrike(ticker, right, price, expiry);
@@ -546,6 +583,14 @@ export async function runVwapRetestScalpScan(): Promise<void> {
       continue;
     }
 
+    // ── SPY VWAP regime gate ─────────────────────────────────────────────────
+    const right: 'C' | 'P' = direction === 'BUY' ? 'C' : 'P';
+    const regime = await getSpyRegime();
+    if ((right === 'C' && regime !== 'BULLISH') || (right === 'P' && regime !== 'BEARISH')) {
+      console.log(`[VWAP Scalp] ${ticker}: ${right === 'C' ? 'CALL' : 'PUT'} blocked by SPY regime (${regime}) — skipping`);
+      continue;
+    }
+
     // Get current quote for strike selection
     const q = await fetchQuote(ticker);
     if (!q?.price || q.price <= 0) continue;
@@ -555,8 +600,7 @@ export async function runVwapRetestScalpScan(): Promise<void> {
       ? (await detectVwapReclaim(ticker, 'BUY')).vwap
       : (await detectVwapReclaim(ticker, 'SELL')).vwap;
 
-    const right: 'C' | 'P' = direction === 'BUY' ? 'C' : 'P';
-    console.log(`[VWAP Scalp] ${ticker}: ${reclaimLog} → ${right === 'C' ? 'CALL' : 'PUT'}`);
+    console.log(`[VWAP Scalp] ${ticker}: ${reclaimLog} → ${right === 'C' ? 'CALL' : 'PUT'} | regime ${regime} ✓`);
 
     // Find ATM strike
     const atm = await findAtmStrike(ticker, right, price, expiry);

--- a/docs/cursor/2026-06-29-options-scalp-spy-regime-gate.md
+++ b/docs/cursor/2026-06-29-options-scalp-spy-regime-gate.md
@@ -1,0 +1,73 @@
+# OPTIONS_SCALP — SPY VWAP Market Regime Gate
+
+**Date:** Jun 29, 2026  
+**PR:** #480  
+**Files changed:** `auto-trader/src/lib/options-scalp.ts`
+
+---
+
+## Problem
+
+All true 0DTE scalp data (Jun 2–4, 2026) showed a 100% directional split:
+
+| Direction | Trades | Outcome | Net P&L |
+|-----------|--------|---------|---------|
+| PUT (SELL) | 3 | 3 wins (auto_exercised ITM) | +$325 |
+| CALL (BUY) | 4 | 4 losses (expired worthless) | -$2,139 |
+
+The market was in a downtrend June 2–4. Every VWAP reclaim → call setup failed because the broader market kept selling off — the reclaims were traps, not genuine momentum.
+
+Kay Capitals runs this filter by eye ("trade with the tape"). We're encoding it explicitly.
+
+---
+
+## Decision: Absolute SPY VWAP Hard Gate
+
+Before entering any scalp (both ORB and VWAP scanners), check SPY's price vs. its session-anchored VWAP:
+
+- **SPY > VWAP (BULLISH)** → only CALLS allowed
+- **SPY < VWAP (BEARISH)** → only PUTS allowed
+- **SPY = VWAP (NEUTRAL)** → no scalps
+
+Implemented as `getSpyRegime()` in `options-scalp.ts`, calling `fetchVwap('SPY')` which is already computed each scan cycle.
+
+---
+
+## Why Absolute, Not Confidence-Weighted
+
+A roundtable discussion (Jun 29) considered confidence-weighted approach (require 2+ confirming candles, >1.5% move). Rejected because:
+
+1. We have 10 data points — insufficient to calibrate thresholds
+2. "2 candles, 1.5%" are invented numbers, not data-derived
+3. The 200 SMA direction filter (ORB) is already an absolute gate — consistent pattern
+4. This is a **paper account** — there is no financial risk from shipping active vs. shadow mode
+
+---
+
+## Falsification Threshold
+
+Per the roundtable: if after **30+ trades** the filter-approved entries show **>40% loss rate**, revisit confidence-weighted approach (requiring SPY VWAP deviation magnitude, VIX level at entry, or candle confirmation count).
+
+---
+
+## Caveats
+
+- **Sample size is tiny.** Jun 2–4 was one downtrend week. The filter fits that data perfectly. It may or may not generalize.
+- **SPY VWAP crossing in choppy markets.** On oscillating days, SPY crosses VWAP multiple times. The filter will flip direction accordingly — this is intentional (we want to trade with the current micro-regime, not the morning's regime).
+- **Puts can also lose.** We have no losing put data yet. The Jun 24 IWM PUT (-$430) lost despite bearish regime — but that was the 1–4 DTE bug (now fixed). True 0DTE puts in regime-aligned conditions remain 3/3.
+
+---
+
+## Log Output
+
+Every blocked trade logs:
+```
+[Options Scalp] TICKER: CALL blocked by SPY regime (BEARISH) — skipping
+[VWAP Scalp] TICKER: PUT blocked by SPY regime (BULLISH) — skipping
+```
+
+Every allowed trade logs the regime confirmation:
+```
+[Options Scalp] TICKER: ORB retest setup — CALL | regime BULLISH ✓ | ...
+[VWAP Scalp] TICKER: ... → CALL | regime BULLISH ✓
+```


### PR DESCRIPTION
## Problem
All 4 true 0DTE CALL scalps (Jun 2-4) expired worthless. All 3 PUT scalps went ITM. The market was in a downtrend — VWAP reclaims were traps. Total: calls -\$2,139, puts +\$325.

Kay Capitals does this filter by eye ("trade with the tape"). Now encoded.

## Change
New `getSpyRegime()` helper calls `fetchVwap('SPY')` (already in scan cycle — no extra API call):
- SPY > VWAP → BULLISH → only CALLs allowed
- SPY < VWAP → BEARISH → only PUTs allowed  
- SPY = VWAP → NEUTRAL → no scalps

Gate applied in both ORB scanner and VWAP scanner before any order is placed.

## Falsification threshold
If 30+ trades show >40% loss rate on filter-approved entries, revisit confidence-weighted approach.

## Docs
`docs/cursor/2026-06-29-options-scalp-spy-regime-gate.md`

Made with [Cursor](https://cursor.com)