### PR TITLE
Extend scalp/day-trade entry window to 1:30 PM, add NVDA, remove lunch block

### DIFF
--- a/auto-trader/src/lib/options-scalp.ts
+++ b/auto-trader/src/lib/options-scalp.ts
@@ -32,8 +32,8 @@ const PARTIAL_TARGET_MULT = 1.5;         // sell 1st contract when premium up 50
 const PROFIT_TARGET_MULT = 2.0;          // close all remaining when premium doubles
 const STOP_LOSS_MULT = 0.50;             // close all when premium halves (only before first partial)
 const MAX_SPREAD_MARKET_ORDER_PCT = 3;   // use market order only if spread < 3% of mid
-const LAST_ENTRY_HOUR_ET = 11;           // no new scalp entries after 11:00 AM ET (90-minute rule)
-const LAST_ENTRY_MIN_ET  = 0;
+const LAST_ENTRY_HOUR_ET = 13;           // no new scalp entries after 1:30 PM ET
+const LAST_ENTRY_MIN_ET  = 30;
 const ORB_END_HOUR_ET    = 9;            // ORB forms during 9:30–9:45; no entries before 9:45
 const ORB_END_MIN_ET     = 45;
 const ORB_RETEST_BUFFER_PCT = 0.0015;   // retest buffer = 0.15% of ORB level (relative, not absolute)
@@ -298,9 +298,9 @@ export async function runOptionScalpScan(): Promise<void> {
     return;
   }
 
-  // 90-minute rule: no new entries after 11:00 AM ET
+  // 90-minute rule removed — entries allowed 9:45 AM–1:30 PM ET
   if (etHour > LAST_ENTRY_HOUR_ET || (etHour === LAST_ENTRY_HOUR_ET && etMin >= LAST_ENTRY_MIN_ET)) {
-    console.log('[Options Scalp] Past 11:00 AM ET — no new entries (90-min rule)');
+    console.log('[Options Scalp] Past 1:30 PM ET — no new entries');
     return;
   }
 
@@ -506,20 +506,20 @@ const VWAP_ETF_ONLY_UNIVERSE = ['QQQ', 'SPY', 'IWM', 'SMH', 'SOXL', 'TQQQ', 'NVD
 // Do NOT expand this list aggressively. Previous $2k loss (Jun 29) came from running
 // APP, MSFT, GOOGL etc. with multi-day expiry + a broken management cycle.
 // The management cycle is now fixed (#475) but keep this list tight.
-const VWAP_STOCK_WEEKLY_UNIVERSE = ['AMD', 'PLTR'];
+const VWAP_STOCK_WEEKLY_UNIVERSE = ['AMD', 'PLTR', 'NVDA'];
 
 /**
  * VWAP retest scalp scanner — runs every 15 min 10 AM–3 PM ET.
  * Detects VWAP reclaim/breakdown + retest pattern and buys ATM call/put.
  */
 export async function runVwapRetestScalpScan(): Promise<void> {
-  // Only reliable after 10 AM ET; no new entries after 11:30 AM ET (90-minute rule)
+  // Only reliable after 10 AM ET; no new entries after 1:30 PM ET
   const nowET = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
   const etHour = nowET.getHours();
   const etMin  = nowET.getMinutes();
   if (etHour < VWAP_RELIABLE_HOUR_ET) return;
   if (etHour > LAST_ENTRY_HOUR_ET || (etHour === LAST_ENTRY_HOUR_ET && etMin >= LAST_ENTRY_MIN_ET)) {
-    console.log('[VWAP Scalp] Past 11:00 AM ET — no new entries (90-min rule)');
+    console.log('[VWAP Scalp] Past 1:30 PM ET — no new entries');
     return;
   }
 

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -594,11 +594,11 @@ export function startScheduler(): void {
   }, { timezone: 'America/New_York' });
   log('Credit spread management: every 30 min, Mon-Fri 10-4 PM ET');
 
-  // Options Scalp scan — every 5 min from 9:45 AM to 11:00 AM ET.
+  // Options Scalp scan — every 5 min from 9:45 AM to 1:30 PM ET.
   // Runs frequently to catch ORB retest windows (retests last only 5-10 min).
-  // Internal guards in runOptionScalpScan() enforce the 9:45–11:00 window and
+  // Internal guards in runOptionScalpScan() enforce the 9:45–1:30 PM window and
   // skip the scan when ORB hasn't formed yet or daily cap is reached.
-  cron.schedule('*/5 9-10 * * 1-5', async () => {
+  cron.schedule('*/5 9-13 * * 1-5', async () => {
     try {
       const { runOptionScalpScan } = await import('./lib/options-scalp.js');
       await runOptionScalpScan();
@@ -606,7 +606,7 @@ export function startScheduler(): void {
       console.error('[Scheduler] Options scalp scan error:', err instanceof Error ? err.message : err);
     }
   }, { timezone: 'America/New_York' });
-  log('Options scalp scan: every 5 min, 9:45–11:00 AM ET, Mon-Fri');
+  log('Options scalp scan: every 5 min, 9:45–1:30 PM ET, Mon-Fri');
 
   // Options Scalp position management + VWAP retest scan — every 15 min during market hours.
   // Management: checks profit target (100%) and stop loss (50%).
@@ -3997,20 +3997,6 @@ async function executeScannerTrade(
   // Gate expires after 12 PM ET — the opening range is stale by afternoon.
   // Skip for vwap_confluence — the strategy IS a chop-exit play.
   const etMinutes = getETMinutes();
-
-  // ── Lunch-hour exclusion gate ─────────────────────────────────────────
-  // Block new day-trade entries from 12:00–13:00 ET. This is the "death
-  // zone": institutional desks step away, volume craters, moves are random
-  // and often mean-reverting. Even technically valid setups fail at elevated
-  // rates during this window. Existing positions continue to be managed
-  // normally — this only gates new entries.
-  if (mode === 'DAY_TRADE' && etMinutes >= 12 * 60 && etMinutes < 13 * 60) {
-    log(`${ticker}: skipped — lunch-hour exclusion (12:00–13:00 ET, low-quality entry window)`);
-    persistEvent(ticker, 'skipped', 'Lunch-hour exclusion: no new day-trade entries 12:00–13:00 ET', {
-      action: 'skipped', source: 'scanner', mode, skip_reason: 'lunch_hour',
-    });
-    return 'skipped:lunch_hour';
-  }
 
   const skipOrbGate = idea.tags?.includes('vwap_confluence');
   if (mode === 'DAY_TRADE' && etMinutes < 12 * 60 && !skipOrbGate) {


### PR DESCRIPTION
## Summary
- **Entry window**: Options scalp and VWAP scan extended from 11 AM → 1:30 PM (Kay Capitals trades all session)
- **ORB cron**: Updated from `9-10` to `9-13` to match new window
- **NVDA**: Added to `VWAP_STOCK_WEEKLY_UNIVERSE` — strong AVWAP performer in Kay's $63k day
- **Lunch block removed**: DAY_TRADE 12:00–13:00 exclusion removed (was cutting 1.5h of trading window)
- Runner/partial-exit logic was already implemented — no change needed

## Inspired by
Kay Capitals $63k day (Jul 1): SPY/QQQ AVWAP from open, IWM 300 breakout, PLTR 125 LTP, NVDA AVWAP, SPX 7500 basketball reject — all within 9:30–11:30 AM, demonstrating value of full-session scanning.

## Test plan
- [ ] After 11 AM: scanner still fires every 5 min (was previously blocked)
- [ ] NVDA appears in Mon–Thu VWAP scan universe with `getNearestFridayExpiry()` expiry
- [ ] Day trade signals not blocked between 12:00–1:00 PM
- [ ] EOD 3:45 PM sweep closes any afternoon positions same day

Made with [Cursor](https://cursor.com)