### PR TITLE
docs: codify options scalp TIF vs universe gates

### DIFF
--- a/.cursor/rules/auto-trader-invariants.mdc
+++ b/.cursor/rules/auto-trader-invariants.mdc
@@ -34,6 +34,14 @@ If a change would violate any of these, STOP and ask the user before proceeding.
 - **External/influencer signals must not execute before 9:35 AM ET** either.
   Same rationale: spreads are widest at open, fills are worst. Apply the same gate.
 
+- **0DTE / same-day options orders must use DAY TIF; multi-day options keep GTC.**
+  Implemented in `placeOptionsOrder`. Do not hardcode GTC for same-day expiry.
+
+- **Never treat options TIF as a substitute for scalp universe / expiry eligibility.**
+  DAY vs GTC is execution hygiene. ETF-only Mon–Thu 0DTE vs intentional stock weeklies
+  is strategy eligibility. See `.cursor/rules/options-scalp-strategy.mdc` Gate A vs Gate B.
+  Collapsing them requires explicit user approval + a P&L argument — not a "cleanup."
+
 ## 3. Influencer Signal Attribution
 
 - **Always preserve influencer attribution.** `strategy_source`, `strategy_source_url`,

--- a/.cursor/rules/options-scalp-strategy.mdc
+++ b/.cursor/rules/options-scalp-strategy.mdc
@@ -41,8 +41,40 @@ Before changing any constant or logic in `options-scalp.ts`:
 - **Entry cutoff: 11:00 AM ET** — no new entries after that (90-minute rule)
 - **EOD close: 3:45 PM ET** — hard close, never hold options overnight
 
+## Two Orthogonal Gates (do not conflate)
+
+These solve different jobs. Changing one never retires the other.
+
+### Gate A — Execution hygiene (TIF)
+
+- **0DTE / same-day expiry orders → DAY**
+- **Multi-day options (weeklies, wheel, LEAPs) → GTC** (unless caller overrides)
+- Job answered: "How long does this resting order stay live?"
+- Implemented in `placeOptionsOrder` (`ib-connection.ts`). PR #486.
+
+**Anti-pattern:** "We use DAY now, so ETF vs stock universe rules can be the same."
+DAY only cancels unfilled orders at session end. It does not create a daily options chain,
+does not make multi-DTE into 0DTE, and does not prevent overnight position risk after a fill.
+
+### Gate B — Strategy eligibility (universe + expiry)
+
+- **Mon–Thu ORB:** ETF-only (`VWAP_ETF_ONLY_UNIVERSE`) + `getTodayExpiry()` (true 0DTE)
+- **Mon–Thu VWAP:** ETFs → 0DTE; intentional stock carve-outs (AMD/PLTR) → `getNearestFridayExpiry()` weeklies
+- **Friday:** full HIGH_VOL watchlist + 0DTE (weekly chains exist for stocks)
+- Job answered: "May we open this scalp on this underlier with this expiry today?"
+
+**Why Gate B exists (evidence, not preference):**
+1. Most individual stocks have **no Mon–Thu daily chain** → IB code-200
+2. Kay Capitals scalp is **0DTE** — next-Friday Mon–Thu = multi-DTE + overnight risk (PR #472: do NOT Friday-for-all)
+3. Jun 29 ORB burned ~$3.5k on APP/MSFT/GOOGL/PLTR/HOOD without the ETF filter
+4. AMD/PLTR weeklies Mon–Thu are an **intentional product exception**, not "same rules for everyone"
+
+**Anti-pattern:** Unifying ETF and non-ETF into one Mon–Thu ruleset "for simplicity."
+That is a strategy change requiring a P&L argument — not a cleanup from a TIF fix.
+
 ## Strategy source docs
 
 - `docs/cursor/2026-06-05-kaycapitals-scalp-exit-strategy.md` — Somesh's full framework + implementation status (Kay Capitals = Somesh's channel)
 - `docs/guides/somesh-strategies.md` — Somesh's other strategies (ORB, VWAP, SPX levels, confluence)
 - `docs/cursor/2026-05-28-options-three-strategies.md` — how scalp fits alongside wheel and LEAPs
+- `docs/cursor/2026-07-08-options-scalp-tif-vs-universe-gates.md` — ADR: Gate A vs Gate B

--- a/docs/cursor/2026-07-08-options-scalp-tif-vs-universe-gates.md
+++ b/docs/cursor/2026-07-08-options-scalp-tif-vs-universe-gates.md
@@ -1,0 +1,35 @@
+# ADR: Options Scalp — TIF vs Universe Gates
+
+**Date:** 2026-07-08  
+**Status:** Accepted  
+**Context:** After PR #486 (basketball EOD scope + DAY TIF for 0DTE), the question came up: if options orders are DAY, do we still need different ETF vs non-ETF scalp rules?
+
+## Decision
+
+Keep **two orthogonal product gates**. Do not collapse them.
+
+| Gate | Job | Knob |
+|------|-----|------|
+| **A — TIF** | How long does the resting order live? | DAY for same-day expiry; GTC for multi-day |
+| **B — Universe / expiry** | May we open this scalp on this underlier today? | ETF 0DTE Mon–Thu; stock weeklies only as intentional carve-outs; full watchlist Friday |
+
+## Why not unify
+
+1. **DAY does not create a contract.** Most stocks lack Mon–Thu daily chains → IB code-200.
+2. **DAY does not change filled-position risk.** Next-Friday fill still carries overnight / multi-DTE risk.
+3. **Jun 29 loss** (~$3.5k APP/MSFT/GOOGL/PLTR/HOOD) was universe selection, not TIF.
+4. **AMD/PLTR Mon–Thu weeklies** are a deliberate exception (Jul 1). One ruleset either kills that or silently re-expands the universe.
+
+Unifying "for simplicity" is a **strategy change**, not a cleanup. It needs a P&L argument and explicit user approval.
+
+## Alternatives considered
+
+- **Friday-for-all Mon–Thu** — rejected (PR #472). Violates Kay Capitals 0DTE.
+- **Scan everyone, skip on code-200** — rejected for ORB (Jun 29). Wastes IB calls and previously burned premium when wrong expiries filled.
+- **Same entry/exit logic once a valid 0DTE contract exists** — allowed. Gate B is about *eligibility*, not about forking profit/stop math.
+
+## Enforcement
+
+- Product rule: `.cursor/rules/options-scalp-strategy.mdc` → "Two Orthogonal Gates"
+- Code: `options-scalp.ts` (`VWAP_ETF_ONLY_UNIVERSE`, per-ticker expiry); `ib-connection.ts` (`placeOptionsOrder` TIF default)
+- History: `docs/cursor/discrepancy-fixes-log.md` (Jun 24 #472, Jun 29 ORB, Jul 1 AMD/PLTR, Jul 8 #486)


### PR DESCRIPTION
## Summary
- Document Gate A (TIF / execution hygiene) vs Gate B (universe + expiry eligibility) in `options-scalp-strategy.mdc`
- Add hard invariants so DAY TIF is never treated as a substitute for ETF/stock scalp eligibility
- Add ADR `2026-07-08-options-scalp-tif-vs-universe-gates.md` capturing the decision and anti-patterns

## Test plan
- [ ] Confirm rule files render cleanly in Cursor
- [ ] Confirm ADR is linked from options-scalp-strategy.mdc
- [ ] No runtime code changes — docs/rules only


Made with [Cursor](https://cursor.com)