### PR TITLE
Stop scalp CANCELLED rows flooding Trade History

### DIFF
--- a/auto-trader/src/ib-connection.ts
+++ b/auto-trader/src/ib-connection.ts
@@ -1587,6 +1587,18 @@ export function placeOptionsOrder(params: OptionsOrderParams): Promise<OptionsOr
   return paperConn.placeOptionsOrder(params);
 }
 
+/** Resolve an option to IB conId (+ working expiry). Null if IB has no matching contract. */
+export async function resolveOptionConId(
+  symbol: string,
+  right: 'P' | 'C',
+  strike: number,
+  expiry: string,
+  onIbError?: (error: string) => void,
+): Promise<{ conId: number; resolvedExpiry: string } | null> {
+  if (!paperConn) return null;
+  return paperConn.resolveOptionConId(symbol, right, strike, expiry.replace(/-/g, ''), onIbError);
+}
+
 export async function placeVerticalSpreadOrder(
   params: VerticalSpreadOrderParams,
 ): Promise<VerticalSpreadOrderResult> {

--- a/auto-trader/src/lib/options-chain.ts
+++ b/auto-trader/src/lib/options-chain.ts
@@ -330,6 +330,9 @@ export async function getOptionGreeksForContract(
   const ib = getIBApi();
   if (!ib || !isConnected()) return null;
 
+  // Normalize to YYYYMMDD — IB rejects dashed dates; callers may pass either.
+  const expiryYmd = expiry.replace(/-/g, '');
+
   await acquireRequestSlot();
   try {
     return await new Promise<OptionGreeks | null>((resolve) => {
@@ -339,6 +342,8 @@ export async function getOptionGreeksForContract(
       let bidPrice = -1, askPrice = -1;
       let impliedVol = 0, delta = 0, theta = 0, gamma = 0, vega = 0;
 
+      // tradingClass intentionally omitted — hardcoding symbol-as-class causes
+      // code-200 for tickers where IB's class differs (same rule as placeOptionsOrder).
       const contract: Contract = {
         symbol: symbol.toUpperCase(),
         secType: SecType.OPT,
@@ -346,9 +351,8 @@ export async function getOptionGreeksForContract(
         currency: 'USD',
         strike,
         right: optionType === 'P' ? OptionType.Put : OptionType.Call,
-        lastTradeDateOrContractMonth: expiry,
+        lastTradeDateOrContractMonth: expiryYmd,
         multiplier: 100,
-        tradingClass: symbol.toUpperCase(),
       };
 
       function finish(result: OptionGreeks | null) {
@@ -366,13 +370,13 @@ export async function getOptionGreeksForContract(
       function buildResult(): OptionGreeks {
         const mid = bidPrice >= 0 && askPrice >= 0 ? (bidPrice + askPrice) / 2 : Math.max(bidPrice, askPrice, 0);
         const realisticMid = Math.max(mid - 0.05, 0.01);
-        const dte = daysToExpiry(expiry);
+        const dte = daysToExpiry(expiryYmd);
         const annualYield = dte > 0 ? (realisticMid / strike) * (365 / dte) * 100 : 0;
         const absDelta = Math.abs(delta);
         const probProfit = (1 - absDelta) * 100;
 
         return {
-          strike, expiry,
+          strike, expiry: expiryYmd,
           optionType,
           bid: bidPrice >= 0 ? bidPrice : 0,
           ask: askPrice >= 0 ? askPrice : 0,
@@ -1018,6 +1022,8 @@ export async function findBestContractForStrike(
 
 // ── ATM Strike Finder (for day trading) ─────────────────
 
+export type AtmPricingSource = 'live' | 'bs_ib_strikes' | 'bs_interval';
+
 export interface AtmStrikeResult {
   strike: number;
   expiry: string;
@@ -1026,6 +1032,8 @@ export interface AtmStrikeResult {
   mid: number;
   delta: number;
   spreadPct: number;   // (ask-bid)/mid * 100
+  /** How the bid/ask were obtained. Scalps must not place on BS-only prices. */
+  pricingSource: AtmPricingSource;
 }
 
 /**
@@ -1102,10 +1110,14 @@ export async function findAtmStrike(
         if (absDelta < 0.35 || absDelta > 0.65) continue;
         if (greeks.bid < 0.05) continue;
         const spreadPct = greeks.mid > 0 ? ((greeks.ask - greeks.bid) / greeks.mid) * 100 : 999;
-        return { strike, expiry, bid: greeks.bid, ask: greeks.ask, mid: greeks.mid, delta: greeks.delta, spreadPct };
+        return {
+          strike, expiry: greeks.expiry, bid: greeks.bid, ask: greeks.ask,
+          mid: greeks.mid, delta: greeks.delta, spreadPct, pricingSource: 'live',
+        };
       }
 
-      // BS fallback using real IB strikes
+      // BS fallback using real IB strikes — marked so callers can refuse to place
+      // without a live quote (BS ask caused repeated code-202 NBBO rejects).
       const atmStrike = candidates.reduce((best, s) =>
         Math.abs(s - underlyingPrice) < Math.abs(best - underlyingPrice) ? s : best,
         candidates[0],
@@ -1116,14 +1128,17 @@ export async function findAtmStrike(
         const bid = Math.max(bs.price - spread / 2, 0.01);
         const ask = bs.price + spread / 2;
         console.log(`[Options Chain] ${symbol} ATM ${right} via BS fallback (IB strikes): strike $${atmStrike}, mid $${bs.price.toFixed(2)}, dte ${daysToExpiry(expiry)}`);
-        return { strike: atmStrike, expiry, bid, ask, mid: bs.price, delta: bs.delta, spreadPct: (spread / bs.price) * 100 };
+        return {
+          strike: atmStrike, expiry, bid, ask, mid: bs.price, delta: bs.delta,
+          spreadPct: (spread / bs.price) * 100, pricingSource: 'bs_ib_strikes',
+        };
       }
     }
   }
 
   // ── Attempt 2: price-interval strike + BS ────────────────────────────────
-  // getOptionChainParams failed (IB busy/timeout) — compute strike from standard
-  // price intervals and price via BS. Same approach as the original atmStrikeViaBs.
+  // getOptionChainParams failed (IB busy/timeout) — invent a strike from price
+  // tiers. Callers MUST resolveOptionConId before placing; often code-200.
   const intervalStrike = atmStrikeForPrice(underlyingPrice);
   const bs2 = await atmBsPrice(symbol, right, intervalStrike, underlyingPrice, expiry);
   if (!bs2 || bs2.price < 0.05) return null;
@@ -1138,5 +1153,8 @@ export async function findAtmStrike(
   const spreadPct = (spread / price) * 100;
 
   console.log(`[Options Chain] ${symbol} ATM ${right} via BS fallback (interval strike): strike $${intervalStrike}, mid $${price.toFixed(2)}, dte ${daysToExpiry(expiry)}`);
-  return { strike: intervalStrike, expiry, bid, ask, mid: price, delta, spreadPct };
+  return {
+    strike: intervalStrike, expiry, bid, ask, mid: price, delta, spreadPct,
+    pricingSource: 'bs_interval',
+  };
 }

--- a/auto-trader/src/lib/options-scalp.ts
+++ b/auto-trader/src/lib/options-scalp.ts
@@ -19,8 +19,8 @@
  */
 
 import { getSupabase, createAutoTradeEvent } from './supabase.js';
-import { isConnected, placeOptionsOrder, cancelOrder, getDefaultAccount } from '../ib-connection.js';
-import { findAtmStrike, getOptionGreeksForContract } from './options-chain.js';
+import { isConnected, placeOptionsOrder, cancelOrder, getDefaultAccount, resolveOptionConId } from '../ib-connection.js';
+import { findAtmStrike, getOptionGreeksForContract, type AtmPricingSource } from './options-chain.js';
 import { fetchQuote, fetchIntradayBars, fetchDailyBars, type IntradayBar } from './yahoo-finance.js';
 import { detectVwapReclaim, fetchVwap, VWAP_RELIABLE_HOUR_ET } from './vwap.js';
 
@@ -457,6 +457,7 @@ export async function runOptionScalpScan(): Promise<void> {
       limitPrice: atm.ask, contracts: MAX_CONTRACTS,
       price, intradayMovePct, delta: atm.delta,
       spreadPct: atm.spreadPct,
+      pricingSource: atm.pricingSource,
     });
     if (ok) placed++;
   }
@@ -493,8 +494,8 @@ const VWAP_RETEST_UNIVERSE = [
 
 // ETF-only subset for Mon–Thu: these have daily (Mon–Fri) options chains in IB.
 // Individual stocks and even mega-caps only have weekly Friday expirations — they
-// generate ib_error (code-200) on every 0DTE attempt Mon–Thu, flooding the DB
-// with useless CANCELLED records. On Friday all tickers are valid (weekly = 0DTE).
+// get code-200 on 0DTE Mon–Thu. executeScalp now skips (no CANCELLED History row)
+// when resolveOptionConId fails. On Friday all tickers are valid (weekly = 0DTE).
 // NVDL/TSLL included: leveraged single-asset ETFs with daily chains like SOXL/TQQQ.
 const VWAP_ETF_ONLY_UNIVERSE = ['QQQ', 'SPY', 'IWM', 'SMH', 'SOXL', 'TQQQ', 'NVDL', 'TSLL'];
 
@@ -650,6 +651,7 @@ export async function runVwapRetestScalpScan(): Promise<void> {
       delta: atm.delta, spreadPct: atm.spreadPct,
       entryType: 'vwap_retest',
       vwap: vwapLevel,
+      pricingSource: atm.pricingSource,
     });
 
     if (ok) {
@@ -677,92 +679,172 @@ interface ScalpParams {
   intradayMovePct: number;
   delta: number;
   spreadPct: number;
+  /** How findAtmStrike priced the contract — BS-only must not place. */
+  pricingSource: AtmPricingSource;
   /** 'momentum' = classic >1.5% intraday move; 'vwap_retest' = VWAP bounce entry */
   entryType?: 'momentum' | 'vwap_retest';
   /** VWAP level at entry time (only set for vwap_retest entries) */
   vwap?: number;
 }
 
+async function logScalpSkip(ticker: string, reason: string, metadata: Record<string, unknown> = {}): Promise<void> {
+  console.log(`[Options Scalp] ${ticker} — skipped: ${reason}`);
+  createAutoTradeEvent({
+    ticker,
+    event_type: 'warning',
+    action: 'skipped',
+    source: 'scanner',
+    mode: 'OPTIONS_SCALP',
+    message: `Scalp skipped — ${reason}`,
+    metadata,
+  }).catch(() => {});
+}
+
+/**
+ * Place a scalp only when IB can resolve the contract AND we have a live bid/ask.
+ * paper_trades is inserted only after a confirmed fill — failed attempts must not
+ * flood Trade History as CANCELLED/ib_error rows (Jul 2026 cancel storm).
+ */
 async function executeScalp(p: ScalpParams): Promise<boolean> {
   const sb = getSupabase();
   const account = getDefaultAccount() ?? undefined;
 
-  const { data: trade, error } = await sb
-    .from('paper_trades')
-    .insert({
-      ticker:         p.ticker,
-      mode:           'OPTIONS_SCALP',
-      signal:         p.signal,
-      entry_price:    p.price,
-      quantity:       p.contracts,
-      position_size:  Math.round(p.limitPrice * 100 * p.contracts),
-      status:         'SUBMITTED',
-      option_strike:  p.strike,
-      option_expiry:  p.expiry,
-      option_premium: 0,
-      option_contracts: p.contracts,
-      option_delta:   p.delta,
-      notes: p.entryType === 'vwap_retest'
-        ? `[SCALP] Buy ${p.right === 'C' ? 'call' : 'put'}: $${p.strike} exp ${p.expiry} — VWAP retest @ $${(p.vwap ?? 0).toFixed(2)}`
-        : `[SCALP] Buy ${p.right === 'C' ? 'call' : 'put'}: $${p.strike} exp ${p.expiry} — intraday ${p.intradayMovePct > 0 ? '+' : ''}${p.intradayMovePct.toFixed(1)}%`,
-      scanner_reason: p.entryType === 'vwap_retest'
-        ? `VWAP retest scalp — δ ${Math.abs(p.delta).toFixed(2)}, bounce off VWAP $${(p.vwap ?? 0).toFixed(2)}, spread ${p.spreadPct.toFixed(1)}%`
-        : `Options scalp — δ ${Math.abs(p.delta).toFixed(2)}, ${p.intradayMovePct > 0 ? '+' : ''}${p.intradayMovePct.toFixed(1)}% intraday, spread ${p.spreadPct.toFixed(1)}%`,
-    })
-    .select('id')
-    .single();
-
-  if (error || !trade) {
-    console.error(`[Options Scalp] DB insert failed for ${p.ticker}:`, error?.message);
+  // Gate 1: IB must resolve the exact option (kills invented interval-strike contracts).
+  const resolved = await resolveOptionConId(p.ticker, p.right, p.strike, p.expiry);
+  if (!resolved) {
+    await logScalpSkip(p.ticker, `no IB security definition for $${p.strike}${p.right} ${p.expiry}`, {
+      strike: p.strike, expiry: p.expiry, right: p.right, pricingSource: p.pricingSource,
+    });
     return false;
   }
 
-  // Place IB order
+  // Gate 2: require live NBBO — BS-only asks caused code-202 (limit too far from market).
+  let limitPrice = p.limitPrice;
+  let delta = p.delta;
+  let liveQuote = p.pricingSource === 'live';
+
+  if (!liveQuote) {
+    const greeks = await getOptionGreeksForContract(
+      p.ticker, p.strike, resolved.resolvedExpiry, p.right, p.price,
+    );
+    if (greeks && greeks.bid >= 0.10 && greeks.ask > 0) {
+      limitPrice = greeks.ask;
+      delta = greeks.delta;
+      liveQuote = true;
+      console.log(
+        `[Options Scalp] ${p.ticker} — refreshed live quote after resolve: `
+        + `bid $${greeks.bid.toFixed(2)} ask $${greeks.ask.toFixed(2)} (was ${p.pricingSource})`,
+      );
+    }
+  }
+
+  if (!liveQuote) {
+    await logScalpSkip(
+      p.ticker,
+      `no live option quote (pricing=${p.pricingSource}) — refusing BS-only limit`,
+      { strike: p.strike, expiry: resolved.resolvedExpiry, right: p.right, pricingSource: p.pricingSource },
+    );
+    return false;
+  }
+
+  if (limitPrice < 0.10) {
+    await logScalpSkip(p.ticker, `limit too thin ($${limitPrice.toFixed(2)})`, {
+      strike: p.strike, expiry: resolved.resolvedExpiry,
+    });
+    return false;
+  }
+
+  // Place first — only persist paper_trades after a real fill.
   let result;
   try {
     result = await placeOptionsOrder({
       symbol:     p.ticker,
       right:      p.right,
       strike:     p.strike,
-      expiry:     p.expiry,
+      expiry:     resolved.resolvedExpiry,
       contracts:  p.contracts,
-      limitPrice: p.limitPrice,
+      limitPrice,
       action:     'BUY',
+      conId:      resolved.conId,
       ...(account ? { account } : {}),
     });
   } catch (err) {
-    console.error(`[Options Scalp] IB order failed for ${p.ticker}:`, err instanceof Error ? err.message : err);
-    await sb.from('paper_trades').update({
-      status: 'CANCELLED', close_reason: 'ib_error', closed_at: new Date().toISOString(),
-    }).eq('id', trade.id);
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[Options Scalp] IB order failed for ${p.ticker}:`, msg);
+    await logScalpSkip(p.ticker, `IB reject — ${msg}`, {
+      strike: p.strike, expiry: resolved.resolvedExpiry, right: p.right, conId: resolved.conId,
+    });
     return false;
   }
 
   if (result.timedOut || !result.avgFillPrice || result.avgFillPrice <= 0) {
-    // Cancel the live GTC order in IB — without this the order stays open and can
-    // ghost-fill the next morning even though the DB already shows CANCELLED.
+    // Cancel so the DAY/GTC order cannot ghost-fill overnight with no DB row.
     if (result.orderId && isConnected()) {
       try {
         cancelOrder(result.orderId);
         console.log(`[Options Scalp] ${p.ticker} — cancelled IB order #${result.orderId} (no fill)`);
       } catch (cancelErr) {
-        console.warn(`[Options Scalp] ${p.ticker} — cancel IB #${result.orderId} failed:`, cancelErr instanceof Error ? cancelErr.message : cancelErr);
+        console.warn(
+          `[Options Scalp] ${p.ticker} — cancel IB #${result.orderId} failed:`,
+          cancelErr instanceof Error ? cancelErr.message : cancelErr,
+        );
       }
     }
-    await sb.from('paper_trades').update({
-      status: 'CANCELLED', close_reason: 'no_fill', closed_at: new Date().toISOString(),
-    }).eq('id', trade.id);
-    console.log(`[Options Scalp] ${p.ticker} — no fill (timed out)`);
+    await logScalpSkip(p.ticker, 'no fill (timed out)', {
+      strike: p.strike, expiry: resolved.resolvedExpiry, orderId: result.orderId,
+    });
     return false;
   }
 
-  await sb.from('paper_trades').update({
-    ib_order_id:    result.orderId,
-    status:         'FILLED',
-    fill_price:     result.avgFillPrice,
-    option_premium: result.avgFillPrice,
-    filled_at:      new Date().toISOString(),
-  }).eq('id', trade.id);
+  const notes = p.entryType === 'vwap_retest'
+    ? `[SCALP] Buy ${p.right === 'C' ? 'call' : 'put'}: $${p.strike} exp ${resolved.resolvedExpiry} — VWAP retest @ $${(p.vwap ?? 0).toFixed(2)}`
+    : `[SCALP] Buy ${p.right === 'C' ? 'call' : 'put'}: $${p.strike} exp ${resolved.resolvedExpiry} — intraday ${p.intradayMovePct > 0 ? '+' : ''}${p.intradayMovePct.toFixed(1)}%`;
+  const scannerReason = p.entryType === 'vwap_retest'
+    ? `VWAP retest scalp — δ ${Math.abs(delta).toFixed(2)}, bounce off VWAP $${(p.vwap ?? 0).toFixed(2)}, spread ${p.spreadPct.toFixed(1)}%`
+    : `Options scalp — δ ${Math.abs(delta).toFixed(2)}, ${p.intradayMovePct > 0 ? '+' : ''}${p.intradayMovePct.toFixed(1)}% intraday, spread ${p.spreadPct.toFixed(1)}%`;
+
+  const { data: trade, error } = await sb
+    .from('paper_trades')
+    .insert({
+      ticker:           p.ticker,
+      mode:             'OPTIONS_SCALP',
+      signal:           p.signal,
+      entry_price:      p.price,
+      quantity:         p.contracts,
+      position_size:    Math.round(result.avgFillPrice * 100 * p.contracts),
+      status:           'FILLED',
+      fill_price:       result.avgFillPrice,
+      filled_at:        new Date().toISOString(),
+      ib_order_id:      result.orderId,
+      option_strike:    p.strike,
+      option_expiry:    resolved.resolvedExpiry,
+      option_premium:   result.avgFillPrice,
+      option_contracts: p.contracts,
+      option_delta:     delta,
+      notes,
+      scanner_reason:   scannerReason,
+    })
+    .select('id')
+    .single();
+
+  if (error || !trade) {
+    // Fill happened in IB but DB insert failed — CRITICAL so it surfaces for manual link.
+    console.error(`[Options Scalp] DB insert failed AFTER fill for ${p.ticker} IB #${result.orderId}:`, error?.message);
+    createAutoTradeEvent({
+      ticker: p.ticker,
+      event_type: 'error',
+      action: 'failed',
+      source: 'scanner',
+      mode: 'OPTIONS_SCALP',
+      message: `CRITICAL: scalp FILLED in IB #${result.orderId} @ $${result.avgFillPrice.toFixed(2)} but paper_trades insert failed — link manually`,
+      metadata: {
+        orderId: result.orderId, fillPrice: result.avgFillPrice,
+        strike: p.strike, expiry: resolved.resolvedExpiry, right: p.right, conId: resolved.conId,
+        dbError: error?.message ?? 'unknown',
+      },
+    }).catch(() => {});
+    return false;
+  }
 
   console.log(`[Options Scalp] ✅ ${p.ticker} ${p.right === 'C' ? 'CALL' : 'PUT'} $${p.strike} @ $${result.avgFillPrice.toFixed(2)} | IB #${result.orderId}`);
 
@@ -773,9 +855,9 @@ async function executeScalp(p: ScalpParams): Promise<boolean> {
     source:     'scanner',
     mode:       'OPTIONS_SCALP',
     message: p.entryType === 'vwap_retest'
-      ? `📈 Scalp ${p.right === 'C' ? 'CALL' : 'PUT'} $${p.strike} exp ${p.expiry} @ $${result.avgFillPrice.toFixed(2)} — VWAP retest (${p.right === 'C' ? 'bounce' : 'breakdown'}) @ $${(p.vwap ?? 0).toFixed(2)}`
-      : `📈 Scalp ${p.right === 'C' ? 'CALL' : 'PUT'} $${p.strike} exp ${p.expiry} @ $${result.avgFillPrice.toFixed(2)} — intraday ${p.intradayMovePct > 0 ? '+' : ''}${p.intradayMovePct.toFixed(1)}%`,
-    metadata:   { strike: p.strike, expiry: p.expiry, premium: result.avgFillPrice, delta: p.delta, right: p.right },
+      ? `📈 Scalp ${p.right === 'C' ? 'CALL' : 'PUT'} $${p.strike} exp ${resolved.resolvedExpiry} @ $${result.avgFillPrice.toFixed(2)} — VWAP retest (${p.right === 'C' ? 'bounce' : 'breakdown'}) @ $${(p.vwap ?? 0).toFixed(2)}`
+      : `📈 Scalp ${p.right === 'C' ? 'CALL' : 'PUT'} $${p.strike} exp ${resolved.resolvedExpiry} @ $${result.avgFillPrice.toFixed(2)} — intraday ${p.intradayMovePct > 0 ? '+' : ''}${p.intradayMovePct.toFixed(1)}%`,
+    metadata:   { strike: p.strike, expiry: resolved.resolvedExpiry, premium: result.avgFillPrice, delta, right: p.right, conId: resolved.conId },
   }).catch(() => {});
 
   return true;

--- a/auto-trader/src/lib/spy-basketball.ts
+++ b/auto-trader/src/lib/spy-basketball.ts
@@ -29,8 +29,8 @@
  */
 
 import { getSupabase, createAutoTradeEvent } from './supabase.js';
-import { isConnected, placeOptionsOrder, getDefaultAccount } from '../ib-connection.js';
-import { findAtmStrike, getOptionGreeksForContract } from './options-chain.js';
+import { isConnected, placeOptionsOrder, cancelOrder, getDefaultAccount, resolveOptionConId } from '../ib-connection.js';
+import { findAtmStrike, getOptionGreeksForContract, type AtmPricingSource } from './options-chain.js';
 import { finnhubFetch, FINNHUB_KEY, FINNHUB_BASE } from './finnhub.js';
 import { fetchVwap } from './vwap.js';
 
@@ -290,6 +290,7 @@ export async function runBasketballScan(): Promise<void> {
     spreadPct: atm.spreadPct,
     level: signal.level,
     vwap: vwapResult?.vwap ?? null,
+    pricingSource: atm.pricingSource,
   });
 }
 
@@ -307,6 +308,7 @@ interface BasketballParams {
   spreadPct: number;
   level: number;
   vwap: number | null;
+  pricingSource: AtmPricingSource;
 }
 
 async function executeBaskeball(p: BasketballParams): Promise<boolean> {
@@ -318,29 +320,35 @@ async function executeBaskeball(p: BasketballParams): Promise<boolean> {
     : `Resistance rejection at $${p.level} zone`;
   const targetDesc = p.vwap ? `, target VWAP $${p.vwap.toFixed(2)}` : '';
 
-  const { data: trade, error } = await sb
-    .from('paper_trades')
-    .insert({
-      ticker:           TICKER,
-      mode:             'OPTIONS_SCALP',
-      signal:           p.signal,
-      entry_price:      p.price,
-      quantity:         p.contracts,
-      position_size:    Math.round(p.limitPrice * 100 * p.contracts),
-      status:           'SUBMITTED',
-      option_strike:    p.strike,
-      option_expiry:    p.expiry,
-      option_premium:   0,
-      option_contracts: p.contracts,
-      option_delta:     p.delta,
-      notes:            `[BASKETBALL] Buy ${p.right === 'C' ? 'call' : 'put'}: $${p.strike} 0DTE — ${zoneDesc}${targetDesc}`,
-      scanner_reason:   `Basketball zone $${p.level} — δ ${Math.abs(p.delta).toFixed(2)}, spread ${p.spreadPct.toFixed(1)}%, SPY $${p.price.toFixed(2)}`,
-    })
-    .select('id')
-    .single();
+  const resolved = await resolveOptionConId(TICKER, p.right, p.strike, p.expiry);
+  if (!resolved) {
+    console.log(`[Basketball] No IB security definition for $${p.strike}${p.right} ${p.expiry} — skip`);
+    createAutoTradeEvent({
+      ticker: TICKER, event_type: 'warning', action: 'skipped', source: 'scanner', mode: 'OPTIONS_SCALP',
+      message: `Basketball skipped — no IB contract for $${p.strike}${p.right} ${p.expiry}`,
+      metadata: { strike: p.strike, expiry: p.expiry, pricingSource: p.pricingSource },
+    }).catch(() => {});
+    return false;
+  }
 
-  if (error || !trade) {
-    console.error('[Basketball] DB insert failed:', error?.message);
+  let limitPrice = p.limitPrice;
+  let delta = p.delta;
+  let liveQuote = p.pricingSource === 'live';
+  if (!liveQuote) {
+    const greeks = await getOptionGreeksForContract(TICKER, p.strike, resolved.resolvedExpiry, p.right, p.price);
+    if (greeks && greeks.bid >= 0.10 && greeks.ask > 0) {
+      limitPrice = greeks.ask;
+      delta = greeks.delta;
+      liveQuote = true;
+    }
+  }
+  if (!liveQuote) {
+    console.log(`[Basketball] No live quote (pricing=${p.pricingSource}) — refusing BS-only limit`);
+    createAutoTradeEvent({
+      ticker: TICKER, event_type: 'warning', action: 'skipped', source: 'scanner', mode: 'OPTIONS_SCALP',
+      message: `Basketball skipped — no live option quote (pricing=${p.pricingSource})`,
+      metadata: { strike: p.strike, expiry: resolved.resolvedExpiry, pricingSource: p.pricingSource },
+    }).catch(() => {});
     return false;
   }
 
@@ -350,35 +358,70 @@ async function executeBaskeball(p: BasketballParams): Promise<boolean> {
       symbol:     TICKER,
       right:      p.right,
       strike:     p.strike,
-      expiry:     p.expiry,
+      expiry:     resolved.resolvedExpiry,
       contracts:  p.contracts,
-      limitPrice: p.limitPrice,
+      limitPrice,
       action:     'BUY',
+      conId:      resolved.conId,
       ...(account ? { account } : {}),
     });
   } catch (err) {
-    console.error('[Basketball] IB order failed:', err instanceof Error ? err.message : err);
-    await sb.from('paper_trades').update({
-      status: 'CANCELLED', close_reason: 'ib_error', closed_at: new Date().toISOString(),
-    }).eq('id', trade.id);
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[Basketball] IB order failed:', msg);
+    createAutoTradeEvent({
+      ticker: TICKER, event_type: 'warning', action: 'skipped', source: 'scanner', mode: 'OPTIONS_SCALP',
+      message: `Basketball skipped — IB reject: ${msg}`,
+      metadata: { strike: p.strike, expiry: resolved.resolvedExpiry, conId: resolved.conId },
+    }).catch(() => {});
     return false;
   }
 
   if (result.timedOut || !result.avgFillPrice || result.avgFillPrice <= 0) {
-    await sb.from('paper_trades').update({
-      status: 'CANCELLED', close_reason: 'no_fill', closed_at: new Date().toISOString(),
-    }).eq('id', trade.id);
+    if (result.orderId && isConnected()) {
+      try { cancelOrder(result.orderId); } catch { /* best-effort */ }
+    }
     console.log('[Basketball] SPY 0DTE — no fill');
+    createAutoTradeEvent({
+      ticker: TICKER, event_type: 'warning', action: 'skipped', source: 'scanner', mode: 'OPTIONS_SCALP',
+      message: 'Basketball skipped — no fill (timed out)',
+      metadata: { strike: p.strike, expiry: resolved.resolvedExpiry, orderId: result.orderId },
+    }).catch(() => {});
     return false;
   }
 
-  await sb.from('paper_trades').update({
-    ib_order_id:    result.orderId,
-    status:         'FILLED',
-    fill_price:     result.avgFillPrice,
-    option_premium: result.avgFillPrice,
-    filled_at:      new Date().toISOString(),
-  }).eq('id', trade.id);
+  const { data: trade, error } = await sb
+    .from('paper_trades')
+    .insert({
+      ticker:           TICKER,
+      mode:             'OPTIONS_SCALP',
+      signal:           p.signal,
+      entry_price:      p.price,
+      quantity:         p.contracts,
+      position_size:    Math.round(result.avgFillPrice * 100 * p.contracts),
+      status:           'FILLED',
+      fill_price:       result.avgFillPrice,
+      filled_at:        new Date().toISOString(),
+      ib_order_id:      result.orderId,
+      option_strike:    p.strike,
+      option_expiry:    resolved.resolvedExpiry,
+      option_premium:   result.avgFillPrice,
+      option_contracts: p.contracts,
+      option_delta:     delta,
+      notes:            `[BASKETBALL] Buy ${p.right === 'C' ? 'call' : 'put'}: $${p.strike} 0DTE — ${zoneDesc}${targetDesc}`,
+      scanner_reason:   `Basketball zone $${p.level} — δ ${Math.abs(delta).toFixed(2)}, spread ${p.spreadPct.toFixed(1)}%, SPY $${p.price.toFixed(2)}`,
+    })
+    .select('id')
+    .single();
+
+  if (error || !trade) {
+    console.error(`[Basketball] DB insert failed AFTER fill IB #${result.orderId}:`, error?.message);
+    createAutoTradeEvent({
+      ticker: TICKER, event_type: 'error', action: 'failed', source: 'scanner', mode: 'OPTIONS_SCALP',
+      message: `CRITICAL: basketball FILLED in IB #${result.orderId} @ $${result.avgFillPrice.toFixed(2)} but paper_trades insert failed`,
+      metadata: { orderId: result.orderId, fillPrice: result.avgFillPrice, strike: p.strike, expiry: resolved.resolvedExpiry },
+    }).catch(() => {});
+    return false;
+  }
 
   console.log(
     `[Basketball] ✅ SPY ${p.right === 'C' ? 'CALL' : 'PUT'} $${p.strike} 0DTE `
@@ -392,7 +435,7 @@ async function executeBaskeball(p: BasketballParams): Promise<boolean> {
     source:     'scanner',
     mode:       'OPTIONS_SCALP',
     message:    `🏀 Basketball 0DTE ${p.right === 'C' ? 'CALL' : 'PUT'} $${p.strike} @ $${result.avgFillPrice.toFixed(2)} — ${zoneDesc}${targetDesc}`,
-    metadata:   { strike: p.strike, expiry: p.expiry, premium: result.avgFillPrice, delta: p.delta, right: p.right, level: p.level },
+    metadata:   { strike: p.strike, expiry: resolved.resolvedExpiry, premium: result.avgFillPrice, delta, right: p.right, level: p.level, conId: resolved.conId },
   }).catch(() => {});
 
   return true;

--- a/docs/cursor/2026-07-13-scalp-cancel-flood-fix.md
+++ b/docs/cursor/2026-07-13-scalp-cancel-flood-fix.md
@@ -1,0 +1,40 @@
+# Options Scalp Cancel Flood Fix (2026-07-13)
+
+## Problem
+
+Trade History was dominated by `CANCELLED` / `ib_error` / `no_fill` rows from `OPTIONS_SCALP`. Most were never real trades — failed IB attempts persisted as History noise.
+
+Today's evidence (Jul 13): 8/8 scalp attempts cancelled. Logs showed Black-Scholes fallback pricing → IB reject (code 200 no security definition, or code 202 limit too far from NBBO).
+
+## Root causes
+
+1. `getOptionGreeksForContract` hardcoded `tradingClass = ticker` (while `placeOptionsOrder` deliberately omits it) → live greeks often failed → BS fallback.
+2. `findAtmStrike` Attempt 2 invented interval strikes and treated BS ask as placeable.
+3. `executeScalp` / basketball inserted `paper_trades` **before** IB accepted → every reject became a permanent CANCELLED row.
+
+## Fix (option C)
+
+**B — stop placing garbage**
+- Omit `tradingClass` on greeks requests; normalize expiry to YYYYMMDD.
+- Tag ATM results with `pricingSource`: `live` | `bs_ib_strikes` | `bs_interval`.
+- Before place: `resolveOptionConId` must succeed; require live bid/ask (refresh after resolve if needed). BS-only → skip.
+- Place with `conId` + resolved expiry.
+
+**A — stop flooding History**
+- Insert `paper_trades` only after a confirmed fill.
+- Skips/rejects/timeouts → `auto_trade_events` warning only (no CANCELLED row).
+- On timeout: still cancel the live IB order to prevent ghost fills.
+- If fill succeeds but DB insert fails → CRITICAL error event (IB has position, needs manual link).
+
+## Files
+
+- `auto-trader/src/lib/options-chain.ts`
+- `auto-trader/src/lib/options-scalp.ts`
+- `auto-trader/src/lib/spy-basketball.ts`
+- `auto-trader/src/ib-connection.ts` (export `resolveOptionConId`)
+
+## Expected behavior change
+
+- Fewer (ideally zero) new scalp CANCELLED rows in Trade History.
+- Skipped setups appear in activity events, not as fake trades.
+- Scalps only open when IB resolves the contract and a live quote exists.


### PR DESCRIPTION
## Summary
- Fix live option greeks requests (drop hardcoded `tradingClass`) so we stop falling into BS-only pricing
- Require `resolveOptionConId` + live bid/ask before placing a scalp; BS-only / unresolved contracts are skipped
- Insert `paper_trades` only after a confirmed fill — rejects/timeouts log activity skips instead of CANCELLED History rows
- Same gates applied to SPY basketball scalps

## Test plan
- [ ] Confirm auto-trader restarted with new build
- [ ] Next VWAP/ORB scalp attempt: if IB rejects or has no live quote, check `auto_trade_events` for skip — no new CANCELLED `OPTIONS_SCALP` row
- [ ] On a real fill: History shows FILLED with premium/order id as before
- [ ] Timeout path still cancels the live IB order (no overnight ghost fill)

Made with [Cursor](https://cursor.com)