### PR TITLE
Block swing BUY into extended 10-day dumps

### DIFF
--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -4359,6 +4359,29 @@ async function executeScannerTrade(
     } catch { /* non-blocking */ }
   }
 
+  // ── Swing BUY hard gate — no falling knives ───────────────────────────────
+  // Mirror SELL Gate C: if the stock is already down >12% over 10 trading days,
+  // skip mean-reversion / dip-buy entries. Evidence (2026-07-16):
+  //   IREN Jul 15: −16% / 10d → stopped next day (−$985)
+  //   ORCL Jun 29: −20% / 10d → stopped (−$1.2k)
+  // Recent TARGET_HIT winners (NU, MELI, JPM, GS, FCX) were NOT extended — gate
+  // would have spared them. Yahoo failure = fail-open (same as SELL Gate C).
+  if (mode === 'SWING_TRADE' && signal === 'BUY') {
+    try {
+      const stockBars = await fetchYahooDailyBars(ticker);
+      if (stockBars && stockBars.closes.length >= 11) {
+        const closes = stockBars.closes;
+        const today = closes[closes.length - 1];
+        const tenDaysAgo = closes[closes.length - 11];
+        const pctDrop = (tenDaysAgo - today) / tenDaysAgo * 100;
+        if (pctDrop > 12) {
+          log(`${ticker}: swing BUY blocked — stock already down ${pctDrop.toFixed(1)}% in 10 days (extended dump, falling-knife risk)`);
+          return 'skipped:swing_long_extended';
+        }
+      }
+    } catch { /* non-blocking — if we can't check bars, allow the trade */ }
+  }
+
   // SPY regime multiplier for swing BUY: reduce size in bearish macro conditions.
   // SELL signals handled above with hard gates. Non-blocking: defaults to 1.0 on failure.
   let spyRegimeMult = 1.0;

--- a/docs/cursor/2026-07-16-swing-buy-extended-gate.md
+++ b/docs/cursor/2026-07-16-swing-buy-extended-gate.md
@@ -1,0 +1,38 @@
+# Swing BUY extended-move gate (2026-07-16)
+
+## Goal
+
+Stop swing BUY entries into names already in a sharp 10-day dump (falling knives), after IREN −$985 stop-out.
+
+## What happened
+
+- IREN opened Jul 15 as split-bracket swing BUY (379 sh, T1/T2), stopped Jul 16 via IB STP.
+- Not an execution bug — shared stop + T1/T2 by design; `close_reason=stopped`.
+- At entry, IREN was already **−16% over 10 trading days**. ORCL Jun 29 was **−20%** and also stopped hard.
+
+## Asymmetry (root cause)
+
+Swing **SELL** already hard-blocks when the stock is down >12% in 10 days (`skipped:swing_short_extended`). Swing **BUY** only had SPY regime *sizing* haircuts — no stock-level hard gate.
+
+## Decision (automated — party mode)
+
+Ship BUY mirror of SELL Gate C. Do not change T1/T2 stops or R:R floor.
+
+| Ticker | Entry day | 10d drop | Gate would… |
+|--------|-----------|----------|-------------|
+| IREN | Jul 15 | −16% | **block** |
+| ORCL | Jun 29 | −20% | **block** |
+| NU, MELI, JPM, GS, FCX (winners) | various | not extended | **allow** |
+
+## Change
+
+`auto-trader/src/scheduler.ts` — before `spyRegimeMult`:
+
+- If `SWING_TRADE` + `BUY` and 10-day drop > 12% → `skipped:swing_long_extended`
+- Yahoo failure → fail-open (same as SELL)
+
+## Out of scope
+
+- Per-leg stops / trail after T1
+- UI “Loss Cut” vs “Stopped Out” label (separate UX)
+- Raising swing R:R floor


### PR DESCRIPTION
## Summary
- Add swing BUY hard gate mirroring SELL Gate C: skip when stock is down >12% over 10 trading days (`skipped:swing_long_extended`)
- Would have blocked IREN (−16%) and ORCL (−20%) knife catches; backtested winners (NU, MELI, JPM, GS, FCX) still pass
- Documented in `docs/cursor/2026-07-16-swing-buy-extended-gate.md`

## Test plan
- [x] `auto-trader` `tsc` build passes
- [x] Auto-trader rebuilt + LaunchAgent restarted locally
- [ ] Next swing BUY candidate with >12% 10d drop logs `skipped:swing_long_extended`
- [ ] Yahoo failure path still fail-open (does not block)


Made with [Cursor](https://cursor.com)