### PR TITLE
Centralize exit-management routing: getConnectionForManagement + invariant

### DIFF
--- a/.cursor/rules/auto-trader-invariants.mdc
+++ b/.cursor/rules/auto-trader-invariants.mdc
@@ -22,6 +22,18 @@ If a change would violate any of these, STOP and ask the user before proceeding.
   If `strategy_source`, `strategy_video_id`, `mode`, or `signal` was set when the trade was created,
   no downstream code path may null it out. These are immutable attribution fields.
 
+- **Exit / position-management must NEVER be gated by mode routing (`off`).**
+  `off` means "do not open NEW positions" — it must NOT stop management of positions
+  we already hold. ENTRY code (scanner buys, dip buys, new options/spreads) uses
+  `getConnectionForMode()` (which throws on `off`, so the caller skips). EXIT and
+  position-management code (stop-loss, hard-stop, trailing-stop, profit-take,
+  max-hold, covered-call, reconcile) MUST use `getConnectionForManagement()`, which
+  falls back to paper on `off` and never returns empty. Do NOT wrap
+  `getConnectionForMode()` in `try { } catch { return; }` inside a management
+  function — that silently disables protection when entries are paused (the Jul 21
+  2026 bug: pausing Suggested Finds routed LONG_TERM `off` and stripped stop-loss/
+  hard-stop/trailing/max-hold off existing longs while profit-take kept running).
+
 ## 2. Market Hours
 
 - **Never place MKT/DAY orders outside regular trading hours (9:30 AM – 4:00 PM ET).**

--- a/auto-trader/src/lib/mode-router.ts
+++ b/auto-trader/src/lib/mode-router.ts
@@ -102,6 +102,34 @@ export function getConnectionForMode(
 }
 
 /**
+ * Get the IB connection(s) for MANAGING AN EXISTING position (exits: stop-loss,
+ * hard-stop, trailing-stop, profit-take, max-hold, covered-call, reconcile).
+ *
+ * CRITICAL DIFFERENCE from `getConnectionForMode`: this NEVER throws for `off`.
+ * `off` means "do not open NEW positions" — it must NOT stop us from managing
+ * positions we already hold. A prior bug (Jul 21 2026) had exit functions call
+ * `getConnectionForMode` inside `try { } catch { return; }`, so pausing entries
+ * (routing a mode `off`) silently disabled stop-loss/hard-stop/trailing/max-hold
+ * on existing longs while profit-take kept running. Existing positions bled with
+ * no protection.
+ *
+ * Rule: ENTRY code uses `getConnectionForMode` (respects `off`). EXIT / position-
+ * management code uses THIS (`off` → paper fallback, never returns empty).
+ *
+ * For `live`/`both`/`paper` it delegates to `getConnectionForMode` (unchanged
+ * kill-switch / connectivity semantics). Only `off` is special-cased to paper.
+ */
+export function getConnectionForManagement(
+  mode: TradeMode,
+  config: AutoTraderConfig,
+): { connections: RoutedConnection[] } {
+  if (getRouteTarget(mode, config) === 'off') {
+    return { connections: [{ connection: getConnectionForAccount('paper'), accountType: 'paper' }] };
+  }
+  return getConnectionForMode(mode, config);
+}
+
+/**
  * Get position sizing configuration for an account type.
  * Live uses conservative overrides; paper uses the standard config values.
  */

--- a/auto-trader/src/scheduler.ts
+++ b/auto-trader/src/scheduler.ts
@@ -32,7 +32,7 @@ import {
   type PositionData,
   type IBConnection,
 } from './ib-connection.js';
-import { getConnectionForMode, getAccountForMode, getPositionSizeConfig, assertLiveLossLimitNotBreached, isModeEnabled, type RoutedConnection } from './lib/mode-router.js';
+import { getConnectionForMode, getConnectionForManagement, getAccountForMode, getPositionSizeConfig, assertLiveLossLimitNotBreached, isModeEnabled, type RoutedConnection } from './lib/mode-router.js';
 import type { AccountType } from '../../shared/trade-types.js';
 import {
   isConfigured,
@@ -6877,14 +6877,8 @@ async function checkSwingHoldExpiry(
   const maxDays = config.swingMaxHoldDays ?? 5;
   if (maxDays <= 0 || !config.accountId) return;
 
-  // Manage existing swings even when SWING_TRADE is routed 'off' — 'off' blocks
-  // new entries, not exit management. Falls back to paper (same as LONG_TERM).
-  let swingConnections: RoutedConnection[];
-  try {
-    swingConnections = getConnectionForMode('SWING_TRADE', config).connections;
-  } catch {
-    swingConnections = [{ connection: getConnectionForAccount('paper'), accountType: 'paper' }];
-  }
+  // Exit management — never gated by 'off' (see getConnectionForManagement).
+  const swingConnections = getConnectionForManagement('SWING_TRADE', config).connections;
   const swingAcct = swingConnections[0].accountType;
 
   const activeTrades = await getActiveTrades(swingAcct);
@@ -7015,17 +7009,10 @@ async function checkLongTermAutoSell(
 
   if (!config.accountId) return;
 
-  // Exit management must run even when LONG_TERM mode is 'off'. 'off' means "no
-  // new entries", NOT "ignore existing positions". Pausing Suggested Finds routes
-  // LONG_TERM off — if we returned here, existing longs (AOS/FAST/etc.) would lose
-  // ALL downside protection (stop-loss, hard-stop, trailing, max-hold) while
-  // profit-taking kept running (it already has this fallback). Mirror that.
-  let ltConnections: RoutedConnection[];
-  try {
-    ltConnections = getConnectionForMode('LONG_TERM', config).connections;
-  } catch {
-    ltConnections = [{ connection: getConnectionForAccount('paper'), accountType: 'paper' }];
-  }
+  // Exit management (stop-loss, hard-stop, trailing, max-hold) — never gated by
+  // 'off'. 'off' means "no new entries", NOT "ignore existing positions". See
+  // getConnectionForManagement. (Pausing Suggested Finds routes LONG_TERM off.)
+  const ltConnections = getConnectionForManagement('LONG_TERM', config).connections;
   const ltAcct = ltConnections[0].accountType;
 
   const activeTrades = await getActiveTrades(ltAcct);
@@ -7281,15 +7268,9 @@ async function checkProfitTakeOpportunities(
   const trimmedTickers = new Set<string>();
   if (!config.profitTakeEnabled || !config.accountId) return trimmedTickers;
 
-  // Profit-taking must run even when LONG_TERM mode is 'off' (off = no new entries,
-  // NOT "ignore existing positions"). Fall back to paper connection when mode is off.
-  let ptConnections: RoutedConnection[];
-  try {
-    ptConnections = getConnectionForMode('LONG_TERM', config).connections;
-  } catch {
-    // Mode is off — still manage existing filled LT positions via paper connection
-    ptConnections = [{ connection: getConnectionForAccount('paper'), accountType: 'paper' }];
-  }
+  // Profit-taking manages existing positions — never gated by 'off' (off = no new
+  // entries, NOT "ignore existing positions"). See getConnectionForManagement.
+  const ptConnections = getConnectionForManagement('LONG_TERM', config).connections;
   const ptAcct = ptConnections[0].accountType;
 
   const activeTrades = await getActiveTrades(ptAcct);


### PR DESCRIPTION
## Summary
Follow-up to #498 to **prevent the whole class of bug** where pausing entries (routing a mode `off`) disables exit management on existing positions.

- New `getConnectionForManagement(mode, config)` in `mode-router.ts`: like `getConnectionForMode` but **never throws for `off`** — falls back to paper. For managing EXISTING positions only.
- Refactored `checkLongTermAutoSell`, `checkSwingHoldExpiry`, `checkLongTermProfitTake` to use it, removing the fragile `try { getConnectionForMode() } catch { return }` pattern.
- Added an auto-trader **invariant**: exit/position-management must use `getConnectionForManagement`; only ENTRY code uses `getConnectionForMode` (which respects `off`).

## Why
In #498 pausing Suggested Finds (routes LONG_TERM `off`) silently stripped stop-loss/hard-stop/trailing/max-hold off existing longs. That fix used inline paper fallbacks; this makes it structural + documented so it can't be reintroduced.

## Test plan
- [x] `tsc --noEmit` passes, no lint errors
- [x] Rebuilt + restarted
- [ ] With LONG_TERM/SWING routed off, confirm exits still fire on existing positions

Made with [Cursor](https://cursor.com)